### PR TITLE
feat: combined status endpoint for agent queries

### DIFF
--- a/lib/canary/status.ex
+++ b/lib/canary/status.ex
@@ -22,13 +22,14 @@ defmodule Canary.Status do
   end
 
   defp fetch_targets do
-    repo = Canary.Repos.read_repo()
-
-    from(t in Target, order_by: t.name)
-    |> repo.all()
-    |> Enum.map(fn target ->
-      state = repo.get(TargetState, target.id)
-
+    from(t in Target,
+      left_join: s in TargetState,
+      on: t.id == s.target_id,
+      order_by: t.name,
+      select: {t, s}
+    )
+    |> Canary.Repos.read_repo().all()
+    |> Enum.map(fn {target, state} ->
       %{
         id: target.id,
         name: target.name,
@@ -59,18 +60,23 @@ defmodule Canary.Status do
     |> Canary.Repos.read_repo().all()
   end
 
-  defp compute_overall([], _errors), do: "empty"
+  defp compute_overall([], []), do: "empty"
+
+  defp compute_overall([], _errors), do: "warning"
 
   defp compute_overall(targets, error_summary) do
+    all_up = Enum.all?(targets, &(&1.state == "up"))
     has_down = Enum.any?(targets, &(&1.state == "down"))
     has_degraded = Enum.any?(targets, &(&1.state == "degraded"))
+    has_non_up = Enum.any?(targets, &(&1.state != "up"))
     has_errors = error_summary != []
 
     cond do
       has_down -> "unhealthy"
       has_degraded -> "degraded"
+      has_non_up -> "degraded"
       has_errors -> "warning"
-      true -> "healthy"
+      all_up -> "healthy"
     end
   end
 end

--- a/lib/canary/status.ex
+++ b/lib/canary/status.ex
@@ -15,10 +15,12 @@ defmodule Canary.Status do
     error_summary = fetch_error_summary()
     overall = compute_overall(targets, error_summary)
 
-    result = %{overall: overall, targets: targets, error_summary: error_summary}
-    summary = Canary.Summary.combined_status(result)
-
-    Map.put(result, :summary, summary)
+    %{
+      overall: overall,
+      summary: Canary.Summary.combined_status(overall, targets, error_summary),
+      targets: targets,
+      error_summary: error_summary
+    }
   end
 
   defp fetch_targets do

--- a/lib/canary/status.ex
+++ b/lib/canary/status.ex
@@ -65,18 +65,15 @@ defmodule Canary.Status do
   defp compute_overall([], _errors), do: "warning"
 
   defp compute_overall(targets, error_summary) do
-    all_up = Enum.all?(targets, &(&1.state == "up"))
     has_down = Enum.any?(targets, &(&1.state == "down"))
-    has_degraded = Enum.any?(targets, &(&1.state == "degraded"))
     has_non_up = Enum.any?(targets, &(&1.state != "up"))
     has_errors = error_summary != []
 
     cond do
       has_down -> "unhealthy"
-      has_degraded -> "degraded"
       has_non_up -> "degraded"
       has_errors -> "warning"
-      all_up -> "healthy"
+      true -> "healthy"
     end
   end
 end

--- a/lib/canary/status.ex
+++ b/lib/canary/status.ex
@@ -1,0 +1,76 @@
+defmodule Canary.Status do
+  @moduledoc """
+  Combined status for agent queries. Merges health check state
+  and error counts into a single agent-digestible response.
+  """
+
+  alias Canary.Schemas.{ErrorGroup, Target, TargetState}
+  import Ecto.Query
+
+  @window_seconds 3_600
+
+  @spec combined() :: map()
+  def combined do
+    targets = fetch_targets()
+    error_summary = fetch_error_summary()
+    overall = compute_overall(targets, error_summary)
+
+    result = %{overall: overall, targets: targets, error_summary: error_summary}
+    summary = Canary.Summary.combined_status(result)
+
+    Map.put(result, :summary, summary)
+  end
+
+  defp fetch_targets do
+    repo = Canary.Repos.read_repo()
+
+    from(t in Target, order_by: t.name)
+    |> repo.all()
+    |> Enum.map(fn target ->
+      state = repo.get(TargetState, target.id)
+
+      %{
+        id: target.id,
+        name: target.name,
+        url: target.url,
+        state: (state && state.state) || "unknown",
+        consecutive_failures: (state && state.consecutive_failures) || 0,
+        last_checked_at: state && state.last_checked_at
+      }
+    end)
+  end
+
+  defp fetch_error_summary do
+    cutoff =
+      DateTime.utc_now()
+      |> DateTime.add(-@window_seconds, :second)
+      |> DateTime.to_iso8601()
+
+    from(g in ErrorGroup,
+      where: g.last_seen_at >= ^cutoff and g.status == "active",
+      group_by: g.service,
+      select: %{
+        service: g.service,
+        total_count: sum(g.total_count),
+        unique_classes: count(g.group_hash)
+      },
+      order_by: [desc: sum(g.total_count)]
+    )
+    |> Canary.Repos.read_repo().all()
+  end
+
+  defp compute_overall([], _errors), do: "empty"
+
+  defp compute_overall(targets, error_summary) do
+    has_down = Enum.any?(targets, &(&1.state == "down"))
+    has_degraded = Enum.any?(targets, &(&1.state == "degraded"))
+    has_errors = error_summary != []
+
+    cond do
+      has_down -> "unhealthy"
+      has_degraded -> "degraded"
+      has_errors -> "warning"
+      true -> "healthy"
+    end
+  end
+end

--- a/lib/canary/summary.ex
+++ b/lib/canary/summary.ex
@@ -57,6 +57,45 @@ defmodule Canary.Summary do
     Enum.join(parts) <> "."
   end
 
+  @spec combined_status(map()) :: String.t()
+  def combined_status(%{overall: "empty"}), do: "No services configured."
+
+  def combined_status(%{overall: "healthy", targets: targets}) do
+    "All #{length(targets)} targets healthy. No errors in the last hour."
+  end
+
+  def combined_status(%{targets: targets, error_summary: error_summary}) do
+    by_state = Enum.group_by(targets, & &1.state)
+    down = by_state["down"] || []
+    degraded = by_state["degraded"] || []
+    total_errors = Enum.reduce(error_summary, 0, &(&1.total_count + &2))
+
+    parts = ["#{length(targets)} targets monitored."]
+
+    parts =
+      if down != [] do
+        names = Enum.map_join(down, ", ", & &1.name)
+        parts ++ [" #{length(down)} down (#{names})."]
+      else
+        parts
+      end
+
+    parts =
+      if degraded != [] do
+        names = Enum.map_join(degraded, ", ", & &1.name)
+        parts ++ [" #{length(degraded)} degraded (#{names})."]
+      else
+        parts
+      end
+
+    if total_errors > 0 do
+      parts ++ [" #{total_errors} errors across #{length(error_summary)} services in the last hour."]
+    else
+      parts
+    end
+    |> Enum.join()
+  end
+
   @spec error_detail(map()) :: String.t()
   def error_detail(%{
         error_class: error_class,

--- a/lib/canary/summary.ex
+++ b/lib/canary/summary.ex
@@ -25,71 +25,35 @@ defmodule Canary.Summary do
   def health_status(%{targets: targets}) do
     total = length(targets)
     by_state = Enum.group_by(targets, & &1.state)
-
     up = length(by_state["up"] || [])
-    degraded = length(by_state["degraded"] || [])
-    down = length(by_state["down"] || [])
 
-    parts = ["#{total} targets monitored. #{up} up"]
-
-    parts =
-      if degraded > 0 do
-        degraded_names =
-          (by_state["degraded"] || [])
-          |> Enum.map_join(", ", & &1.name)
-
-        parts ++ [", #{degraded} degraded (#{degraded_names})"]
-      else
-        parts
-      end
-
-    parts =
-      if down > 0 do
-        down_names =
-          (by_state["down"] || [])
-          |> Enum.map_join(", ", & &1.name)
-
-        parts ++ [", #{down} down (#{down_names})"]
-      else
-        parts
-      end
-
-    Enum.join(parts) <> "."
+    [
+      "#{total} targets monitored. #{up} up",
+      describe_group(by_state["degraded"], "degraded"),
+      describe_group(by_state["down"], "down")
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
+    |> Kernel.<>(".")
   end
 
-  @spec combined_status(map()) :: String.t()
-  def combined_status(%{overall: "empty"}), do: "No services configured."
+  @spec combined_status(String.t(), list(), list()) :: String.t()
+  def combined_status("empty", _targets, _errors), do: "No services configured."
 
-  def combined_status(%{overall: "healthy", targets: targets}) do
+  def combined_status("healthy", targets, _errors) do
     "All #{length(targets)} targets healthy. No errors in the last hour."
   end
 
-  def combined_status(%{targets: targets, error_summary: error_summary}) do
+  def combined_status(_overall, targets, error_summary) do
     by_state = Enum.group_by(targets, & &1.state)
-    down = by_state["down"] || []
-    degraded = by_state["degraded"] || []
     total_errors = Enum.reduce(error_summary, 0, &(&1.total_count + &2))
 
-    down_part =
-      if down != [] do
-        names = Enum.map_join(down, ", ", & &1.name)
-        " #{length(down)} down (#{names})."
-      end
-
-    degraded_part =
-      if degraded != [] do
-        names = Enum.map_join(degraded, ", ", & &1.name)
-        " #{length(degraded)} degraded (#{names})."
-      end
-
-    errors_part =
-      if total_errors > 0 do
-        svc_count = length(error_summary)
-        svc_word = if svc_count == 1, do: "service", else: "services"
-        " #{total_errors} errors across #{svc_count} #{svc_word} in the last hour."
-      end
-
-    ["#{length(targets)} targets monitored.", down_part, degraded_part, errors_part]
+    [
+      "#{length(targets)} targets monitored.",
+      describe_group(by_state["down"], "down", " "),
+      describe_group(by_state["degraded"], "degraded", " "),
+      errors_part(total_errors, error_summary)
+    ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join()
   end
@@ -103,5 +67,31 @@ defmodule Canary.Summary do
         last_seen: last_seen
       }) do
     "#{error_class} in #{service}. Seen #{count} times since #{first_seen}. Last occurrence: #{last_seen}."
+  end
+
+  # --- Helpers ---
+
+  defp describe_group(nil, _label), do: nil
+  defp describe_group([], _label), do: nil
+
+  defp describe_group(targets, label) do
+    names = Enum.map_join(targets, ", ", & &1.name)
+    "#{length(targets)} #{label} (#{names})"
+  end
+
+  defp describe_group(nil, _label, _prefix), do: nil
+  defp describe_group([], _label, _prefix), do: nil
+
+  defp describe_group(targets, label, prefix) do
+    names = Enum.map_join(targets, ", ", & &1.name)
+    "#{prefix}#{length(targets)} #{label} (#{names})."
+  end
+
+  defp errors_part(0, _summary), do: nil
+
+  defp errors_part(total, error_summary) do
+    svc_count = length(error_summary)
+    svc_word = if svc_count == 1, do: "service", else: "services"
+    " #{total} errors across #{svc_count} #{svc_word} in the last hour."
   end
 end

--- a/lib/canary/summary.ex
+++ b/lib/canary/summary.ex
@@ -70,29 +70,25 @@ defmodule Canary.Summary do
     degraded = by_state["degraded"] || []
     total_errors = Enum.reduce(error_summary, 0, &(&1.total_count + &2))
 
-    parts = ["#{length(targets)} targets monitored."]
-
-    parts =
+    down_part =
       if down != [] do
         names = Enum.map_join(down, ", ", & &1.name)
-        parts ++ [" #{length(down)} down (#{names})."]
-      else
-        parts
+        " #{length(down)} down (#{names})."
       end
 
-    parts =
+    degraded_part =
       if degraded != [] do
         names = Enum.map_join(degraded, ", ", & &1.name)
-        parts ++ [" #{length(degraded)} degraded (#{names})."]
-      else
-        parts
+        " #{length(degraded)} degraded (#{names})."
       end
 
-    if total_errors > 0 do
-      parts ++ [" #{total_errors} errors across #{length(error_summary)} services in the last hour."]
-    else
-      parts
-    end
+    errors_part =
+      if total_errors > 0 do
+        " #{total_errors} errors across #{length(error_summary)} services in the last hour."
+      end
+
+    ["#{length(targets)} targets monitored.", down_part, degraded_part, errors_part]
+    |> Enum.reject(&is_nil/1)
     |> Enum.join()
   end
 

--- a/lib/canary/summary.ex
+++ b/lib/canary/summary.ex
@@ -84,7 +84,9 @@ defmodule Canary.Summary do
 
     errors_part =
       if total_errors > 0 do
-        " #{total_errors} errors across #{length(error_summary)} services in the last hour."
+        svc_count = length(error_summary)
+        svc_word = if svc_count == 1, do: "service", else: "services"
+        " #{total_errors} errors across #{svc_count} #{svc_word} in the last hour."
       end
 
     ["#{length(targets)} targets monitored.", down_part, degraded_part, errors_part]

--- a/lib/canary_web/controllers/status_controller.ex
+++ b/lib/canary_web/controllers/status_controller.ex
@@ -1,0 +1,7 @@
+defmodule CanaryWeb.StatusController do
+  use CanaryWeb, :controller
+
+  def index(conn, _params) do
+    json(conn, Canary.Status.combined())
+  end
+end

--- a/lib/canary_web/router.ex
+++ b/lib/canary_web/router.ex
@@ -46,6 +46,7 @@ defmodule CanaryWeb.Router do
       pipe_through :query_rate_limit
       get "/query", QueryController, :query
       get "/errors/:id", QueryController, :show
+      get "/status", StatusController, :index
       get "/health-status", HealthController, :status
       get "/targets/:id/checks", HealthController, :target_checks
     end

--- a/test/canary/status_test.exs
+++ b/test/canary/status_test.exs
@@ -5,10 +5,7 @@ defmodule Canary.StatusTest do
   import Canary.Fixtures
 
   setup do
-    Canary.Repo.delete_all(Canary.Schemas.TargetState)
-    Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
-    Canary.Repo.delete_all(Canary.Schemas.Target)
-    Canary.Repo.delete_all(Canary.Schemas.ErrorGroup)
+    clean_status_tables()
     :ok
   end
 

--- a/test/canary/status_test.exs
+++ b/test/canary/status_test.exs
@@ -2,9 +2,9 @@ defmodule Canary.StatusTest do
   use Canary.DataCase
 
   alias Canary.Status
+  import Canary.Fixtures
 
   setup do
-    # Clear pre-existing data (Health.Manager boot) within sandbox
     Canary.Repo.delete_all(Canary.Schemas.TargetState)
     Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
     Canary.Repo.delete_all(Canary.Schemas.Target)
@@ -14,10 +14,7 @@ defmodule Canary.StatusTest do
 
   describe "combined/0" do
     test "all healthy targets and no errors" do
-      # Create 3 healthy targets
-      for name <- ["alpha", "bravo", "charlie"] do
-        create_target_with_state(name, "up")
-      end
+      for name <- ["alpha", "bravo", "charlie"], do: create_target_with_state(name, "up")
 
       result = Status.combined()
 
@@ -25,16 +22,13 @@ defmodule Canary.StatusTest do
       assert length(result.targets) == 3
       assert Enum.all?(result.targets, &(&1.state == "up"))
       assert result.error_summary == []
-      assert is_binary(result.summary)
       assert result.summary =~ "All 3 targets healthy"
     end
 
     test "target down with errors for that service" do
       create_target_with_state("volume", "down")
       create_target_with_state("api", "up")
-
-      # Ingest errors for "volume" service
-      for _ <- 1..12, do: create_error("volume", "ConnectionError")
+      create_error_group("volume", "ConnectionError", 12)
 
       result = Status.combined()
 
@@ -46,7 +40,6 @@ defmodule Canary.StatusTest do
 
       volume_errors = Enum.find(result.error_summary, &(&1.service == "volume"))
       assert volume_errors.total_count == 12
-      assert is_binary(result.summary)
       assert result.summary =~ "volume"
     end
 
@@ -71,79 +64,29 @@ defmodule Canary.StatusTest do
 
     test "errors exist but all targets healthy" do
       create_target_with_state("api", "up")
-      for _ <- 1..5, do: create_error("api", "TimeoutError")
+      create_error_group("api", "TimeoutError", 5)
 
       result = Status.combined()
 
       assert result.overall == "warning"
       assert result.summary =~ "error"
     end
-  end
 
-  # --- Helpers ---
+    test "errors exist with no targets returns warning" do
+      create_error_group("orphan-svc", "CrashError", 3)
 
-  defp create_target_with_state(name, state) do
-    id = "TGT-#{name}"
-    now = DateTime.utc_now() |> DateTime.to_iso8601()
+      result = Status.combined()
 
-    Canary.Repo.insert!(%Canary.Schemas.Target{
-      id: id,
-      name: name,
-      url: "https://#{name}.example.com/healthz",
-      created_at: now
-    })
+      assert result.overall == "warning"
+      assert result.summary =~ "error"
+    end
 
-    Canary.Repo.insert!(%Canary.Schemas.TargetState{
-      target_id: id,
-      state: state,
-      consecutive_failures: if(state == "up", do: 0, else: 3),
-      last_checked_at: now,
-      last_success_at: if(state == "up", do: now, else: nil)
-    })
-  end
+    test "unknown target state treated as degraded" do
+      create_target_with_state("booting", "unknown")
 
-  defp create_error(service, error_class) do
-    id = "ERR-#{:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)}"
-    now = DateTime.utc_now() |> DateTime.to_iso8601()
-    group_hash = :crypto.hash(:sha256, "#{service}:#{error_class}") |> Base.encode16(case: :lower)
+      result = Status.combined()
 
-    Canary.Repo.insert!(
-      %Canary.Schemas.Error{
-        id: id,
-        service: service,
-        error_class: error_class,
-        message: "#{error_class}: something failed",
-        message_template: "#{error_class}: something failed",
-        severity: "error",
-        environment: "production",
-        group_hash: group_hash,
-        created_at: now
-      },
-      on_conflict: :nothing
-    )
-
-    # Upsert the error group
-    case Canary.Repos.read_repo().get(Canary.Schemas.ErrorGroup, group_hash) do
-      nil ->
-        Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
-          group_hash: group_hash,
-          service: service,
-          error_class: error_class,
-          severity: "error",
-          first_seen_at: now,
-          last_seen_at: now,
-          total_count: 1,
-          last_error_id: id
-        })
-
-      group ->
-        group
-        |> Ecto.Changeset.change(%{
-          total_count: group.total_count + 1,
-          last_seen_at: now,
-          last_error_id: id
-        })
-        |> Canary.Repo.update!()
+      assert result.overall == "degraded"
     end
   end
 end

--- a/test/canary/status_test.exs
+++ b/test/canary/status_test.exs
@@ -88,5 +88,30 @@ defmodule Canary.StatusTest do
 
       assert result.overall == "degraded"
     end
+
+    test "old errors outside 1h window are excluded" do
+      create_target_with_state("api", "up")
+
+      two_hours_ago =
+        DateTime.utc_now()
+        |> DateTime.add(-7_200, :second)
+        |> DateTime.to_iso8601()
+
+      create_error_group("api", "StaleError", 10, last_seen_at: two_hours_ago)
+
+      result = Status.combined()
+
+      assert result.overall == "healthy"
+      assert result.error_summary == []
+    end
+
+    test "singular service wording with one service" do
+      create_target_with_state("api", "up")
+      create_error_group("api", "TimeoutError", 5)
+
+      result = Status.combined()
+
+      assert result.summary =~ "1 service in the last hour"
+    end
   end
 end

--- a/test/canary/status_test.exs
+++ b/test/canary/status_test.exs
@@ -1,0 +1,149 @@
+defmodule Canary.StatusTest do
+  use Canary.DataCase
+
+  alias Canary.Status
+
+  setup do
+    # Clear pre-existing data (Health.Manager boot) within sandbox
+    Canary.Repo.delete_all(Canary.Schemas.TargetState)
+    Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
+    Canary.Repo.delete_all(Canary.Schemas.Target)
+    Canary.Repo.delete_all(Canary.Schemas.ErrorGroup)
+    :ok
+  end
+
+  describe "combined/0" do
+    test "all healthy targets and no errors" do
+      # Create 3 healthy targets
+      for name <- ["alpha", "bravo", "charlie"] do
+        create_target_with_state(name, "up")
+      end
+
+      result = Status.combined()
+
+      assert result.overall == "healthy"
+      assert length(result.targets) == 3
+      assert Enum.all?(result.targets, &(&1.state == "up"))
+      assert result.error_summary == []
+      assert is_binary(result.summary)
+      assert result.summary =~ "All 3 targets healthy"
+    end
+
+    test "target down with errors for that service" do
+      create_target_with_state("volume", "down")
+      create_target_with_state("api", "up")
+
+      # Ingest errors for "volume" service
+      for _ <- 1..12, do: create_error("volume", "ConnectionError")
+
+      result = Status.combined()
+
+      assert result.overall == "unhealthy"
+
+      unhealthy = Enum.filter(result.targets, &(&1.state != "up"))
+      assert length(unhealthy) == 1
+      assert hd(unhealthy).name == "volume"
+
+      volume_errors = Enum.find(result.error_summary, &(&1.service == "volume"))
+      assert volume_errors.total_count == 12
+      assert is_binary(result.summary)
+      assert result.summary =~ "volume"
+    end
+
+    test "no targets and no errors" do
+      result = Status.combined()
+
+      assert result.overall == "empty"
+      assert result.targets == []
+      assert result.error_summary == []
+      assert result.summary =~ "No services configured"
+    end
+
+    test "degraded target without errors" do
+      create_target_with_state("api", "degraded")
+      create_target_with_state("web", "up")
+
+      result = Status.combined()
+
+      assert result.overall == "degraded"
+      assert result.summary =~ "degraded"
+    end
+
+    test "errors exist but all targets healthy" do
+      create_target_with_state("api", "up")
+      for _ <- 1..5, do: create_error("api", "TimeoutError")
+
+      result = Status.combined()
+
+      assert result.overall == "warning"
+      assert result.summary =~ "error"
+    end
+  end
+
+  # --- Helpers ---
+
+  defp create_target_with_state(name, state) do
+    id = "TGT-#{name}"
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    Canary.Repo.insert!(%Canary.Schemas.Target{
+      id: id,
+      name: name,
+      url: "https://#{name}.example.com/healthz",
+      created_at: now
+    })
+
+    Canary.Repo.insert!(%Canary.Schemas.TargetState{
+      target_id: id,
+      state: state,
+      consecutive_failures: if(state == "up", do: 0, else: 3),
+      last_checked_at: now,
+      last_success_at: if(state == "up", do: now, else: nil)
+    })
+  end
+
+  defp create_error(service, error_class) do
+    id = "ERR-#{:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)}"
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+    group_hash = :crypto.hash(:sha256, "#{service}:#{error_class}") |> Base.encode16(case: :lower)
+
+    Canary.Repo.insert!(
+      %Canary.Schemas.Error{
+        id: id,
+        service: service,
+        error_class: error_class,
+        message: "#{error_class}: something failed",
+        message_template: "#{error_class}: something failed",
+        severity: "error",
+        environment: "production",
+        group_hash: group_hash,
+        created_at: now
+      },
+      on_conflict: :nothing
+    )
+
+    # Upsert the error group
+    case Canary.Repos.read_repo().get(Canary.Schemas.ErrorGroup, group_hash) do
+      nil ->
+        Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
+          group_hash: group_hash,
+          service: service,
+          error_class: error_class,
+          severity: "error",
+          first_seen_at: now,
+          last_seen_at: now,
+          total_count: 1,
+          last_error_id: id
+        })
+
+      group ->
+        group
+        |> Ecto.Changeset.change(%{
+          total_count: group.total_count + 1,
+          last_seen_at: now,
+          last_error_id: id
+        })
+        |> Canary.Repo.update!()
+    end
+  end
+end

--- a/test/canary/summary_test.exs
+++ b/test/canary/summary_test.exs
@@ -69,32 +69,26 @@ defmodule Canary.SummaryTest do
     end
   end
 
-  describe "combined_status/1" do
+  describe "combined_status/3" do
     test "empty — no targets, no errors" do
-      assert Summary.combined_status(%{overall: "empty"}) == "No services configured."
+      assert Summary.combined_status("empty", [], []) == "No services configured."
     end
 
     test "healthy — all targets up" do
-      result =
-        Summary.combined_status(%{
-          overall: "healthy",
-          targets: [%{name: "a", state: "up"}, %{name: "b", state: "up"}]
-        })
+      targets = [%{name: "a", state: "up"}, %{name: "b", state: "up"}]
 
-      assert result == "All 2 targets healthy. No errors in the last hour."
+      assert Summary.combined_status("healthy", targets, []) ==
+               "All 2 targets healthy. No errors in the last hour."
     end
 
     test "unhealthy — multiple down targets" do
-      result =
-        Summary.combined_status(%{
-          overall: "unhealthy",
-          targets: [
-            %{name: "api", state: "down"},
-            %{name: "web", state: "down"},
-            %{name: "db", state: "up"}
-          ],
-          error_summary: []
-        })
+      targets = [
+        %{name: "api", state: "down"},
+        %{name: "web", state: "down"},
+        %{name: "db", state: "up"}
+      ]
+
+      result = Summary.combined_status("unhealthy", targets, [])
 
       assert result =~ "3 targets monitored."
       assert result =~ "2 down (api, web)."
@@ -102,30 +96,25 @@ defmodule Canary.SummaryTest do
     end
 
     test "degraded — mixed degraded states" do
-      result =
-        Summary.combined_status(%{
-          overall: "degraded",
-          targets: [
-            %{name: "api", state: "degraded"},
-            %{name: "web", state: "degraded"},
-            %{name: "db", state: "up"}
-          ],
-          error_summary: []
-        })
+      targets = [
+        %{name: "api", state: "degraded"},
+        %{name: "web", state: "degraded"},
+        %{name: "db", state: "up"}
+      ]
+
+      result = Summary.combined_status("degraded", targets, [])
 
       assert result =~ "2 degraded (api, web)."
     end
 
     test "mixed down and degraded with errors" do
-      result =
-        Summary.combined_status(%{
-          overall: "unhealthy",
-          targets: [
-            %{name: "api", state: "down"},
-            %{name: "web", state: "degraded"}
-          ],
-          error_summary: [%{service: "api", total_count: 10, unique_classes: 2}]
-        })
+      targets = [
+        %{name: "api", state: "down"},
+        %{name: "web", state: "degraded"}
+      ]
+
+      errors = [%{service: "api", total_count: 10, unique_classes: 2}]
+      result = Summary.combined_status("unhealthy", targets, errors)
 
       assert result =~ "1 down (api)."
       assert result =~ "1 degraded (web)."
@@ -133,12 +122,8 @@ defmodule Canary.SummaryTest do
     end
 
     test "warning — errors only, no targets" do
-      result =
-        Summary.combined_status(%{
-          overall: "warning",
-          targets: [],
-          error_summary: [%{service: "orphan", total_count: 5, unique_classes: 1}]
-        })
+      errors = [%{service: "orphan", total_count: 5, unique_classes: 1}]
+      result = Summary.combined_status("warning", [], errors)
 
       assert result =~ "0 targets monitored."
       assert result =~ "5 errors"

--- a/test/canary/summary_test.exs
+++ b/test/canary/summary_test.exs
@@ -129,7 +129,7 @@ defmodule Canary.SummaryTest do
 
       assert result =~ "1 down (api)."
       assert result =~ "1 degraded (web)."
-      assert result =~ "10 errors across 1 services"
+      assert result =~ "10 errors across 1 service in the last hour"
     end
 
     test "warning — errors only, no targets" do

--- a/test/canary/summary_test.exs
+++ b/test/canary/summary_test.exs
@@ -69,6 +69,82 @@ defmodule Canary.SummaryTest do
     end
   end
 
+  describe "combined_status/1" do
+    test "empty — no targets, no errors" do
+      assert Summary.combined_status(%{overall: "empty"}) == "No services configured."
+    end
+
+    test "healthy — all targets up" do
+      result =
+        Summary.combined_status(%{
+          overall: "healthy",
+          targets: [%{name: "a", state: "up"}, %{name: "b", state: "up"}]
+        })
+
+      assert result == "All 2 targets healthy. No errors in the last hour."
+    end
+
+    test "unhealthy — multiple down targets" do
+      result =
+        Summary.combined_status(%{
+          overall: "unhealthy",
+          targets: [
+            %{name: "api", state: "down"},
+            %{name: "web", state: "down"},
+            %{name: "db", state: "up"}
+          ],
+          error_summary: []
+        })
+
+      assert result =~ "3 targets monitored."
+      assert result =~ "2 down (api, web)."
+      refute result =~ "error"
+    end
+
+    test "degraded — mixed degraded states" do
+      result =
+        Summary.combined_status(%{
+          overall: "degraded",
+          targets: [
+            %{name: "api", state: "degraded"},
+            %{name: "web", state: "degraded"},
+            %{name: "db", state: "up"}
+          ],
+          error_summary: []
+        })
+
+      assert result =~ "2 degraded (api, web)."
+    end
+
+    test "mixed down and degraded with errors" do
+      result =
+        Summary.combined_status(%{
+          overall: "unhealthy",
+          targets: [
+            %{name: "api", state: "down"},
+            %{name: "web", state: "degraded"}
+          ],
+          error_summary: [%{service: "api", total_count: 10, unique_classes: 2}]
+        })
+
+      assert result =~ "1 down (api)."
+      assert result =~ "1 degraded (web)."
+      assert result =~ "10 errors across 1 services"
+    end
+
+    test "warning — errors only, no targets" do
+      result =
+        Summary.combined_status(%{
+          overall: "warning",
+          targets: [],
+          error_summary: [%{service: "orphan", total_count: 5, unique_classes: 1}]
+        })
+
+      assert result =~ "0 targets monitored."
+      assert result =~ "5 errors"
+    end
+  end
+
   describe "error_detail/1" do
     test "generates detail summary" do
       result =

--- a/test/canary_web/controllers/status_controller_test.exs
+++ b/test/canary_web/controllers/status_controller_test.exs
@@ -4,11 +4,7 @@ defmodule CanaryWeb.StatusControllerTest do
   import Canary.Fixtures
 
   setup %{conn: conn} do
-    Canary.Repo.delete_all(Canary.Schemas.TargetState)
-    Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
-    Canary.Repo.delete_all(Canary.Schemas.Target)
-    Canary.Repo.delete_all(Canary.Schemas.ErrorGroup)
-
+    clean_status_tables()
     {raw_key, _key} = create_api_key()
     conn = authenticate(conn, raw_key)
     {:ok, conn: conn}

--- a/test/canary_web/controllers/status_controller_test.exs
+++ b/test/canary_web/controllers/status_controller_test.exs
@@ -1,0 +1,125 @@
+defmodule CanaryWeb.StatusControllerTest do
+  use CanaryWeb.ConnCase
+
+  setup %{conn: conn} do
+    # Clear pre-existing data (Health.Manager boot) within sandbox
+    Canary.Repo.delete_all(Canary.Schemas.TargetState)
+    Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
+    Canary.Repo.delete_all(Canary.Schemas.Target)
+    Canary.Repo.delete_all(Canary.Schemas.ErrorGroup)
+
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "GET /api/v1/status" do
+    test "all healthy, no errors", %{conn: conn} do
+      # Create 3 healthy targets
+      now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+      for name <- ["alpha", "bravo", "charlie"] do
+        id = "TGT-#{name}"
+
+        Canary.Repo.insert!(%Canary.Schemas.Target{
+          id: id,
+          name: name,
+          url: "https://#{name}.example.com/healthz",
+          created_at: now
+        })
+
+        Canary.Repo.insert!(%Canary.Schemas.TargetState{
+          target_id: id,
+          state: "up",
+          consecutive_failures: 0,
+          last_checked_at: now,
+          last_success_at: now
+        })
+      end
+
+      conn = get(conn, "/api/v1/status")
+      body = json_response(conn, 200)
+
+      assert body["overall"] == "healthy"
+      assert length(body["targets"]) == 3
+      assert body["error_summary"] == []
+      assert is_binary(body["summary"])
+    end
+
+    test "target down with errors", %{conn: conn} do
+      now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+      Canary.Repo.insert!(%Canary.Schemas.Target{
+        id: "TGT-volume",
+        name: "volume",
+        url: "https://volume.example.com/healthz",
+        created_at: now
+      })
+
+      Canary.Repo.insert!(%Canary.Schemas.TargetState{
+        target_id: "TGT-volume",
+        state: "down",
+        consecutive_failures: 5,
+        last_checked_at: now
+      })
+
+      group_hash =
+        :crypto.hash(:sha256, "volume:ConnectionError") |> Base.encode16(case: :lower)
+
+      for i <- 1..12 do
+        Canary.Repo.insert!(
+          %Canary.Schemas.Error{
+            id: "ERR-vol-#{i}",
+            service: "volume",
+            error_class: "ConnectionError",
+            message: "connection refused",
+            message_template: "connection refused",
+            severity: "error",
+            environment: "production",
+            group_hash: group_hash,
+            created_at: now
+          },
+          on_conflict: :nothing
+        )
+      end
+
+      Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
+        group_hash: group_hash,
+        service: "volume",
+        error_class: "ConnectionError",
+        severity: "error",
+        first_seen_at: now,
+        last_seen_at: now,
+        total_count: 12,
+        last_error_id: "ERR-vol-12"
+      })
+
+      conn = get(conn, "/api/v1/status")
+      body = json_response(conn, 200)
+
+      assert body["overall"] == "unhealthy"
+      assert [error_entry] = body["error_summary"]
+      assert error_entry["service"] == "volume"
+      assert error_entry["total_count"] == 12
+    end
+
+    test "no targets and no errors", %{conn: conn} do
+      conn = get(conn, "/api/v1/status")
+      body = json_response(conn, 200)
+
+      assert body["overall"] == "empty"
+      assert body["targets"] == []
+      assert body["error_summary"] == []
+      assert body["summary"] =~ "No services configured"
+    end
+
+    test "401 without auth", %{conn: conn} do
+      conn =
+        conn
+        |> delete_req_header("authorization")
+        |> get("/api/v1/status")
+
+      assert json_response(conn, 401)["code"] == "invalid_api_key"
+    end
+  end
+end

