### PR TITLE
fix: disable HTTP redirects in health probes to prevent SSRF bypass

### DIFF
--- a/lib/canary/health/probe.ex
+++ b/lib/canary/health/probe.ex
@@ -25,8 +25,7 @@ defmodule Canary.Health.Probe do
       url: target.url,
       headers: headers,
       receive_timeout: target.timeout_ms,
-      redirect: true,
-      max_redirects: 3,
+      redirect: false,
       retry: false,
       finch: Canary.Finch
     ]
@@ -89,6 +88,9 @@ defmodule Canary.Health.Probe do
 
   defp evaluate_response(status, body, target) do
     cond do
+      status in 300..399 ->
+        "redirect_not_followed"
+
       not status_matches?(status, target.expected_status) ->
         "status_mismatch"
 

--- a/lib/canary/schemas/target_check.ex
+++ b/lib/canary/schemas/target_check.ex
@@ -15,7 +15,7 @@ defmodule Canary.Schemas.TargetCheck do
 
   @required ~w(target_id checked_at result)a
   @optional ~w(status_code latency_ms tls_expires_at error_detail region)a
-  @results ~w(success timeout dns_error tls_error status_mismatch body_mismatch connection_error)
+  @results ~w(success timeout dns_error tls_error status_mismatch body_mismatch connection_error redirect_not_followed)
 
   def changeset(check, attrs) do
     check

--- a/test/canary/health/probe_test.exs
+++ b/test/canary/health/probe_test.exs
@@ -1,0 +1,83 @@
+defmodule Canary.Health.ProbeTest do
+  use ExUnit.Case, async: true
+
+  alias Canary.Health.Probe
+  alias Canary.Schemas.Target
+
+  defp build_target(url, opts \\ []) do
+    %Target{
+      id: "TGT-test",
+      url: url,
+      name: "test",
+      method: Keyword.get(opts, :method, "GET"),
+      headers: nil,
+      timeout_ms: 5_000,
+      expected_status: Keyword.get(opts, :expected_status, "200"),
+      body_contains: nil,
+      created_at: "2026-01-01T00:00:00Z"
+    }
+  end
+
+  describe "SSRF redirect protection" do
+    test "rejects redirect to loopback (127.0.0.1)" do
+      bypass = Bypass.open()
+      target = build_target("http://localhost:#{bypass.port}/health")
+
+      Bypass.expect_once(bypass, "GET", "/health", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://127.0.0.1/secret")
+        |> Plug.Conn.send_resp(302, "")
+      end)
+
+      assert {:error, result} = Probe.check(target)
+      assert result.result == "redirect_not_followed"
+      assert result.status_code == 302
+    end
+
+    test "rejects redirect to cloud metadata (169.254.169.254)" do
+      bypass = Bypass.open()
+      target = build_target("http://localhost:#{bypass.port}/health")
+
+      Bypass.expect_once(bypass, "GET", "/health", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://169.254.169.254/latest/meta-data/")
+        |> Plug.Conn.send_resp(302, "")
+      end)
+
+      assert {:error, result} = Probe.check(target)
+      assert result.result == "redirect_not_followed"
+      assert result.status_code == 302
+    end
+
+    test "treats redirect to valid public URL as redirect_not_followed (redirects disabled)" do
+      bypass = Bypass.open()
+      target = build_target("http://localhost:#{bypass.port}/health")
+
+      Bypass.expect_once(bypass, "GET", "/health", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://example.com/ok")
+        |> Plug.Conn.send_resp(302, "")
+      end)
+
+      # With redirects disabled, ANY redirect is not followed
+      assert {:error, result} = Probe.check(target)
+      assert result.result == "redirect_not_followed"
+      assert result.status_code == 302
+    end
+  end
+
+  describe "successful probes" do
+    test "returns success for 200 response" do
+      bypass = Bypass.open()
+      target = build_target("http://localhost:#{bypass.port}/health")
+
+      Bypass.expect_once(bypass, "GET", "/health", fn conn ->
+        Plug.Conn.send_resp(conn, 200, "OK")
+      end)
+
+      assert {:ok, result} = Probe.check(target)
+      assert result.status_code == 200
+      assert result.result == "success"
+    end
+  end
+end

--- a/test/canary/health/probe_test.exs
+++ b/test/canary/health/probe_test.exs
@@ -19,10 +19,13 @@ defmodule Canary.Health.ProbeTest do
   end
 
   describe "SSRF redirect protection" do
-    test "rejects redirect to loopback (127.0.0.1)" do
+    setup do
       bypass = Bypass.open()
       target = build_target("http://localhost:#{bypass.port}/health")
+      {:ok, bypass: bypass, target: target}
+    end
 
