### PR TITLE
feat: warn on missing Litestream env vars at boot

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,6 +3,20 @@ set -e
 
 DB_PATH="${CANARY_DB_PATH:-/data/canary.db}"
 
+# --- Litestream env validation ---
+if [ -z "$LITESTREAM_S3_BUCKET" ]; then
+  echo "WARNING: Litestream replication NOT configured — running without backups" >&2
+else
+  MISSING=""
+  [ -z "$LITESTREAM_ACCESS_KEY_ID" ] && MISSING="$MISSING LITESTREAM_ACCESS_KEY_ID"
+  [ -z "$LITESTREAM_SECRET_ACCESS_KEY" ] && MISSING="$MISSING LITESTREAM_SECRET_ACCESS_KEY"
+  [ -z "$LITESTREAM_S3_REGION" ] && MISSING="$MISSING LITESTREAM_S3_REGION"
+
+  if [ -n "$MISSING" ]; then
+    echo "WARNING: Litestream S3 bucket set but missing required variables:$MISSING" >&2
+  fi
+fi
+
 # Restore from Litestream if DB doesn't exist locally
 if [ ! -f "$DB_PATH" ] && [ -n "$LITESTREAM_S3_BUCKET" ]; then
   echo "Restoring database from Litestream..."

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 DB_PATH="${CANARY_DB_PATH:-/data/canary.db}"
 
 # --- Litestream env validation ---
+LITESTREAM_READY=0
 if [ -z "$LITESTREAM_S3_BUCKET" ]; then
   echo "WARNING: Litestream replication NOT configured — running without backups" >&2
 else
@@ -14,17 +15,19 @@ else
 
   if [ -n "$MISSING" ]; then
     echo "WARNING: Litestream S3 bucket set but missing required variables:$MISSING" >&2
+  else
+    LITESTREAM_READY=1
   fi
 fi
 
 # Restore from Litestream if DB doesn't exist locally
-if [ ! -f "$DB_PATH" ] && [ -n "$LITESTREAM_S3_BUCKET" ]; then
+if [ ! -f "$DB_PATH" ] && [ "$LITESTREAM_READY" = "1" ]; then
   echo "Restoring database from Litestream..."
   litestream restore -if-replica-exists -o "$DB_PATH" -config /etc/litestream.yml "$DB_PATH"
 fi
 
 # Start app under Litestream (continuous replication)
-if [ -n "$LITESTREAM_S3_BUCKET" ]; then
+if [ "$LITESTREAM_READY" = "1" ]; then
   exec litestream replicate -exec "/app/bin/canary start" -config /etc/litestream.yml
 else
   exec /app/bin/canary start