--- a/test/canary_web/controllers/status_controller_test.exs
+++ b/test/canary_web/controllers/status_controller_test.exs
@@ -1,8 +1,9 @@
 defmodule CanaryWeb.StatusControllerTest do
   use CanaryWeb.ConnCase
 
+  import Canary.Fixtures
+
   setup %{conn: conn} do
-    # Clear pre-existing data (Health.Manager boot) within sandbox
     Canary.Repo.delete_all(Canary.Schemas.TargetState)
     Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
     Canary.Repo.delete_all(Canary.Schemas.Target)
@@ -15,27 +16,7 @@ defmodule CanaryWeb.StatusControllerTest do
 
   describe "GET /api/v1/status" do
     test "all healthy, no errors", %{conn: conn} do
-      # Create 3 healthy targets
-      now = DateTime.utc_now() |> DateTime.to_iso8601()
-
-      for name <- ["alpha", "bravo", "charlie"] do
-        id = "TGT-#{name}"
-
-        Canary.Repo.insert!(%Canary.Schemas.Target{
-          id: id,
-          name: name,
-          url: "https://#{name}.example.com/healthz",
-          created_at: now
-        })
-
-        Canary.Repo.insert!(%Canary.Schemas.TargetState{
-          target_id: id,
-          state: "up",
-          consecutive_failures: 0,
-          last_checked_at: now,
-          last_success_at: now
-        })
-      end
+      for name <- ["alpha", "bravo", "charlie"], do: create_target_with_state(name, "up")
 
       conn = get(conn, "/api/v1/status")
       body = json_response(conn, 200)
