### PR TITLE
feat: external dead-man's switch for Canary

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -5,6 +5,10 @@ on:
     - cron: "*/5 * * * *"
   workflow_dispatch:
 
+concurrency:
+  group: uptime-monitor
+  cancel-in-progress: false
+
 jobs:
   healthcheck:
     runs-on: ubuntu-latest
@@ -18,15 +22,22 @@ jobs:
       - name: Check healthz
         id: check
         run: |
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$TARGET_URL" || echo "000")
+          set +e
+          RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$TARGET_URL")
+          CURL_EXIT=$?
+          set -e
 
-          if [ "$STATUS" != "200" ]; then
-            echo "First check failed ($STATUS), retrying in 15s..."
+          if [ "$RESPONSE" != "200" ]; then
+            echo "First check failed (HTTP $RESPONSE, curl exit $CURL_EXIT), retrying in 15s..."
             sleep 15
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$TARGET_URL" || echo "000")
+            set +e
+            RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$TARGET_URL")
+            CURL_EXIT=$?
+            set -e
           fi
 
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "status=$RESPONSE" >> "$GITHUB_OUTPUT"
+          echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
 
       - name: Find existing incident issue
         id: find
@@ -41,6 +52,16 @@ jobs:
             --jq '.[0].number // empty')
           echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
 
+      - name: Ensure label exists
+        if: steps.check.outputs.status != '200' && steps.find.outputs.issue == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "$ISSUE_LABEL" \
+            --repo "${{ github.repository }}" \
+            --description "Automated: Canary healthz unreachable" \
+            --color "B60205" 2>/dev/null || true
+
       - name: Open incident issue
         if: steps.check.outputs.status != '200' && steps.find.outputs.issue == ''
         env:
