### PR TITLE
Controller integration tests for all API routes

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -19,6 +19,10 @@ config :canary, Oban, testing: :inline
 
 config :canary, run_migrations: false
 
+# Route reads through write Repo in test for sandbox compatibility.
+# SQLite can't share transactions across separate repo pools.
+config :canary, :read_repo, Canary.Repo
+
 config :bcrypt_elixir, :log_rounds, 4
 
 config :logger, level: :warning

--- a/lib/canary.ex
+++ b/lib/canary.ex
@@ -6,4 +6,7 @@ defmodule Canary do
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
   """
+
+  @doc "Read-only repo. Routes to Repo in test for sandbox compatibility."
+  def read_repo, do: Application.get_env(:canary, :read_repo, Canary.ReadRepo)
 end

--- a/lib/canary.ex
+++ b/lib/canary.ex
@@ -6,7 +6,4 @@ defmodule Canary do
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
   """
-
-  @doc "Read-only repo. Routes to Repo in test for sandbox compatibility."
-  def read_repo, do: Application.get_env(:canary, :read_repo, Canary.ReadRepo)
 end

--- a/lib/canary/health/manager.ex
+++ b/lib/canary/health/manager.ex
@@ -35,7 +35,7 @@ defmodule Canary.Health.Manager do
 
   def list_targets do
     from(t in Target, order_by: t.name)
-    |> Canary.read_repo().all()
+    |> Canary.Repos.read_repo().all()
   end
 
   # --- Callbacks ---

--- a/lib/canary/health/manager.ex
+++ b/lib/canary/health/manager.ex
@@ -6,7 +6,7 @@ defmodule Canary.Health.Manager do
 
   use GenServer
 
-  alias Canary.{ID, ReadRepo, Repo}
+  alias Canary.{ID, Repo}
   alias Canary.Schemas.{Target, TargetState}
   alias Canary.Health.Supervisor, as: HealthSup
   import Ecto.Query
@@ -35,7 +35,7 @@ defmodule Canary.Health.Manager do
 
   def list_targets do
     from(t in Target, order_by: t.name)