@@ -47,52 +28,8 @@ defmodule CanaryWeb.StatusControllerTest do
     end
 
     test "target down with errors", %{conn: conn} do
-      now = DateTime.utc_now() |> DateTime.to_iso8601()
-
-      Canary.Repo.insert!(%Canary.Schemas.Target{
-        id: "TGT-volume",
-        name: "volume",
-        url: "https://volume.example.com/healthz",
-        created_at: now
-      })
-
-      Canary.Repo.insert!(%Canary.Schemas.TargetState{
-        target_id: "TGT-volume",
-        state: "down",
-        consecutive_failures: 5,
-        last_checked_at: now
-      })
-
-      group_hash =
-        :crypto.hash(:sha256, "volume:ConnectionError") |> Base.encode16(case: :lower)
-
-      for i <- 1..12 do
-        Canary.Repo.insert!(
-          %Canary.Schemas.Error{
-            id: "ERR-vol-#{i}",
-            service: "volume",
-            error_class: "ConnectionError",
-            message: "connection refused",
-            message_template: "connection refused",
-            severity: "error",
-            environment: "production",
-            group_hash: group_hash,
-            created_at: now
-          },
-          on_conflict: :nothing
-        )
-      end
-
-      Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
-        group_hash: group_hash,
-        service: "volume",
-        error_class: "ConnectionError",
-        severity: "error",
-        first_seen_at: now,
-        last_seen_at: now,
-        total_count: 12,
-        last_error_id: "ERR-vol-12"
-      })
+      create_target_with_state("volume", "down")
+      create_error_group("volume", "ConnectionError", 12)
 
       conn = get(conn, "/api/v1/status")
       body = json_response(conn, 200)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -21,8 +21,9 @@ defmodule Canary.Fixtures do
     })
   end
 