--- a/test/bin/entrypoint_test.sh
+++ b/test/bin/entrypoint_test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Tests for entrypoint.sh Litestream env validation.
+# Runs the entrypoint in a subshell with stubbed exec/litestream to capture warnings.
+set -e
+
+ENTRYPOINT="$(cd "$(dirname "$0")/../.." && pwd)/bin/entrypoint.sh"
+PASS=0
+FAIL=0
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Stub: override exec and litestream so entrypoint doesn't actually launch anything
+setup_stubs() {
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+  mkdir -p "$TMPDIR_TEST/bin"
+  # exec replacement — just exit cleanly
+  cat > "$TMPDIR_TEST/bin/litestream" << 'STUB'
+#!/bin/bash
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/litestream"
+  # Fake DB path so restore is skipped
+  export CANARY_DB_PATH="$TMPDIR_TEST/canary.db"
+  touch "$CANARY_DB_PATH"
+}
+
+run_entrypoint() {
+  # Run in subshell, capture stderr, override exec to just exit
+  bash -c "exec() { exit 0; }; source '$ENTRYPOINT'" 2>&1
+}
+
+assert_contains() {
+  local output="$1" expected="$2" test_name="$3"
+  if echo "$output" | grep -qF "$expected"; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected to contain: $expected"
+    echo "    Got: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" test_name="$3"
+  if echo "$output" | grep -qF "$unexpected"; then
+    echo "  FAIL: $test_name"
+    echo "    Expected NOT to contain: $unexpected"
+    echo "    Got: $output"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# --- Test 1: No bucket → warn about missing replication ---
+echo "Test 1: LITESTREAM_S3_BUCKET unset"
+setup_stubs
+unset LITESTREAM_S3_BUCKET
+unset LITESTREAM_ACCESS_KEY_ID
+unset LITESTREAM_SECRET_ACCESS_KEY
+unset LITESTREAM_S3_REGION
+OUTPUT=$(run_entrypoint)
+assert_contains "$OUTPUT" "Litestream replication NOT configured — running without backups" \
+  "warns about missing replication"
+
+# --- Test 2: Bucket set, creds missing → warn about missing vars ---
+echo "Test 2: LITESTREAM_S3_BUCKET set, ACCESS_KEY_ID missing"
+setup_stubs
+export LITESTREAM_S3_BUCKET="my-bucket"
+export LITESTREAM_SECRET_ACCESS_KEY="secret"
+export LITESTREAM_S3_REGION="us-east-1"
+unset LITESTREAM_ACCESS_KEY_ID
+OUTPUT=$(run_entrypoint)
+assert_contains "$OUTPUT" "LITESTREAM_ACCESS_KEY_ID" \
+  "identifies missing ACCESS_KEY_ID"
+assert_not_contains "$OUTPUT" "NOT configured" \
+  "does not warn about unconfigured replication"
+
+# --- Test 3: All vars set → no warnings ---
+echo "Test 3: All Litestream vars set"
+setup_stubs
+export LITESTREAM_S3_BUCKET="my-bucket"
+export LITESTREAM_ACCESS_KEY_ID="key"
+export LITESTREAM_SECRET_ACCESS_KEY="secret"
+export LITESTREAM_S3_REGION="us-east-1"
+OUTPUT=$(run_entrypoint)
+assert_not_contains "$OUTPUT" "WARNING" \
+  "no warnings when fully configured"
+
+# --- Test 4: Bucket set, multiple creds missing ---
+echo "Test 4: LITESTREAM_S3_BUCKET set, multiple vars missing"
+setup_stubs
+export LITESTREAM_S3_BUCKET="my-bucket"
+unset LITESTREAM_ACCESS_KEY_ID
+unset LITESTREAM_SECRET_ACCESS_KEY
+unset LITESTREAM_S3_REGION
+OUTPUT=$(run_entrypoint)
+assert_contains "$OUTPUT" "LITESTREAM_ACCESS_KEY_ID" \
+  "identifies missing ACCESS_KEY_ID"
+assert_contains "$OUTPUT" "LITESTREAM_SECRET_ACCESS_KEY" \
+  "identifies missing SECRET_ACCESS_KEY"
+assert_contains "$OUTPUT" "LITESTREAM_S3_REGION" \
+  "identifies missing S3_REGION"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/test/bin/entrypoint_test.sh
+++ b/test/bin/entrypoint_test.sh
@@ -9,24 +9,28 @@ FAIL=0
 TMPDIR_TEST=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
-# Stub: override exec and litestream so entrypoint doesn't actually launch anything
+reset_env() {
+  unset LITESTREAM_S3_BUCKET
+  unset LITESTREAM_ACCESS_KEY_ID
+  unset LITESTREAM_SECRET_ACCESS_KEY
+  unset LITESTREAM_S3_REGION
+}
+
 setup_stubs() {
   export PATH="$TMPDIR_TEST/bin:$PATH"
   mkdir -p "$TMPDIR_TEST/bin"
-  # exec replacement — just exit cleanly
   cat > "$TMPDIR_TEST/bin/litestream" << 'STUB'
 #!/bin/bash
-exit 0
+exit "${LITESTREAM_STUB_EXIT:-0}"
 STUB
   chmod +x "$TMPDIR_TEST/bin/litestream"
-  # Fake DB path so restore is skipped
   export CANARY_DB_PATH="$TMPDIR_TEST/canary.db"
   touch "$CANARY_DB_PATH"
 }
 
 run_entrypoint() {
-  # Run in subshell, capture stderr, override exec to just exit
-  bash -c "exec() { exit 0; }; source '$ENTRYPOINT'" 2>&1
+  # Override exec to echo what would run, then exit
+  bash -c "exec() { echo \"EXEC:\$*\"; exit 0; }; source '$ENTRYPOINT'" 2>&1
 }
 
 assert_contains() {
@@ -57,22 +61,19 @@ assert_not_contains() {
 
 # --- Test 1: No bucket → warn about missing replication ---
 echo "Test 1: LITESTREAM_S3_BUCKET unset"
+reset_env
 setup_stubs
-unset LITESTREAM_S3_BUCKET
-unset LITESTREAM_ACCESS_KEY_ID
-unset LITESTREAM_SECRET_ACCESS_KEY
-unset LITESTREAM_S3_REGION
 OUTPUT=$(run_entrypoint)
 assert_contains "$OUTPUT" "Litestream replication NOT configured — running without backups" \
   "warns about missing replication"
 
 # --- Test 2: Bucket set, creds missing → warn about missing vars ---
 echo "Test 2: LITESTREAM_S3_BUCKET set, ACCESS_KEY_ID missing"
+reset_env
 setup_stubs
 export LITESTREAM_S3_BUCKET="my-bucket"
 export LITESTREAM_SECRET_ACCESS_KEY="secret"
 export LITESTREAM_S3_REGION="us-east-1"
-unset LITESTREAM_ACCESS_KEY_ID
 OUTPUT=$(run_entrypoint)
 assert_contains "$OUTPUT" "LITESTREAM_ACCESS_KEY_ID" \
   "identifies missing ACCESS_KEY_ID"
@@ -81,6 +82,7 @@ assert_not_contains "$OUTPUT" "NOT configured" \
 
 # --- Test 3: All vars set → no warnings ---
 echo "Test 3: All Litestream vars set"
+reset_env
 setup_stubs
 export LITESTREAM_S3_BUCKET="my-bucket"
 export LITESTREAM_ACCESS_KEY_ID="key"
@@ -92,11 +94,9 @@ assert_not_contains "$OUTPUT" "WARNING" \
 
 # --- Test 4: Bucket set, multiple creds missing ---
 echo "Test 4: LITESTREAM_S3_BUCKET set, multiple vars missing"
+reset_env
 setup_stubs
 export LITESTREAM_S3_BUCKET="my-bucket"
-unset LITESTREAM_ACCESS_KEY_ID
-unset LITESTREAM_SECRET_ACCESS_KEY
-unset LITESTREAM_S3_REGION
 OUTPUT=$(run_entrypoint)
 assert_contains "$OUTPUT" "LITESTREAM_ACCESS_KEY_ID" \
   "identifies missing ACCESS_KEY_ID"
@@ -104,6 +104,29 @@ assert_contains "$OUTPUT" "LITESTREAM_SECRET_ACCESS_KEY" \
   "identifies missing SECRET_ACCESS_KEY"
 assert_contains "$OUTPUT" "LITESTREAM_S3_REGION" \
   "identifies missing S3_REGION"
+
+# --- Test 5: Missing creds → app starts directly, not via litestream ---
+echo "Test 5: Missing creds do not block startup"
+reset_env
+setup_stubs
+export LITESTREAM_S3_BUCKET="my-bucket"
+OUTPUT=$(run_entrypoint)
+assert_contains "$OUTPUT" "EXEC:/app/bin/canary start" \
+  "starts app directly when creds missing"
+assert_not_contains "$OUTPUT" "litestream replicate" \
+  "does not run litestream replicate when creds missing"
+
+# --- Test 6: All vars set → starts via litestream ---
+echo "Test 6: Full config starts via litestream"
+reset_env
+setup_stubs
+export LITESTREAM_S3_BUCKET="my-bucket"
+export LITESTREAM_ACCESS_KEY_ID="key"
+export LITESTREAM_SECRET_ACCESS_KEY="secret"
+export LITESTREAM_S3_REGION="us-east-1"
+OUTPUT=$(run_entrypoint)
+assert_contains "$OUTPUT" "EXEC:litestream replicate" \
+  "starts via litestream when fully configured"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
Closes #24

## Summary

- Adds boot-time validation of Litestream S3 env vars in `bin/entrypoint.sh`
- If `LITESTREAM_S3_BUCKET` is unset: warns "Litestream replication NOT configured — running without backups"
- If bucket is set but credentials are missing: names the specific missing variables
- App startup is never blocked — warn-only, per issue boundaries

## Changes

- `bin/entrypoint.sh` — 14-line validation block before restore/start logic
- `test/bin/entrypoint_test.sh` — 7 test cases covering all AC permutations

## Test plan

- [x] Shell tests: `bash test/bin/entrypoint_test.sh` — 7/7 pass
- [x] Elixir suite: `mix test` — 114/114 pass, 0 failures
- [x] Quality gates: `mix format --check-formatted` + `mix credo --strict` clean
- [ ] Manual: deploy to staging, verify warning appears in `flyctl logs` when S3 vars unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced startup backup handling: validates backup environment variables, warns when backups are disabled or credentials are incomplete, restores from backup only when appropriate, and runs the app under replication only when replication is ready; otherwise starts directly.

* **Tests**
  * Added tests covering various backup configuration scenarios and startup behaviors (warnings, restore, and replication vs direct start).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->