@@ -53,6 +74,7 @@ jobs:
           The uptime monitor failed to reach \`${TARGET_URL}\`.
 
           **HTTP status:** ${{ steps.check.outputs.status }}
+          **curl exit code:** ${{ steps.check.outputs.curl_exit }}
           **Detected at:** ${DETECTED_AT}
 
           ### Runbook
@@ -78,4 +100,5 @@ jobs:
         run: |
           gh issue close "${{ steps.find.outputs.issue }}" \
             --repo "${{ github.repository }}" \
-            --comment "Canary is back up. Recovered at $(date -u +%Y-%m-%dT%H:%M:%SZ)."
+            --comment "Canary is back up. Recovered at $(date -u +%Y-%m-%dT%H:%M:%SZ)." \
+            || true

--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -1,0 +1,81 @@
+name: Uptime Monitor
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      TARGET_URL: https://canary-obs.fly.dev/healthz
+      ISSUE_LABEL: canary-down
+      ISSUE_TITLE: "Canary is down"
+    steps:
+      - name: Check healthz
+        id: check
+        run: |
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$TARGET_URL" || echo "000")
+
+          if [ "$STATUS" != "200" ]; then
+            echo "First check failed ($STATUS), retrying in 15s..."
+            sleep 15
+            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$TARGET_URL" || echo "000")
+          fi
+
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing incident issue
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "$ISSUE_LABEL" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+
+      - name: Open incident issue
+        if: steps.check.outputs.status != '200' && steps.find.outputs.issue == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DETECTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          BODY=$(cat <<EOF
+          ## Canary is unreachable
+
+          The uptime monitor failed to reach \`${TARGET_URL}\`.
+
+          **HTTP status:** ${{ steps.check.outputs.status }}
+          **Detected at:** ${DETECTED_AT}
+
+          ### Runbook
+
+          1. Check Fly.io machine status: \`flyctl status --app canary-obs\`
+          2. Check logs: \`flyctl logs --app canary-obs\`
+          3. If machine is stopped: \`flyctl machines start <id> --app canary-obs\`
+          4. If DB corruption: see CLAUDE.md "Nuclear reset" section
+
+          This issue will auto-close when the monitor detects recovery.
+          EOF
+          )
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "$ISSUE_TITLE" \
+            --label "$ISSUE_LABEL" \
+            --body "$BODY"
+
+      - name: Close recovered issue
+        if: steps.check.outputs.status == '200' && steps.find.outputs.issue != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue close "${{ steps.find.outputs.issue }}" \
+            --repo "${{ github.repository }}" \
+            --comment "Canary is back up. Recovered at $(date -u +%Y-%m-%dT%H:%M:%SZ)."


### PR DESCRIPTION
## Why This Matters

Canary monitors other services, but nothing monitors Canary. If the BEAM crashes, Fly kills the machine, or the DB corrupts, the self-monitoring loop (ErrorReporter → Ingest → Webhook → Triage) is dead too. Silent failure of an observability service is a P0.

Closes #19

## Trade-offs / Risks

- **GitHub Actions cron granularity is 5 minutes** (and can drift). For sub-minute detection, an external SaaS like UptimeRobot/Better Stack would be needed. 5-min is acceptable for v1 — we're going from zero external monitoring to something.
- **GH Actions availability** — if GitHub itself is down, the monitor won't fire. Acceptable: if GitHub is down, we have bigger problems and will notice.
- **No email/Slack/PagerDuty** — alerts are GitHub issues. This matches the existing triage flow (Canary → webhook → Triage → GitHub issue). Adding notification channels is additive.

## Intent Reference

Dead-man's switch: external watchdog that detects when Canary is fully unreachable and alerts via a channel that doesn't depend on Canary being alive.

## Changes

- `.github/workflows/uptime-monitor.yml` — new cron workflow
- `canary-down` label created on the repo

**Workflow behavior:**
1. Every 5 min, `curl` hits `/healthz` with 10s timeout
2. On failure, retries once after 15s (handles transient blips)
3. If still down, checks for existing open `canary-down` issue (dedup)
4. If none exists, creates one with runbook (flyctl commands, nuclear reset reference)
5. If healthz is back up AND an open incident issue exists, auto-closes it with recovery timestamp

## Alternatives Considered

| Option | Verdict |
|--------|---------|
| Do nothing | Unacceptable — P0 gap |
| UptimeRobot free tier | Better check frequency (1 min), but adds external account dependency. Good future addition. |
| Better Stack | Best UX (status page), but more setup. Overkill for single-endpoint check. |
| Cron curl from another Fly machine | Couples the watchdog to the same infra provider. |
| **GitHub Actions cron** | Free, external to Fly, zero new accounts, auto-resolves, fits existing issue workflow. ✓ |

## Acceptance Criteria

- [x] `curl -s https://canary-obs.fly.dev/healthz` returns 200
- [x] External monitor configured (GHA cron every 5 min with retry)
- [x] Alert mechanism: GitHub issue with `canary-down` label + runbook
- [x] Auto-close on recovery

## Manual QA

```bash
# Verify healthz
curl -s -o /dev/null -w '%{http_code}' https://canary-obs.fly.dev/healthz
# Expected: 200

# Trigger workflow manually (after merge)
gh workflow run uptime-monitor.yml

# Verify run succeeded
gh run list --workflow=uptime-monitor.yml --limit 1
```

## What Changed

```mermaid
graph LR
    subgraph Before
        C[Canary] -->|self-monitor| C
        C -->|webhook| T[Triage]
        T -->|issue| GH[GitHub]
    end
```

```mermaid
graph LR
    subgraph After
        GHA[GitHub Actions<br/>cron 5m] -->|curl /healthz| C[Canary]
        C -->|self-monitor| C
        C -->|webhook| T[Triage]
        T -->|issue| GH[GitHub]
        GHA -->|issue if down| GH
    end
```

The external GHA loop is independent of Canary's BEAM VM. If Canary dies, the GHA loop still fires and creates an issue directly.

## Before / After

**Before:** Canary down = silent. No alert reaches anyone.
**After:** Canary down = GitHub issue within ~5 min with actionable runbook. Auto-resolves on recovery.

## Test Coverage

Infrastructure-only change. No app code modified. Workflow validated with `actionlint`. Can be end-to-end tested post-merge via `workflow_dispatch`.

## Merge Confidence

**High.** Single workflow file, no app code changes, zero risk of regression. Worst case: workflow doesn't trigger (we're no worse off). Can be verified immediately after merge with manual dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated uptime monitoring that checks service health every 5 minutes.
  * Automatically creates incident issues when the service becomes unavailable and closes them upon recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->