-    |> ReadRepo.all()
+    |> Canary.read_repo().all()
   end
 
   # --- Callbacks ---

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -4,7 +4,6 @@ defmodule Canary.Query do
   All responses include deterministic summary strings.
   """
 
-  alias Canary.ReadRepo
   alias Canary.Schemas.{Error, ErrorGroup, Target, TargetCheck, TargetState}
   import Ecto.Query
 
@@ -21,7 +20,7 @@ defmodule Canary.Query do
         )
 
       query = apply_cursor(query, cursor)
-      groups = ReadRepo.all(query)
+      groups = Canary.read_repo().all(query)
 
       total = Enum.reduce(groups, 0, &(&1.total_count + &2))
 
@@ -76,21 +75,21 @@ defmodule Canary.Query do
           order_by: [desc: sum(g.total_count)],
           limit: 50
         )
-        |> ReadRepo.all()
+        |> Canary.read_repo().all()
 
       {:ok, %{window: window, groups: groups}}
     end
   end
 
   def error_detail(error_id) do
-    case ReadRepo.get(Error, error_id) do
+    case Canary.read_repo().get(Error, error_id) do
       nil -> {:error, :not_found}
       error -> {:ok, build_error_detail(error)}
     end
   end
 
   defp build_error_detail(error) do
-    group = ReadRepo.get(ErrorGroup, error.group_hash)
+    group = Canary.read_repo().get(ErrorGroup, error.group_hash)
 
     summary =
       Canary.Summary.error_detail(%{
@@ -130,7 +129,7 @@ defmodule Canary.Query do
   end
 
   def health_status do
-    targets = from(t in Target, order_by: t.name) |> ReadRepo.all()
+    targets = from(t in Target, order_by: t.name) |> Canary.read_repo().all()
     enriched = Enum.map(targets, &enrich_target/1)
     summary = Canary.Summary.health_status(%{targets: enriched})
 
@@ -138,7 +137,7 @@ defmodule Canary.Query do
   end
 
   defp enrich_target(target) do
-    state = ReadRepo.get(TargetState, target.id)
+    state = Canary.read_repo().get(TargetState, target.id)
 
     recent_checks =
       from(c in TargetCheck,
@@ -146,7 +145,7 @@ defmodule Canary.Query do
         order_by: [desc: c.checked_at],
         limit: 5
       )
-      |> ReadRepo.all()
+      |> Canary.read_repo().all()
 
     %{
       id: target.id,
@@ -181,7 +180,7 @@ defmodule Canary.Query do
           order_by: [desc: c.checked_at],
           limit: 500
         )
-        |> ReadRepo.all()
+        |> Canary.read_repo().all()
 
       {:ok, checks}
     end

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -20,7 +20,7 @@ defmodule Canary.Query do
         )
 
       query = apply_cursor(query, cursor)
-      groups = Canary.read_repo().all(query)
+      groups = Canary.Repos.read_repo().all(query)
 
       total = Enum.reduce(groups, 0, &(&1.total_count + &2))
 
@@ -75,21 +75,21 @@ defmodule Canary.Query do
           order_by: [desc: sum(g.total_count)],
           limit: 50
         )
-        |> Canary.read_repo().all()
+        |> Canary.Repos.read_repo().all()
 
       {:ok, %{window: window, groups: groups}}
     end
   end
 
   def error_detail(error_id) do
-    case Canary.read_repo().get(Error, error_id) do
+    case Canary.Repos.read_repo().get(Error, error_id) do
       nil -> {:error, :not_found}
       error -> {:ok, build_error_detail(error)}
     end
   end
 
   defp build_error_detail(error) do
-    group = Canary.read_repo().get(ErrorGroup, error.group_hash)
+    group = Canary.Repos.read_repo().get(ErrorGroup, error.group_hash)
 
     summary =
       Canary.Summary.error_detail(%{
@@ -129,7 +129,7 @@ defmodule Canary.Query do
   end
 
   def health_status do
-    targets = from(t in Target, order_by: t.name) |> Canary.read_repo().all()
+    targets = from(t in Target, order_by: t.name) |> Canary.Repos.read_repo().all()
     enriched = Enum.map(targets, &enrich_target/1)
     summary = Canary.Summary.health_status(%{targets: enriched})
 
@@ -137,7 +137,7 @@ defmodule Canary.Query do
   end
 
   defp enrich_target(target) do
-    state = Canary.read_repo().get(TargetState, target.id)
+    state = Canary.Repos.read_repo().get(TargetState, target.id)
 
     recent_checks =
       from(c in TargetCheck,
@@ -145,7 +145,7 @@ defmodule Canary.Query do
         order_by: [desc: c.checked_at],
         limit: 5
       )
-      |> Canary.read_repo().all()
+      |> Canary.Repos.read_repo().all()
 
     %{
       id: target.id,
@@ -180,7 +180,7 @@ defmodule Canary.Query do
           order_by: [desc: c.checked_at],
           limit: 500
         )
-        |> Canary.read_repo().all()
+        |> Canary.Repos.read_repo().all()
 
       {:ok, checks}
     end

--- a/lib/canary/repos.ex
+++ b/lib/canary/repos.ex
@@ -1,0 +1,5 @@
+defmodule Canary.Repos do
+  @moduledoc "Repo routing. Returns Repo in test for sandbox compatibility."
+
+  def read_repo, do: Application.get_env(:canary, :read_repo, Canary.ReadRepo)
+end

--- a/lib/canary/workers/tls_scan.ex
+++ b/lib/canary/workers/tls_scan.ex
@@ -6,7 +6,6 @@ defmodule Canary.Workers.TlsScan do
 
   use Oban.Worker, queue: :maintenance, max_attempts: 2
 
-  alias Canary.ReadRepo
   alias Canary.Schemas.{Target, TargetCheck}
   import Ecto.Query
 
@@ -18,7 +17,7 @@ defmodule Canary.Workers.TlsScan do
   def perform(_job) do
     targets =
       from(t in Target, where: t.active == 1 and like(t.url, "https://%"))
-      |> ReadRepo.all()
+      |> Canary.read_repo().all()
 
     Enum.each(targets, &check_tls_expiry/1)
     :ok
@@ -31,7 +30,7 @@ defmodule Canary.Workers.TlsScan do
         order_by: [desc: c.checked_at],
         limit: 1
       )
-      |> ReadRepo.one()
+      |> Canary.read_repo().one()
 
     case latest_check do
       %{tls_expires_at: expiry} when is_binary(expiry) ->

--- a/lib/canary/workers/tls_scan.ex
+++ b/lib/canary/workers/tls_scan.ex
@@ -17,7 +17,7 @@ defmodule Canary.Workers.TlsScan do
   def perform(_job) do
     targets =
       from(t in Target, where: t.active == 1 and like(t.url, "https://%"))
-      |> Canary.read_repo().all()
+      |> Canary.Repos.read_repo().all()
 
     Enum.each(targets, &check_tls_expiry/1)
     :ok
@@ -30,7 +30,7 @@ defmodule Canary.Workers.TlsScan do
         order_by: [desc: c.checked_at],
         limit: 1
       )
-      |> Canary.read_repo().one()
+      |> Canary.Repos.read_repo().one()
 
     case latest_check do
       %{tls_expires_at: expiry} when is_binary(expiry) ->

--- a/lib/canary/workers/webhook_delivery.ex
+++ b/lib/canary/workers/webhook_delivery.ex
@@ -21,7 +21,7 @@ defmodule Canary.Workers.WebhookDelivery do
   def perform(%Oban.Job{
         args: %{"webhook_id" => webhook_id, "payload" => payload, "event" => event}
       }) do
-    case Canary.read_repo().get(Webhook, webhook_id) do
+    case Canary.Repos.read_repo().get(Webhook, webhook_id) do
       nil ->
         Logger.warning("Webhook #{webhook_id} not found, discarding")
         :ok
@@ -81,7 +81,7 @@ defmodule Canary.Workers.WebhookDelivery do
   def enqueue_for_event(event, payload) do
     webhooks =
       from(w in Webhook, where: w.active == 1)
-      |> Canary.read_repo().all()
+      |> Canary.Repos.read_repo().all()
       |> Enum.filter(&Webhook.subscribes_to?(&1, event))
 
     Enum.each(webhooks, fn webhook ->

--- a/lib/canary/workers/webhook_delivery.ex
+++ b/lib/canary/workers/webhook_delivery.ex
@@ -10,7 +10,6 @@ defmodule Canary.Workers.WebhookDelivery do
     priority: 1
 
   alias Canary.Alerter.{CircuitBreaker, Cooldown, Signer}
-  alias Canary.ReadRepo
   alias Canary.Schemas.Webhook
   import Ecto.Query
 
@@ -22,7 +21,7 @@ defmodule Canary.Workers.WebhookDelivery do
   def perform(%Oban.Job{
         args: %{"webhook_id" => webhook_id, "payload" => payload, "event" => event}
       }) do
-    case ReadRepo.get(Webhook, webhook_id) do
+    case Canary.read_repo().get(Webhook, webhook_id) do
       nil ->
         Logger.warning("Webhook #{webhook_id} not found, discarding")
         :ok
@@ -82,7 +81,7 @@ defmodule Canary.Workers.WebhookDelivery do
   def enqueue_for_event(event, payload) do
     webhooks =
       from(w in Webhook, where: w.active == 1)
-      |> ReadRepo.all()
+      |> Canary.read_repo().all()
       |> Enum.filter(&Webhook.subscribes_to?(&1, event))
 
     Enum.each(webhooks, fn webhook ->

--- a/lib/canary_web/controllers/webhook_controller.ex
+++ b/lib/canary_web/controllers/webhook_controller.ex
@@ -1,7 +1,7 @@
 defmodule CanaryWeb.WebhookController do
   use CanaryWeb, :controller
 
-  alias Canary.{ID, ReadRepo, Repo}
+  alias Canary.{ID, Repo}
   alias Canary.Schemas.Webhook
   import Ecto.Query
 
@@ -11,7 +11,7 @@ defmodule CanaryWeb.WebhookController do
   )
 
   def index(conn, _params) do
-    webhooks = from(w in Webhook, order_by: w.created_at) |> ReadRepo.all()
+    webhooks = from(w in Webhook, order_by: w.created_at) |> Canary.read_repo().all()
 
     json(conn, %{
       webhooks:
@@ -92,7 +92,7 @@ defmodule CanaryWeb.WebhookController do
   end
 
   def test(conn, %{"id" => id}) do
-    case ReadRepo.get(Webhook, id) do
+    case Canary.read_repo().get(Webhook, id) do
       nil ->
         CanaryWeb.Plugs.ProblemDetails.render_error(
           conn,

--- a/lib/canary_web/controllers/webhook_controller.ex
+++ b/lib/canary_web/controllers/webhook_controller.ex
@@ -11,7 +11,7 @@ defmodule CanaryWeb.WebhookController do
   )
 
   def index(conn, _params) do
-    webhooks = from(w in Webhook, order_by: w.created_at) |> Canary.read_repo().all()
+    webhooks = from(w in Webhook, order_by: w.created_at) |> Canary.Repos.read_repo().all()
 
     json(conn, %{
       webhooks:
@@ -92,7 +92,7 @@ defmodule CanaryWeb.WebhookController do
   end
 
   def test(conn, %{"id" => id}) do
-    case Canary.read_repo().get(Webhook, id) do
+    case Canary.Repos.read_repo().get(Webhook, id) do
       nil ->
         CanaryWeb.Plugs.ProblemDetails.render_error(
           conn,

--- a/test/canary_web/controllers/error_controller_test.exs
+++ b/test/canary_web/controllers/error_controller_test.exs
@@ -1,0 +1,47 @@
+defmodule CanaryWeb.ErrorControllerTest do
+  use CanaryWeb.ConnCase
+
+  @valid_payload %{
+    "service" => "test-svc",
+    "error_class" => "RuntimeError",
+    "message" => "something went wrong"
+  }
+
+  describe "POST /api/v1/errors" do
+    test "401 with RFC 9457 body when no auth header", %{conn: conn} do
+      conn = post(conn, "/api/v1/errors", @valid_payload)
+
+      assert json_response(conn, 401)["code"] == "invalid_api_key"
+      assert json_response(conn, 401)["status"] == 401
+      assert json_response(conn, 401)["type"] =~ "invalid-api-key"
+    end
+
+    test "201 with error ID on valid payload", %{conn: conn} do
+      {raw_key, _key} = create_api_key()
+
+      conn =
+        conn
+        |> authenticate(raw_key)
+        |> post("/api/v1/errors", @valid_payload)
+
+      body = json_response(conn, 201)
+      assert body["id"] =~ ~r/^ERR-/
+      assert body["group_hash"]
+      assert is_boolean(body["is_new_class"])
+    end
+
+    test "422 with validation errors when required fields missing", %{conn: conn} do
+      {raw_key, _key} = create_api_key()
+
+      conn =
+        conn
+        |> authenticate(raw_key)
+        |> post("/api/v1/errors", %{})
+
+      body = json_response(conn, 422)
+      assert body["code"] == "validation_error"
+      assert body["status"] == 422
+      assert body["errors"]
+    end
+  end
+end

--- a/test/canary_web/controllers/error_controller_test.exs
+++ b/test/canary_web/controllers/error_controller_test.exs
@@ -11,9 +11,10 @@ defmodule CanaryWeb.ErrorControllerTest do
     test "401 with RFC 9457 body when no auth header", %{conn: conn} do
       conn = post(conn, "/api/v1/errors", @valid_payload)
 
-      assert json_response(conn, 401)["code"] == "invalid_api_key"
-      assert json_response(conn, 401)["status"] == 401
-      assert json_response(conn, 401)["type"] =~ "invalid-api-key"
+      body = json_response(conn, 401)
+      assert body["code"] == "invalid_api_key"
+      assert body["status"] == 401
+      assert body["type"] =~ "invalid-api-key"
     end
 
     test "201 with error ID on valid payload", %{conn: conn} do

--- a/test/canary_web/controllers/health_controller_test.exs
+++ b/test/canary_web/controllers/health_controller_test.exs
@@ -1,0 +1,40 @@
+defmodule CanaryWeb.HealthControllerTest do
+  use CanaryWeb.ConnCase
+
+  describe "GET /healthz" do
+    test "200 with no auth", %{conn: conn} do
+      conn = get(conn, "/healthz")
+      assert json_response(conn, 200) == %{"status" => "ok"}
+    end
+  end
+
+  describe "GET /readyz" do
+    test "200 when DB is healthy with no auth", %{conn: conn} do
+      conn = get(conn, "/readyz")
+
+      body = json_response(conn, 200)
+      assert body["status"] == "ready"
+      assert body["checks"]["database"] == "ok"
+    end
+  end
+
+  describe "GET /api/v1/health-status" do
+    test "200 with summary", %{conn: conn} do
+      {raw_key, _key} = create_api_key()
+
+      conn =
+        conn
+        |> authenticate(raw_key)
+        |> get("/api/v1/health-status")
+
+      body = json_response(conn, 200)
+      assert is_binary(body["summary"])
+      assert is_list(body["targets"])
+    end
+
+    test "401 without auth", %{conn: conn} do
+      conn = get(conn, "/api/v1/health-status")
+      assert json_response(conn, 401)["code"] == "invalid_api_key"
+    end
+  end
+end

--- a/test/canary_web/controllers/key_controller_test.exs
+++ b/test/canary_web/controllers/key_controller_test.exs
@@ -1,0 +1,55 @@
+defmodule CanaryWeb.KeyControllerTest do
+  use CanaryWeb.ConnCase
+
+  setup %{conn: conn} do
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "POST /api/v1/keys" do
+    test "returns raw key on creation", %{conn: conn} do
+      conn = post(conn, "/api/v1/keys", %{"name" => "new-key"})
+
+      body = json_response(conn, 201)
+      assert body["id"] =~ ~r/^KEY-/
+      assert body["name"] == "new-key"
+      assert body["key"] =~ ~r/^sk_live_/
+      assert body["key_prefix"]
+      assert body["warning"] =~ "Store this key"
+    end
+  end
+
+  describe "GET /api/v1/keys" do
+    test "returns prefixes, not raw keys", %{conn: conn} do
+      # Create a key via API so it exists
+      post(conn, "/api/v1/keys", %{"name" => "listed-key"})
+
+      conn = get(conn, "/api/v1/keys")
+      body = json_response(conn, 200)
+
+      assert is_list(body["keys"])
+      assert length(body["keys"]) >= 1
+
+      Enum.each(body["keys"], fn k ->
+        assert k["key_prefix"]
+        refute Map.has_key?(k, "key")
+        refute Map.has_key?(k, "key_hash")
+      end)
+    end
+  end
+
+  describe "POST /api/v1/keys/:id/revoke" do
+    test "revokes an existing key", %{conn: conn} do
+      create_body = json_response(post(conn, "/api/v1/keys", %{"name" => "doomed"}), 201)
+
+      conn = post(conn, "/api/v1/keys/#{create_body["id"]}/revoke")
+      assert json_response(conn, 200)["status"] == "revoked"
+    end
+
+    test "returns 404 for missing key", %{conn: conn} do
+      conn = post(conn, "/api/v1/keys/KEY-nonexistent/revoke")
+      assert json_response(conn, 404)["code"] == "not_found"
+    end
+  end
+end

--- a/test/canary_web/controllers/key_controller_test.exs
+++ b/test/canary_web/controllers/key_controller_test.exs
@@ -29,7 +29,7 @@ defmodule CanaryWeb.KeyControllerTest do
       body = json_response(conn, 200)
 
       assert is_list(body["keys"])
-      assert length(body["keys"]) >= 1
+      assert length(body["keys"]) >= 2
 
       Enum.each(body["keys"], fn k ->
         assert k["key_prefix"]

--- a/test/canary_web/controllers/query_controller_test.exs
+++ b/test/canary_web/controllers/query_controller_test.exs
@@ -1,0 +1,61 @@
+defmodule CanaryWeb.QueryControllerTest do
+  use CanaryWeb.ConnCase
+
+  setup %{conn: conn} do
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "GET /api/v1/query" do
+    test "returns errors by service", %{conn: conn} do
+      # Ingest an error first
+      post(conn, "/api/v1/errors", %{
+        "service" => "query-test",
+        "error_class" => "TestError",
+        "message" => "test message"
+      })
+
+      conn = get(conn, "/api/v1/query?service=query-test")
+      body = json_response(conn, 200)
+      assert body["service"] == "query-test"
+      assert is_list(body["groups"])
+    end
+
+    test "returns errors by class", %{conn: conn} do
+      conn = get(conn, "/api/v1/query?group_by=error_class")
+      body = json_response(conn, 200)
+      assert is_list(body["groups"])
+    end
+
+    test "422 when no service or group_by", %{conn: conn} do
+      conn = get(conn, "/api/v1/query")
+      assert json_response(conn, 422)["code"] == "validation_error"
+    end
+  end
+
+  describe "GET /api/v1/errors/:id" do
+    test "returns error detail", %{conn: conn} do
+      # Ingest an error
+      create_body =
+        conn
+        |> post("/api/v1/errors", %{
+          "service" => "detail-test",
+          "error_class" => "DetailError",
+          "message" => "detail message"
+        })
+        |> json_response(201)
+
+      conn = get(conn, "/api/v1/errors/#{create_body["id"]}")
+      body = json_response(conn, 200)
+      assert body["id"] == create_body["id"]
+      assert body["error_class"] == "DetailError"
+      assert body["service"] == "detail-test"
+    end
+
+    test "404 for missing error", %{conn: conn} do
+      conn = get(conn, "/api/v1/errors/ERR-nonexistent")
+      assert json_response(conn, 404)["code"] == "not_found"
+    end
+  end
+end

--- a/test/canary_web/controllers/query_controller_test.exs
+++ b/test/canary_web/controllers/query_controller_test.exs
@@ -19,13 +19,26 @@ defmodule CanaryWeb.QueryControllerTest do
       conn = get(conn, "/api/v1/query?service=query-test")
       body = json_response(conn, 200)
       assert body["service"] == "query-test"
-      assert is_list(body["groups"])
+      assert [group] = body["groups"]
+      assert group["error_class"] == "TestError"
+      assert group["count"] == 1
     end
 
     test "returns errors by class", %{conn: conn} do
+      # Seed errors across two services with distinct classes
+      for {svc, cls} <- [{"svc-a", "FooError"}, {"svc-b", "BarError"}] do
+        post(conn, "/api/v1/errors", %{
+          "service" => svc,
+          "error_class" => cls,
+          "message" => "msg"
+        })
+      end
+
       conn = get(conn, "/api/v1/query?group_by=error_class")
       body = json_response(conn, 200)
-      assert is_list(body["groups"])
+      classes = Enum.map(body["groups"], & &1["error_class"])
+      assert "FooError" in classes
+      assert "BarError" in classes
     end
 
     test "422 when no service or group_by", %{conn: conn} do

--- a/test/canary_web/controllers/target_controller_test.exs
+++ b/test/canary_web/controllers/target_controller_test.exs
@@ -23,7 +23,7 @@ defmodule CanaryWeb.TargetControllerTest do
       assert created["url"] == "https://example.com"
       assert created["active"] == true
 
-      # List
+      # List — sandbox preserves seeded targets, so check membership
       list_conn = get(conn, "/api/v1/targets")
       body = json_response(list_conn, 200)
       assert Enum.any?(body["targets"], &(&1["id"] == created["id"]))

--- a/test/canary_web/controllers/target_controller_test.exs
+++ b/test/canary_web/controllers/target_controller_test.exs
@@ -1,0 +1,52 @@
+defmodule CanaryWeb.TargetControllerTest do
+  use CanaryWeb.ConnCase
+
+  setup %{conn: conn} do
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "CRUD /api/v1/targets" do
+    test "create, list, delete cycle", %{conn: conn} do
+      # Create
+      create_conn =
+        post(conn, "/api/v1/targets", %{
+          "url" => "https://example.com",
+          "name" => "Example",
+          "allow_private" => true
+        })
+
+      created = json_response(create_conn, 201)
+      assert created["id"] =~ ~r/^TGT-/
+      assert created["name"] == "Example"
+      assert created["url"] == "https://example.com"
+      assert created["active"] == true
+
+      # List
+      list_conn = get(conn, "/api/v1/targets")
+      body = json_response(list_conn, 200)
+      assert Enum.any?(body["targets"], &(&1["id"] == created["id"]))
+
+      # Delete
+      delete_conn = delete(conn, "/api/v1/targets/#{created["id"]}")
+      assert response(delete_conn, 204)
+
+      # Verify deleted
+      list_conn2 = get(conn, "/api/v1/targets")
+      refute Enum.any?(json_response(list_conn2, 200)["targets"], &(&1["id"] == created["id"]))
+    end
+
+    test "create returns 422 for invalid URL", %{conn: conn} do
+      conn = post(conn, "/api/v1/targets", %{"url" => "ftp://bad", "name" => "Bad"})
+
+      body = json_response(conn, 422)
+      assert body["code"] == "validation_error"
+    end
+
+    test "delete returns 404 for missing target", %{conn: conn} do
+      conn = delete(conn, "/api/v1/targets/TGT-nonexistent")
+      assert json_response(conn, 404)["code"] == "not_found"
+    end
+  end
+end

--- a/test/canary_web/controllers/webhook_controller_test.exs
+++ b/test/canary_web/controllers/webhook_controller_test.exs
@@ -1,0 +1,54 @@
+defmodule CanaryWeb.WebhookControllerTest do
+  use CanaryWeb.ConnCase
+
+  setup %{conn: conn} do
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "CRUD /api/v1/webhooks" do
+    test "create returns secret, list omits it, delete works", %{conn: conn} do
+      # Create
+      create_conn =
+        post(conn, "/api/v1/webhooks", %{
+          "url" => "https://example.com/hook",
+          "events" => ["error.new_class", "health_check.down"]
+        })
+
+      created = json_response(create_conn, 201)
+      assert created["id"] =~ ~r/^WHK-/
+      assert is_binary(created["secret"])
+      assert String.length(created["secret"]) == 32
+      assert created["events"] == ["error.new_class", "health_check.down"]
+
+      # List (no secret exposed)
+      list_conn = get(conn, "/api/v1/webhooks")
+      body = json_response(list_conn, 200)
+      wh = Enum.find(body["webhooks"], &(&1["id"] == created["id"]))
+      assert wh
+      refute Map.has_key?(wh, "secret")
+
+      # Delete
+      delete_conn = delete(conn, "/api/v1/webhooks/#{created["id"]}")
+      assert response(delete_conn, 204)
+    end
+
+    test "create rejects invalid event types", %{conn: conn} do
+      conn =
+        post(conn, "/api/v1/webhooks", %{
+          "url" => "https://example.com/hook",
+          "events" => ["bogus.event"]
+        })
+
+      body = json_response(conn, 422)
+      assert body["code"] == "validation_error"
+      assert body["detail"] =~ "bogus.event"
+    end
+
+    test "delete returns 404 for missing webhook", %{conn: conn} do
+      conn = delete(conn, "/api/v1/webhooks/WHK-nonexistent")
+      assert json_response(conn, 404)["code"] == "not_found"
+    end
+  end
+end

--- a/test/canary_web/controllers/webhook_controller_test.exs
+++ b/test/canary_web/controllers/webhook_controller_test.exs
@@ -32,6 +32,10 @@ defmodule CanaryWeb.WebhookControllerTest do
       # Delete
       delete_conn = delete(conn, "/api/v1/webhooks/#{created["id"]}")
       assert response(delete_conn, 204)
+
+      # Verify deleted
+      list_conn2 = get(conn, "/api/v1/webhooks")
+      assert json_response(list_conn2, 200)["webhooks"] == []
     end
 
     test "create rejects invalid event types", %{conn: conn} do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -19,12 +19,10 @@ defmodule CanaryWeb.ConnCase do
 
   using do
     quote do
-      # The default endpoint for testing
       @endpoint CanaryWeb.Endpoint
 
       use CanaryWeb, :verified_routes
 
-      # Import conveniences for testing with connections
       import Plug.Conn
       import Phoenix.ConnTest
       import CanaryWeb.ConnCase
@@ -34,5 +32,16 @@ defmodule CanaryWeb.ConnCase do
   setup tags do
     Canary.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+
+  @doc "Creates an API key and returns {raw_key, api_key}."
+  def create_api_key(name \\ "test") do
+    {:ok, key, raw_key} = Canary.Auth.generate_key(name)
+    {raw_key, key}
+  end
+
+  @doc "Adds Bearer auth header with the given raw key."
+  def authenticate(conn, raw_key) do
+    Plug.Conn.put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 end


### PR DESCRIPTION
## Why This Matters

Zero HTTP integration tests existed. The entire client-facing API — auth, rate limiting, error responses, RFC 9457 Problem Details — was untested. Every client SDK depends on this contract, and regressions were invisible.

Fixes #21

## Trade-offs / Risks

- **ReadRepo refactor**: Changed all `ReadRepo` call sites to use `Canary.Repos.read_repo()` (configurable). This is the standard pattern for read replicas in Ecto — SQLite Sandbox wraps each repo in separate transactions, making ReadRepo invisible to Repo writes. In prod, `read_repo()` returns `ReadRepo` unchanged. Cost: one level of indirection for reads. Benefit: tests actually work.
- Target controller tests call `Manager.add_target/1` which starts a Checker GenServer. The checker will attempt HTTP probes in the background and fail silently. This is acceptable — we're testing the HTTP contract, not probe behavior.

## Intent Reference

**Goal**: Test the HTTP contract for all 6 controllers. Auth enforcement, CRUD operations, error responses, RFC 9457 compliance.
**Boundary**: Test HTTP layer only, not domain logic (unit tests cover that) or Oban workers (separate issue #22).

## Changes

- `lib/canary/repos.ex`: New module with `read_repo/0` — returns `ReadRepo` in prod, `Repo` in test
- `config/test.exs`: Added `:read_repo` config pointing to `Canary.Repo`
- 5 production files: Replaced direct `ReadRepo` references with `Canary.Repos.read_repo()`
- `test/support/conn_case.ex`: Added `create_api_key/1` and `authenticate/2` helpers
- 6 new test files covering all API routes

## Acceptance Criteria

- [x] `POST /api/v1/errors` without auth → 401 with RFC 9457 body
- [x] `POST /api/v1/errors` with valid auth/payload → 201 with error ID
- [x] `POST /api/v1/errors` with missing fields → 422 with validation errors
- [x] `GET /api/v1/health-status` with auth → 200 with summary
- [x] CRUD `/api/v1/targets` → create/list/delete work correctly
- [x] CRUD `/api/v1/webhooks` → create/list/delete work, secret returned on create
- [x] `POST /api/v1/keys` and `GET /api/v1/keys` → creation returns raw key, list returns prefixes only
- [x] `GET /healthz` without auth → 200
- [x] `GET /readyz` without auth → 200 when DB healthy

## Manual QA

```bash
mix test test/canary_web/controllers/  # 24 tests, 0 failures
mix test                                # 78 tests, 0 failures
mix format --check-formatted            # clean
mix credo --strict                      # no issues
```

## What Changed

<details>
<summary>Architecture diagrams</summary>

### Before: Read path
```mermaid
flowchart LR
    Controller --> ReadRepo --> SQLite
    Controller --> Repo --> SQLite
```

### After: Read path (configurable via Canary.Repos)
```mermaid
flowchart LR
    Controller --> Canary.Repos.read_repo
    Canary.Repos.read_repo -->|prod| ReadRepo --> SQLite
    Canary.Repos.read_repo -->|test| Repo --> Sandbox
```

### Test coverage map
```mermaid
graph TD
    A[ConnCase + auth helpers] --> B[ErrorControllerTest]
    A --> C[HealthControllerTest]
    A --> D[TargetControllerTest]
    A --> E[WebhookControllerTest]
    A --> F[KeyControllerTest]
    A --> G[QueryControllerTest]
    B -->|3 tests| H[auth, ingest, validation]
    C -->|4 tests| I[healthz, readyz, status, auth]
    D -->|3 tests| J[CRUD cycle, validation, 404]
    E -->|3 tests| K[CRUD + secret, invalid events, 404]
    F -->|4 tests| L[create, list, revoke, 404]
    G -->|4 tests| M[by service, by class, detail, 404]
```
</details>

## Test Coverage

- `test/canary_web/controllers/error_controller_test.exs` — 3 tests
- `test/canary_web/controllers/health_controller_test.exs` — 4 tests
- `test/canary_web/controllers/target_controller_test.exs` — 3 tests
- `test/canary_web/controllers/webhook_controller_test.exs` — 3 tests
- `test/canary_web/controllers/key_controller_test.exs` — 4 tests
- `test/canary_web/controllers/query_controller_test.exs` — 4 tests (includes ingest + query round-trip)
- No gaps: all 9 ACs covered.

## Merge Confidence

**High**. All 78 tests pass, including 54 pre-existing tests unaffected by the ReadRepo refactor. The production behavior is unchanged — `Canary.Repos.read_repo()` returns `ReadRepo` in all non-test environments. Zero new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for API endpoints: error, health, key, query, target, and webhook controllers.
  * Validates authentication, CRUD operations, error handling, and response formats.

* **Refactor**
  * Introduced centralized repository access pattern for improved test sandbox compatibility.
  * Updated internal data access throughout the application.

* **Chores**
  * Added test helpers for API key generation and request authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->