-  def create_error_group(service, error_class, count) do
-    now = DateTime.utc_now() |> DateTime.to_iso8601()
+  def create_error_group(service, error_class, count, opts \\ [])
+      when count > 0 do
+    last_seen_at = Keyword.get(opts, :last_seen_at, DateTime.utc_now() |> DateTime.to_iso8601())
 
     group_hash =
       :crypto.hash(:sha256, "#{service}:#{error_class}") |> Base.encode16(case: :lower)
@@ -40,7 +41,7 @@ defmodule Canary.Fixtures do
           severity: "error",
           environment: "production",
           group_hash: group_hash,
-          created_at: now
+          created_at: last_seen_at
         },
         on_conflict: :nothing
       )
@@ -52,8 +53,8 @@ defmodule Canary.Fixtures do
           error_class: error_class,
           severity: "error",
           status: "active",
-          first_seen_at: now,
-          last_seen_at: now,
+          first_seen_at: last_seen_at,
+          last_seen_at: last_seen_at,
           total_count: count,
           last_error_id: id
         })

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,6 +1,13 @@
 defmodule Canary.Fixtures do
   @moduledoc "Shared test data builders."
 
+  def clean_status_tables do
+    Canary.Repo.delete_all(Canary.Schemas.TargetState)
+    Canary.Repo.delete_all(Canary.Schemas.TargetCheck)
+    Canary.Repo.delete_all(Canary.Schemas.Target)
+    Canary.Repo.delete_all(Canary.Schemas.ErrorGroup)
+  end
+
   def create_target_with_state(name, state) do
     id = "TGT-#{name}"
     now = DateTime.utc_now() |> DateTime.to_iso8601()
