### PR TITLE
Fix Dockerfile image tag and migration path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-ARG ELIXIR_VERSION=1.17.3
-ARG OTP_VERSION=27.1.2
-ARG DEBIAN_VERSION=bookworm-20240904-slim
-
-ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
-ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
-
-# --- Build stage ---
-FROM ${BUILDER_IMAGE} AS build
+# Use the official Elixir image for build
+FROM elixir:1.17-slim AS build
 
 RUN apt-get update -y && apt-get install -y build-essential git && rm -rf /var/lib/apt/lists/*
 
@@ -27,10 +20,10 @@ RUN mix compile
 RUN mix release
 
 # --- Runtime stage ---
-FROM ${RUNNER_IMAGE}
+FROM debian:bookworm-slim
 
 RUN apt-get update -y && \
-    apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates curl && \
+    apt-get install -y libstdc++6 openssl libncurses6 locales ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen

--- a/lib/canary/application.ex
+++ b/lib/canary/application.ex
@@ -57,7 +57,8 @@ defmodule Canary.Application do
 
   defp run_migrations do
     if Application.get_env(:canary, :run_migrations, true) do
-      Ecto.Migrator.run(Canary.Repo, :up, all: true)
+      path = Application.app_dir(:canary, "priv/repo/migrations")
+      Ecto.Migrator.run(Canary.Repo, path, :up, all: true)
     end
   rescue
     e -> require Logger; Logger.warning("Migration skipped: #{inspect(e)}")


### PR DESCRIPTION
## Summary
- Use official `elixir:1.17-slim` image (hexpm tag didn't exist)
- Fix runtime `libncurses6` for bookworm
- Fix `Ecto.Migrator.run` to pass explicit path

## Test plan
- [x] 54 tests passing
- [ ] Docker build succeeds on Fly.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)