+    test "rejects redirect to loopback (127.0.0.1)", %{bypass: bypass, target: target} do
       Bypass.expect_once(bypass, "GET", "/health", fn conn ->
         conn
         |> Plug.Conn.put_resp_header("location", "http://127.0.0.1/secret")
@@ -34,10 +37,7 @@ defmodule Canary.Health.ProbeTest do
       assert result.status_code == 302
     end
 
-    test "rejects redirect to cloud metadata (169.254.169.254)" do
-      bypass = Bypass.open()
-      target = build_target("http://localhost:#{bypass.port}/health")
-
+    test "rejects redirect to cloud metadata (169.254.169.254)", %{bypass: bypass, target: target} do
       Bypass.expect_once(bypass, "GET", "/health", fn conn ->
         conn
         |> Plug.Conn.put_resp_header("location", "http://169.254.169.254/latest/meta-data/")
@@ -49,17 +49,13 @@ defmodule Canary.Health.ProbeTest do
       assert result.status_code == 302
     end
 
-    test "treats redirect to valid public URL as redirect_not_followed (redirects disabled)" do
-      bypass = Bypass.open()
-      target = build_target("http://localhost:#{bypass.port}/health")
-
+    test "does not follow redirect to public URL", %{bypass: bypass, target: target} do
       Bypass.expect_once(bypass, "GET", "/health", fn conn ->
         conn
         |> Plug.Conn.put_resp_header("location", "https://example.com/ok")
         |> Plug.Conn.send_resp(302, "")
       end)
 
-      # With redirects disabled, ANY redirect is not followed
       assert {:error, result} = Probe.check(target)
       assert result.result == "redirect_not_followed"
       assert result.status_code == 302


### PR DESCRIPTION
## Why This Matters

`Probe.check/1` followed HTTP redirects (up to 3), so a malicious health check target could respond with `302 → http://169.254.169.254/latest/meta-data/` to bypass `SSRFGuard` and exfiltrate Fly.io instance metadata. This is a security bug in the request path — P1/now.

Closes #23

## Trade-offs / Risks

Health check targets that legitimately redirect will now return `redirect_not_followed` instead of following. This is the same approach Better Stack and Checkly use — health endpoints should respond directly. If a user's target redirects, they should update the target URL to the final destination.

## Intent Reference

> Fix SSRF redirect bypass in health check probes. SSRFGuard validates the initial URL, but Req follows redirects to internal IPs without re-validation.

Source: #23

## Changes

- `lib/canary/health/probe.ex`: `redirect: false` (was `redirect: true, max_redirects: 3`), 3xx responses now return `"redirect_not_followed"` result
- `test/canary/health/probe_test.exs`: New test file with 4 tests covering redirect-to-loopback, redirect-to-metadata, redirect-to-public, and basic success

## Alternatives Considered

1. **Do nothing** — leaves SSRF vector open on Fly.io. Unacceptable.
2. **Custom redirect handler validating each hop through SSRFGuard** — more complex, allows redirects for legitimate targets, but adds surface area. Health checks shouldn't redirect.
3. **Disable redirects (chosen)** — simplest, smallest diff, matches industry practice.

## Acceptance Criteria

- [x] [test] 302 → `127.0.0.1` returns SSRF-safe error
- [x] [test] 302 → `169.254.169.254` returns SSRF-safe error  
- [x] [test] 302 → valid public IP returns `redirect_not_followed` (redirects disabled entirely)

## Manual QA

```bash
mix test test/canary/health/probe_test.exs --trace
# All 4 tests pass

mix test
# 114 tests, 0 failures

mix format --check-formatted
# OK

mix credo --strict
# No issues
```

## What Changed

```mermaid
flowchart LR
    A[Probe.check] --> B[Req.request]
    B -->|"redirect: true"| C[Follow 302]
    C --> D[Internal IP — SSRF!]
    style D fill:#f66
```

```mermaid
flowchart LR
    A[Probe.check] --> B[Req.request]
    B -->|"redirect: false"| C[Return 302 as-is]
    C --> D["redirect_not_followed → error"]
    style D fill:#6f6
```

The new shape eliminates the redirect-following code path entirely, removing the SSRF vector rather than trying to validate each hop.

## Test Coverage

- `test/canary/health/probe_test.exs` — 4 tests: redirect-to-loopback, redirect-to-metadata, redirect-to-public, success path
- Full suite: 114 tests, 0 failures

## Merge Confidence

**High.** 4-line production change (2 removed, 4 added). Disabling redirects is strictly more restrictive. No behavioral change for targets that respond directly (the expected case). Full test suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health probes now reject HTTP redirects and report a dedicated "redirect_not_followed" result instead of following them, improving security and clarity.

* **Tests**
  * Added comprehensive tests covering redirect rejection (including loopback and metadata addresses) and successful 200 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->