@@ -24,41 +31,21 @@ defmodule Canary.Fixtures do
   def create_error_group(service, error_class, count, opts \\ [])
       when count > 0 do
     last_seen_at = Keyword.get(opts, :last_seen_at, DateTime.utc_now() |> DateTime.to_iso8601())
+    id = "ERR-#{:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)}"
 
     group_hash =
       :crypto.hash(:sha256, "#{service}:#{error_class}") |> Base.encode16(case: :lower)
 
-    for i <- 1..count do
-      id = "ERR-#{:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)}"
-
-      Canary.Repo.insert!(
-        %Canary.Schemas.Error{
-          id: id,
-          service: service,
-          error_class: error_class,
-          message: "#{error_class}: something failed",
-          message_template: "#{error_class}: something failed",
-          severity: "error",
-          environment: "production",
-          group_hash: group_hash,
-          created_at: last_seen_at
-        },
-        on_conflict: :nothing
-      )
-
-      if i == 1 do
-        Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
-          group_hash: group_hash,
-          service: service,
-          error_class: error_class,
-          severity: "error",
-          status: "active",
-          first_seen_at: last_seen_at,
-          last_seen_at: last_seen_at,
-          total_count: count,
-          last_error_id: id
-        })
-      end
-    end
+    Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
+      group_hash: group_hash,
+      service: service,
+      error_class: error_class,
+      severity: "error",
+      status: "active",
+      first_seen_at: last_seen_at,
+      last_seen_at: last_seen_at,
+      total_count: count,
+      last_error_id: id
+    })
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,0 +1,63 @@
+defmodule Canary.Fixtures do
+  @moduledoc "Shared test data builders."
+
+  def create_target_with_state(name, state) do
+    id = "TGT-#{name}"
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    Canary.Repo.insert!(%Canary.Schemas.Target{
+      id: id,
+      name: name,
+      url: "https://#{name}.example.com/healthz",
+      created_at: now
+    })
+
+    Canary.Repo.insert!(%Canary.Schemas.TargetState{
+      target_id: id,
+      state: state,
+      consecutive_failures: if(state == "up", do: 0, else: 3),
+      last_checked_at: now,
+      last_success_at: if(state == "up", do: now, else: nil)
+    })
+  end
+
+  def create_error_group(service, error_class, count) do
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    group_hash =
+      :crypto.hash(:sha256, "#{service}:#{error_class}") |> Base.encode16(case: :lower)
+
+    for i <- 1..count do
+      id = "ERR-#{:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)}"
+
+      Canary.Repo.insert!(
+        %Canary.Schemas.Error{
+          id: id,
+          service: service,
+          error_class: error_class,
+          message: "#{error_class}: something failed",
+          message_template: "#{error_class}: something failed",
+          severity: "error",
+          environment: "production",
+          group_hash: group_hash,
+          created_at: now
+        },
+        on_conflict: :nothing
+      )
+
+      if i == 1 do
+        Canary.Repo.insert!(%Canary.Schemas.ErrorGroup{
+          group_hash: group_hash,
+          service: service,
+          error_class: error_class,
+          severity: "error",
+          status: "active",
+          first_seen_at: now,
+          last_seen_at: now,
+          total_count: count,
+          last_error_id: id
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why This Matters

Agents debugging issues need to ask "is anything wrong right now?" Today this requires two API calls (`/api/v1/health-status` + `/api/v1/query`) and manual correlation. This endpoint gives agents a single call that returns structured status + deterministic prose summary.

Closes #45

## Trade-offs / Risks

- N+1 query for target state (one `get` per target). Acceptable: target count is typically <20 and this matches the existing `Query.health_status` pattern. Could optimize with a join if target count grows.
- Error window is hardcoded to 1 hour. Could be parameterized later if needed.

## Changes

- `lib/canary/status.ex` — New `Canary.Status.combined/0` combining health targets + error counts
- `lib/canary/summary.ex` — Added `Canary.Summary.combined_status/1` for deterministic summary
- `lib/canary_web/controllers/status_controller.ex` — Thin controller
- `lib/canary_web/router.ex` — Route `GET /api/v1/status` in query rate-limited scope
- 9 new tests (5 unit + 4 integration)

## Acceptance Criteria

- [x] All healthy targets + no errors → `overall: "healthy"`, summary confirms all healthy
- [x] Target down + errors for that service → both in `unhealthy_targets` and `error_summary`
- [x] No targets + no errors → `overall: "empty"`, "No services configured"
- [ ] curl against deployed endpoint returns 200 (post-deploy verification)

## Manual QA

```bash
# After deploy:
curl -s -H "Authorization: Bearer $KEY" https://canary-obs.fly.dev/api/v1/status | jq .
# Expected: 200, JSON with overall/summary/targets/error_summary
```

## Test Coverage

```bash
mix test test/canary/status_test.exs test/canary_web/controllers/status_controller_test.exs
# 9 tests, 0 failures
mix test
# 123 tests, 0 failures
```

## What Changed

```mermaid
flowchart LR
    Agent -->|1| HealthStatus["/health-status"]
    Agent -->|2| Query["/query?service=X"]
    Agent -->|correlate| Decision
```

```mermaid
flowchart LR
    Agent -->|1| Status["/status"]
    Status --> Decision
```

Single call replaces two calls + manual correlation.

## Merge Confidence

**High.** Additive endpoint, no existing behavior changed. Full test suite green. Follows established patterns (Summary, Query, ConnCase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /status API returning overall health, per-target info (state, last-checked, consecutive failures), an hourly error summary aggregated by service, and an improved human-readable summary message.
* **Bug Fixes**
  * Endpoint enforces authentication and returns 401 when unauthorized.
* **Tests**
  * Comprehensive tests and test fixtures added for healthy, degraded, unhealthy, empty, error-only, time-window, and controller auth scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->