### PR TITLE
feat: add unified report endpoint

### DIFF
--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -204,55 +204,30 @@ defmodule Canary.Query do
 
   def error_groups(window) do
     with {:ok, cutoff} <- window_to_cutoff(window) do
-      groups =
-        from(g in ErrorGroup,
-          where: g.last_seen_at >= ^cutoff and g.status == "active",
-          order_by: [desc: g.total_count, asc: g.service, asc: g.error_class],
-          limit: ^@max_groups
-        )
-        |> Canary.Repos.read_repo().all()
-
-      {:ok, Enum.map(groups, &format_group/1)}
+      {:ok, error_groups_since(cutoff)}
     end
   end
 
   def error_summary(window) do
     with {:ok, cutoff} <- window_to_cutoff(window) do
-      summary =
-        from(g in ErrorGroup,
-          where: g.last_seen_at >= ^cutoff and g.status == "active",
-          group_by: g.service,
-          select: %{
-            service: g.service,
-            total_count: sum(g.total_count),
-            unique_classes: count(g.group_hash)
-          },
-          order_by: [desc: sum(g.total_count)]
-        )
-        |> Canary.Repos.read_repo().all()
-
-      {:ok, summary}
+      {:ok, error_summary_since(cutoff)}
     end
   end
 
   def recent_transitions(window) do
     with {:ok, cutoff} <- window_to_cutoff(window) do
-      transitions =
-        from(t in Target,
-          join: s in TargetState,
-          on: t.id == s.target_id,
-          where: not is_nil(s.last_transition_at) and s.last_transition_at >= ^cutoff,
-          order_by: [desc: s.last_transition_at, asc: t.name],
-          select: %{
-            target_id: t.id,
-            target_name: t.name,
-            state: s.state,
-            transitioned_at: s.last_transition_at
-          }
-        )
-        |> Canary.Repos.read_repo().all()
+      {:ok, recent_transitions_since(cutoff)}
+    end
+  end
 
-      {:ok, transitions}
+  def report_slice(window) do
+    with {:ok, cutoff} <- window_to_cutoff(window) do
+      {:ok,
+       %{
+         error_groups: error_groups_since(cutoff),
+         error_summary: error_summary_since(cutoff),
+         recent_transitions: recent_transitions_since(cutoff)
+       }}
     end
   end
 
@@ -321,6 +296,46 @@ defmodule Canary.Query do
   end
 
   # --- Helpers ---
+
+  defp error_groups_since(cutoff) do
+    from(g in ErrorGroup,
+      where: g.last_seen_at >= ^cutoff and g.status == "active",
+      order_by: [desc: g.total_count, asc: g.service, asc: g.error_class],
+      limit: ^@max_groups
+    )
+    |> Canary.Repos.read_repo().all()
+    |> Enum.map(&format_group/1)
+  end
+
+  defp error_summary_since(cutoff) do
+    from(g in ErrorGroup,
+      where: g.last_seen_at >= ^cutoff and g.status == "active",
+      group_by: g.service,
+      select: %{
+        service: g.service,
+        total_count: sum(g.total_count),
+        unique_classes: count(g.group_hash)
+      },
+      order_by: [desc: sum(g.total_count)]
+    )
+    |> Canary.Repos.read_repo().all()
+  end
+
+  defp recent_transitions_since(cutoff) do
+    from(t in Target,
+      join: s in TargetState,
+      on: t.id == s.target_id,
+      where: not is_nil(s.last_transition_at) and s.last_transition_at >= ^cutoff,
+      order_by: [desc: s.last_transition_at, asc: t.name],
+      select: %{
+        target_id: t.id,
+        target_name: t.name,
+        state: s.state,
+        transitioned_at: s.last_transition_at
+      }
+    )
+    |> Canary.Repos.read_repo().all()
+  end
 
   defp window_to_cutoff(window) when window in @allowed_windows do
     seconds =

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -325,7 +325,7 @@ defmodule Canary.Query do
     from(t in Target,
       join: s in TargetState,
       on: t.id == s.target_id,
-      where: not is_nil(s.last_transition_at) and s.last_transition_at >= ^cutoff,
+      where: s.last_transition_at >= ^cutoff,
       order_by: [desc: s.last_transition_at, asc: t.name],
       select: %{
         target_id: t.id,

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -154,7 +154,7 @@ defmodule Canary.Query do
 
   @recent_checks_limit 5
 
-  def health_status do
+  def health_targets do
     repo = Canary.Repos.read_repo()
 
     targets_with_state =
@@ -170,34 +170,90 @@ defmodule Canary.Query do
 
     checks_by_target = fetch_recent_checks(repo, target_ids)
 
-    enriched =
-      Enum.map(targets_with_state, fn {target, state} ->
-        recent = Map.get(checks_by_target, target.id, [])
+    Enum.map(targets_with_state, fn {target, state} ->
+      recent = Map.get(checks_by_target, target.id, [])
 
-        %{
-          id: target.id,
-          name: target.name,
-          url: target.url,
-          state: (state && state.state) || "unknown",
-          consecutive_failures: (state && state.consecutive_failures) || 0,
-          last_checked_at: state && state.last_checked_at,
-          last_success_at: state && state.last_success_at,
-          latency_ms: recent |> List.first() |> then(&(&1 && &1.latency_ms)),
-          tls_expires_at: Enum.find_value(recent, & &1.tls_expires_at),
-          recent_checks:
-            Enum.map(recent, fn c ->
-              %{
-                checked_at: c.checked_at,
-                result: c.result,
-                status_code: c.status_code,
-                latency_ms: c.latency_ms
-              }
-            end)
-        }
-      end)
+      %{
+        id: target.id,
+        name: target.name,
+        url: target.url,
+        state: (state && state.state) || "unknown",
+        consecutive_failures: (state && state.consecutive_failures) || 0,
+        last_checked_at: state && state.last_checked_at,
+        last_success_at: state && state.last_success_at,
+        latency_ms: recent |> List.first() |> then(&(&1 && &1.latency_ms)),
+        tls_expires_at: Enum.find_value(recent, & &1.tls_expires_at),
+        recent_checks:
+          Enum.map(recent, fn c ->
+            %{
+              checked_at: c.checked_at,
+              result: c.result,
+              status_code: c.status_code,
+              latency_ms: c.latency_ms
+            }
+          end)
+      }
+    end)
+  end
 
-    summary = Canary.Summary.health_status(%{targets: enriched})
-    %{summary: summary, targets: enriched}
+  def health_status do
+    targets = health_targets()
+    summary = Canary.Summary.health_status(%{targets: targets})
+    %{summary: summary, targets: targets}
+  end
+
+  def error_groups(window) do
+    with {:ok, cutoff} <- window_to_cutoff(window) do
+      groups =
+        from(g in ErrorGroup,
+          where: g.last_seen_at >= ^cutoff and g.status == "active",
+          order_by: [desc: g.total_count, asc: g.service, asc: g.error_class],
+          limit: ^@max_groups
+        )
+        |> Canary.Repos.read_repo().all()
+
+      {:ok, Enum.map(groups, &format_group/1)}
+    end
+  end
+
+  def error_summary(window) do
+    with {:ok, cutoff} <- window_to_cutoff(window) do
+      summary =
+        from(g in ErrorGroup,
+          where: g.last_seen_at >= ^cutoff and g.status == "active",
+          group_by: g.service,
+          select: %{
+            service: g.service,
+            total_count: sum(g.total_count),
+            unique_classes: count(g.group_hash)
+          },
+          order_by: [desc: sum(g.total_count)]
+        )
+        |> Canary.Repos.read_repo().all()
+
+      {:ok, summary}
+    end
+  end
+
+  def recent_transitions(window) do
+    with {:ok, cutoff} <- window_to_cutoff(window) do
+      transitions =
+        from(t in Target,
+          join: s in TargetState,
+          on: t.id == s.target_id,
+          where: not is_nil(s.last_transition_at) and s.last_transition_at >= ^cutoff,
+          order_by: [desc: s.last_transition_at, asc: t.name],
+          select: %{
+            target_id: t.id,
+            target_name: t.name,
+            state: s.state,
+            transitioned_at: s.last_transition_at
+          }
+        )
+        |> Canary.Repos.read_repo().all()
+
+      {:ok, transitions}
+    end
   end
 
   # Batch-fetch top-N recent checks per target using ROW_NUMBER window function.

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -1,0 +1,27 @@
+defmodule Canary.Report do
+  @moduledoc """
+  Agent-first system report composed from health, errors, and recent transitions.
+  """
+
+  alias Canary.{Query, Status}
+
+  @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_window}
+  def generate(opts \\ []) do
+    window = Keyword.get(opts, :window, "1h")
+
+    with {:ok, error_groups} <- Query.error_groups(window),
+         {:ok, recent_transitions} <- Query.recent_transitions(window) do
+      targets = Query.health_targets()
+      status = Status.combined(window)
+
+      {:ok,
+       %{
+         status: status.overall,
+         summary: status.summary,
+         targets: targets,
+         error_groups: error_groups,
+         recent_transitions: recent_transitions
+       }}
+    end
+  end
+end

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -7,7 +7,7 @@ defmodule Canary.Report do
 
   @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_window}
   def generate(opts \\ []) do
-    window = Keyword.get(opts, :window, "1h")
+    window = Keyword.get(opts, :window) || "1h"
 
     with {:ok, slice} <- Query.report_slice(window) do
       targets = Query.health_targets()

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -9,18 +9,17 @@ defmodule Canary.Report do
   def generate(opts \\ []) do
     window = Keyword.get(opts, :window, "1h")
 
-    with {:ok, error_groups} <- Query.error_groups(window),
-         {:ok, recent_transitions} <- Query.recent_transitions(window) do
+    with {:ok, slice} <- Query.report_slice(window) do
       targets = Query.health_targets()
-      status = Status.combined(window)
+      status = Status.from_snapshot(targets, slice.error_summary, window)
 
       {:ok,
        %{
          status: status.overall,
          summary: status.summary,
          targets: targets,
-         error_groups: error_groups,
-         recent_transitions: recent_transitions
+         error_groups: slice.error_groups,
+         recent_transitions: slice.recent_transitions
        }}
     end
   end

--- a/lib/canary/status.ex
+++ b/lib/canary/status.ex
@@ -4,62 +4,24 @@ defmodule Canary.Status do
   and error counts into a single agent-digestible response.
   """
 
-  alias Canary.Schemas.{ErrorGroup, Target, TargetState}
-  import Ecto.Query
+  alias Canary.Query
 
-  @window_seconds 3_600
-
-  @spec combined() :: map()
-  def combined do
-    targets = fetch_targets()
-    error_summary = fetch_error_summary()
+  @spec combined(String.t()) :: map()
+  def combined(window \\ "1h") do
+    targets = Query.health_targets() |> Enum.map(&legacy_target/1)
+    {:ok, error_summary} = Query.error_summary(window)
     overall = compute_overall(targets, error_summary)
 
     %{
       overall: overall,
-      summary: Canary.Summary.combined_status(overall, targets, error_summary),
+      summary: Canary.Summary.combined_status(overall, targets, error_summary, window),
       targets: targets,
       error_summary: error_summary
     }
   end
 
-  defp fetch_targets do
-    from(t in Target,
-      left_join: s in TargetState,
-      on: t.id == s.target_id,
-      order_by: t.name,
-      select: {t, s}
-    )
-    |> Canary.Repos.read_repo().all()
-    |> Enum.map(fn {target, state} ->
-      %{
-        id: target.id,
-        name: target.name,
-        url: target.url,
-        state: (state && state.state) || "unknown",
-        consecutive_failures: (state && state.consecutive_failures) || 0,
-        last_checked_at: state && state.last_checked_at
-      }
-    end)
-  end
-
-  defp fetch_error_summary do
-    cutoff =
-      DateTime.utc_now()
-      |> DateTime.add(-@window_seconds, :second)
-      |> DateTime.to_iso8601()
-
-    from(g in ErrorGroup,
-      where: g.last_seen_at >= ^cutoff and g.status == "active",
-      group_by: g.service,
-      select: %{
-        service: g.service,
-        total_count: sum(g.total_count),
-        unique_classes: count(g.group_hash)
-      },
-      order_by: [desc: sum(g.total_count)]
-    )
-    |> Canary.Repos.read_repo().all()
+  defp legacy_target(target) do
+    Map.take(target, [:id, :name, :url, :state, :consecutive_failures, :last_checked_at])
   end
 
   defp compute_overall([], []), do: "empty"

--- a/lib/canary/status.ex
+++ b/lib/canary/status.ex
@@ -6,10 +6,16 @@ defmodule Canary.Status do
 
   alias Canary.Query
 
-  @spec combined(String.t()) :: map()
+  @spec combined(String.t()) :: {:ok, map()} | {:error, :invalid_window}
   def combined(window \\ "1h") do
-    targets = Query.health_targets() |> Enum.map(&legacy_target/1)
-    {:ok, error_summary} = Query.error_summary(window)
+    with {:ok, error_summary} <- Query.error_summary(window) do
+      {:ok, from_snapshot(Query.health_targets(), error_summary, window)}
+    end
+  end
+
+  @spec from_snapshot(list(), list(), String.t()) :: map()
+  def from_snapshot(targets, error_summary, window \\ "1h") do
+    targets = Enum.map(targets, &legacy_target/1)
     overall = compute_overall(targets, error_summary)
 
     %{

--- a/lib/canary/summary.ex
+++ b/lib/canary/summary.ex
@@ -112,5 +112,5 @@ defmodule Canary.Summary do
   defp window_label("24h"), do: "24 hours"
   defp window_label("7d"), do: "7 days"
   defp window_label("30d"), do: "30 days"
-  defp window_label(window), do: window
+  defp window_label(_window), do: "requested window"
 end

--- a/lib/canary/summary.ex
+++ b/lib/canary/summary.ex
@@ -38,13 +38,18 @@ defmodule Canary.Summary do
   end
 
   @spec combined_status(String.t(), list(), list()) :: String.t()
-  def combined_status("empty", _targets, _errors), do: "No services configured."
-
-  def combined_status("healthy", targets, _errors) do
-    "All #{length(targets)} targets healthy. No errors in the last hour."
+  def combined_status(overall, targets, error_summary) do
+    combined_status(overall, targets, error_summary, "1h")
   end
 
-  def combined_status(_overall, targets, error_summary) do
+  @spec combined_status(String.t(), list(), list(), String.t()) :: String.t()
+  def combined_status("empty", _targets, _errors, _window), do: "No services configured."
+
+  def combined_status("healthy", targets, _errors, window) do
+    "All #{length(targets)} targets healthy. No errors in the last #{window_label(window)}."
+  end
+
+  def combined_status(_overall, targets, error_summary, window) do
     by_state = Enum.group_by(targets, & &1.state)
     total_errors = Enum.reduce(error_summary, 0, &(&1.total_count + &2))
 
@@ -52,7 +57,7 @@ defmodule Canary.Summary do
       "#{length(targets)} targets monitored.",
       describe_group(by_state["down"], "down", " "),
       describe_group(by_state["degraded"], "degraded", " "),
-      errors_part(total_errors, error_summary)
+      errors_part(total_errors, error_summary, window)
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join()
@@ -94,11 +99,18 @@ defmodule Canary.Summary do
     "#{prefix}#{length(targets)} #{label} (#{names})."
   end
 
-  defp errors_part(0, _summary), do: nil
+  defp errors_part(0, _summary, _window), do: nil
 
-  defp errors_part(total, error_summary) do
+  defp errors_part(total, error_summary, window) do
     svc_count = length(error_summary)
     svc_word = if svc_count == 1, do: "service", else: "services"
-    " #{total} errors across #{svc_count} #{svc_word} in the last hour."
+    " #{total} errors across #{svc_count} #{svc_word} in the last #{window_label(window)}."
   end
+
+  defp window_label("1h"), do: "hour"
+  defp window_label("6h"), do: "6 hours"
+  defp window_label("24h"), do: "24 hours"
+  defp window_label("7d"), do: "7 days"
+  defp window_label("30d"), do: "30 days"
+  defp window_label(window), do: window
 end

--- a/lib/canary_web/controllers/report_controller.ex
+++ b/lib/canary_web/controllers/report_controller.ex
@@ -1,0 +1,24 @@
+defmodule CanaryWeb.ReportController do
+  use CanaryWeb, :controller
+
+  alias Canary.Report
+
+  def index(conn, params) do
+    window = Map.get(params, "window", "1h")
+
+    case Report.generate(window: window) do
+      {:ok, report} -> json(conn, report)
+      {:error, :invalid_window} -> render_invalid_window(conn)
+    end
+  end
+
+  defp render_invalid_window(conn) do
+    CanaryWeb.Plugs.ProblemDetails.render_error(
+      conn,
+      422,
+      "validation_error",
+      "Invalid window. Allowed: 1h, 6h, 24h, 7d, 30d",
+      %{errors: %{window: ["must be one of: 1h, 6h, 24h, 7d, 30d"]}}
+    )
+  end
+end

--- a/lib/canary_web/controllers/status_controller.ex
+++ b/lib/canary_web/controllers/status_controller.ex
@@ -1,8 +1,21 @@
 defmodule CanaryWeb.StatusController do
   use CanaryWeb, :controller
 
-  def index(conn, _params) do
-    {:ok, status} = Canary.Status.combined()
-    json(conn, status)
+  def index(conn, params) do
+    window = Map.get(params, "window", "1h")
+
+    case Canary.Status.combined(window) do
+      {:ok, status} ->
+        json(conn, status)
+
+      {:error, :invalid_window} ->
+        CanaryWeb.Plugs.ProblemDetails.render_error(
+          conn,
+          422,
+          "validation_error",
+          "Invalid window. Allowed: 1h, 6h, 24h, 7d, 30d",
+          %{errors: %{window: ["must be one of: 1h, 6h, 24h, 7d, 30d"]}}
+        )
+    end
   end
 end

--- a/lib/canary_web/controllers/status_controller.ex
+++ b/lib/canary_web/controllers/status_controller.ex
@@ -2,6 +2,7 @@ defmodule CanaryWeb.StatusController do
   use CanaryWeb, :controller
 
   def index(conn, _params) do
-    json(conn, Canary.Status.combined())
+    {:ok, status} = Canary.Status.combined()
+    json(conn, status)
   end
 end

--- a/lib/canary_web/router.ex
+++ b/lib/canary_web/router.ex
@@ -64,6 +64,7 @@ defmodule CanaryWeb.Router do
       pipe_through :query_rate_limit
       get "/query", QueryController, :query
       get "/errors/:id", QueryController, :show
+      get "/report", ReportController, :index
       get "/status", StatusController, :index
       get "/health-status", HealthController, :status
       get "/targets/:id/checks", HealthController, :target_checks

--- a/test/canary/query_test.exs
+++ b/test/canary/query_test.exs
@@ -177,4 +177,20 @@ defmodule Canary.QueryTest do
       assert {:error, :invalid_window} = Query.errors_by_error_class("RuntimeError", "99h")
     end
   end
+
+  describe "error_groups/1" do
+    test "orders groups by count, then service, then error class" do
+      insert_group!(%{service: "beta", error_class: "ZedError", total_count: 3})
+      insert_group!(%{service: "alpha", error_class: "AlphaError", total_count: 5})
+      insert_group!(%{service: "alpha", error_class: "BetaError", total_count: 3})
+
+      assert {:ok, groups} = Query.error_groups("24h")
+
+      assert Enum.map(groups, &{&1.count, &1.service, &1.error_class}) == [
+               {5, "alpha", "AlphaError"},
+               {3, "alpha", "BetaError"},
+               {3, "beta", "ZedError"}
+             ]
+    end
+  end
 end

--- a/test/canary/report_test.exs
+++ b/test/canary/report_test.exs
@@ -2,7 +2,7 @@ defmodule Canary.ReportTest do
   use Canary.DataCase
 
   alias Canary.Report
-  alias Canary.Schemas.TargetState
+  alias Canary.Schemas.{Target, TargetState}
   import Canary.Fixtures
 
   setup do
@@ -58,6 +58,34 @@ defmodule Canary.ReportTest do
 
       assert Enum.map(result.recent_transitions, & &1.target_name) == ["recent"]
       assert hd(result.recent_transitions).transitioned_at == two_hours_ago
+    end
+
+    test "returns invalid_window for unsupported window" do
+      assert {:error, :invalid_window} = Report.generate(window: "99h")
+    end
+
+    test "returns empty status when no targets or errors exist" do
+      assert {:ok, result} = Report.generate(window: "1h")
+
+      assert result.status == "empty"
+      assert result.targets == []
+      assert result.error_groups == []
+      assert result.recent_transitions == []
+      assert result.summary == "No services configured."
+    end
+
+    test "reports unknown state for targets without a state record" do
+      now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+      Canary.Repo.insert!(%Target{
+        id: "TGT-orphan",
+        name: "orphan",
+        url: "https://orphan.example.com/healthz",
+        created_at: now
+      })
+
+      assert {:ok, result} = Report.generate(window: "1h")
+      assert [%{name: "orphan", state: "unknown"}] = result.targets
     end
   end
 end

--- a/test/canary/report_test.exs
+++ b/test/canary/report_test.exs
@@ -1,0 +1,63 @@
+defmodule Canary.ReportTest do
+  use Canary.DataCase
+
+  alias Canary.Report
+  alias Canary.Schemas.TargetState
+  import Canary.Fixtures
+
+  setup do
+    clean_status_tables()
+    :ok
+  end
+
+  describe "generate/1" do
+    test "includes health and error signals for the same service" do
+      create_target_with_state("volume", "degraded")
+      create_target_with_state("api", "up")
+      create_error_group("volume", "ConnectionError", 12)
+
+      assert {:ok, result} = Report.generate(window: "1h")
+
+      assert result.status == "degraded"
+
+      assert Enum.any?(result.targets, fn target ->
+               target.name == "volume" and target.state == "degraded"
+             end)
+
+      assert Enum.any?(result.error_groups, fn group ->
+               group.service == "volume" and group.error_class == "ConnectionError"
+             end)
+
+      assert is_binary(result.summary)
+    end
+
+    test "scopes error groups and recent transitions to the requested window" do
+      create_target_with_state("recent", "degraded")
+      create_target_with_state("stale", "down")
+
+      now = DateTime.utc_now()
+      two_hours_ago = now |> DateTime.add(-7_200, :second) |> DateTime.to_iso8601()
+      eight_hours_ago = now |> DateTime.add(-28_800, :second) |> DateTime.to_iso8601()
+
+      Canary.Repo.update_all(
+        from(s in TargetState, where: s.target_id == "TGT-recent"),
+        set: [last_transition_at: two_hours_ago]
+      )
+
+      Canary.Repo.update_all(
+        from(s in TargetState, where: s.target_id == "TGT-stale"),
+        set: [last_transition_at: eight_hours_ago]
+      )
+
+      create_error_group("recent", "RecentError", 3, last_seen_at: two_hours_ago)
+      create_error_group("stale", "StaleError", 4, last_seen_at: eight_hours_ago)
+
+      assert {:ok, result} = Report.generate(window: "6h")
+
+      assert Enum.map(result.error_groups, & &1.service) == ["recent"]
+
+      assert Enum.map(result.recent_transitions, & &1.target_name) == ["recent"]
+      assert hd(result.recent_transitions).transitioned_at == two_hours_ago
+    end
+  end
+end

--- a/test/canary/report_test.exs
+++ b/test/canary/report_test.exs
@@ -36,8 +36,8 @@ defmodule Canary.ReportTest do
       create_target_with_state("stale", "down")
 
       now = DateTime.utc_now()
-      two_hours_ago = now |> DateTime.add(-7_200, :second) |> DateTime.to_iso8601()
-      eight_hours_ago = now |> DateTime.add(-28_800, :second) |> DateTime.to_iso8601()
+      two_hours_ago = now |> DateTime.add(-2 * 3_600, :second) |> DateTime.to_iso8601()
+      eight_hours_ago = now |> DateTime.add(-8 * 3_600, :second) |> DateTime.to_iso8601()
 
       Canary.Repo.update_all(
         from(s in TargetState, where: s.target_id == "TGT-recent"),

--- a/test/canary/status_test.exs
+++ b/test/canary/status_test.exs
@@ -110,5 +110,9 @@ defmodule Canary.StatusTest do
 
       assert result.summary =~ "1 service in the last hour"
     end
+
+    test "returns invalid_window for unsupported window" do
+      assert {:error, :invalid_window} = Status.combined("99h")
+    end
   end
 end

--- a/test/canary/status_test.exs
+++ b/test/canary/status_test.exs
@@ -13,7 +13,7 @@ defmodule Canary.StatusTest do
     test "all healthy targets and no errors" do
       for name <- ["alpha", "bravo", "charlie"], do: create_target_with_state(name, "up")
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "healthy"
       assert length(result.targets) == 3
@@ -27,7 +27,7 @@ defmodule Canary.StatusTest do
       create_target_with_state("api", "up")
       create_error_group("volume", "ConnectionError", 12)
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "unhealthy"
 
@@ -41,7 +41,7 @@ defmodule Canary.StatusTest do
     end
 
     test "no targets and no errors" do
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "empty"
       assert result.targets == []
@@ -53,7 +53,7 @@ defmodule Canary.StatusTest do
       create_target_with_state("api", "degraded")
       create_target_with_state("web", "up")
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "degraded"
       assert result.summary =~ "degraded"
@@ -63,7 +63,7 @@ defmodule Canary.StatusTest do
       create_target_with_state("api", "up")
       create_error_group("api", "TimeoutError", 5)
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "warning"
       assert result.summary =~ "error"
@@ -72,7 +72,7 @@ defmodule Canary.StatusTest do
     test "errors exist with no targets returns warning" do
       create_error_group("orphan-svc", "CrashError", 3)
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "warning"
       assert result.summary =~ "error"
@@ -81,7 +81,7 @@ defmodule Canary.StatusTest do
     test "unknown target state treated as degraded" do
       create_target_with_state("booting", "unknown")
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "degraded"
     end
@@ -96,7 +96,7 @@ defmodule Canary.StatusTest do
 
       create_error_group("api", "StaleError", 10, last_seen_at: two_hours_ago)
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.overall == "healthy"
       assert result.error_summary == []
@@ -106,7 +106,7 @@ defmodule Canary.StatusTest do
       create_target_with_state("api", "up")
       create_error_group("api", "TimeoutError", 5)
 
-      result = Status.combined()
+      assert {:ok, result} = Status.combined()
 
       assert result.summary =~ "1 service in the last hour"
     end

--- a/test/canary/summary_test.exs
+++ b/test/canary/summary_test.exs
@@ -128,6 +128,24 @@ defmodule Canary.SummaryTest do
       assert result =~ "0 targets monitored."
       assert result =~ "5 errors"
     end
+
+    test "uses non-default window labels in summary text" do
+      targets = [%{name: "api", state: "up"}]
+
+      assert Summary.combined_status("healthy", targets, [], "6h") ==
+               "All 1 targets healthy. No errors in the last 6 hours."
+
+      errors = [%{service: "api", total_count: 2, unique_classes: 1}]
+      result = Summary.combined_status("warning", [], errors, "7d")
+
+      assert result =~ "2 errors across 1 service in the last 7 days."
+    end
+
+    test "falls back to requested window text for unknown values" do
+      result = Summary.combined_status("healthy", [%{name: "a", state: "up"}], [], "99h")
+
+      assert result == "All 1 targets healthy. No errors in the last requested window."
+    end
   end
 
   describe "error_detail/1" do

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -1,0 +1,64 @@
+defmodule CanaryWeb.ReportControllerTest do
+  use CanaryWeb.ConnCase
+
+  import Canary.Fixtures
+
+  setup %{conn: conn} do
+    clean_status_tables()
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "GET /api/v1/report" do
+    test "returns the unified report payload", %{conn: conn} do
+      create_target_with_state("volume", "degraded")
+      create_error_group("volume", "ConnectionError", 12)
+
+      conn = get(conn, "/api/v1/report?window=1h")
+      body = json_response(conn, 200)
+
+      assert Enum.sort(Map.keys(body)) == [
+               "error_groups",
+               "recent_transitions",
+               "status",
+               "summary",
+               "targets"
+             ]
+
+      assert body["status"] == "degraded"
+      assert [%{"service" => "volume"}] = body["error_groups"]
+      assert is_list(body["targets"])
+      assert is_list(body["recent_transitions"])
+    end
+
+    test "returns healthy status and no error groups when everything is healthy", %{conn: conn} do
+      for name <- ["alpha", "bravo"], do: create_target_with_state(name, "up")
+
+      conn = get(conn, "/api/v1/report")
+      body = json_response(conn, 200)
+
+      assert body["status"] == "healthy"
+      assert body["error_groups"] == []
+      assert length(body["targets"]) == 2
+      assert is_binary(body["summary"])
+    end
+
+    test "returns 401 without auth", %{conn: conn} do
+      conn =
+        conn
+        |> delete_req_header("authorization")
+        |> get("/api/v1/report")
+
+      assert json_response(conn, 401)["code"] == "invalid_api_key"
+    end
+
+    test "returns 422 for an invalid window", %{conn: conn} do
+      conn = get(conn, "/api/v1/report?window=99h")
+      body = json_response(conn, 422)
+
+      assert body["code"] == "validation_error"
+      assert body["errors"]["window"] == ["must be one of: 1h, 6h, 24h, 7d, 30d"]
+    end
+  end
+end

--- a/test/canary_web/controllers/status_controller_test.exs
+++ b/test/canary_web/controllers/status_controller_test.exs
@@ -54,5 +54,13 @@ defmodule CanaryWeb.StatusControllerTest do
 
       assert json_response(conn, 401)["code"] == "invalid_api_key"
     end
+
+    test "returns 422 for invalid window", %{conn: conn} do
+      conn = get(conn, "/api/v1/status?window=99h")
+      body = json_response(conn, 422)
+
+      assert body["code"] == "validation_error"
+      assert body["errors"]["window"] == ["must be one of: 1h, 6h, 24h, 7d, 30d"]
+    end
   end
 end


### PR DESCRIPTION
## Reviewer Evidence
- Start here: targeted proof from this branch
  - `mix test test/canary/report_test.exs test/canary_web/controllers/report_controller_test.exs`
  - `mix test`
  - `mix credo --strict && mix dialyzer`
- Direct video download: none; this is an API-only change.
- Walkthrough notes: the new endpoint is exercised by controller coverage, composition coverage, and the preserved `/status` suite.
- Fast claim: agents can now answer "what's wrong?" with one authenticated API call instead of stitching together multiple endpoint responses.

## Why This Matters
- Problem: Canary made agents correlate health, errors, and transitions across several endpoints with different shapes before they could reason about system state.
- Value: `/api/v1/report` collapses that into one bounded payload with deterministic summary text and structured detail.
- Why now: issue [#73](https://github.com/misty-step/canary/issues/73) is the current `p1` / `now` API priority and is foundation work for incident, search, and classification features.
- Issue: [#73](https://github.com/misty-step/canary/issues/73)

## Trade-offs / Risks
- Value gained: one-call agent consumption and a shared query path between report and status flows.
- Cost / risk incurred: a few new public query helpers and one extra report composition module.
- Why this is still the right trade: the interface got simpler for agents while the legacy `/status` contract stayed intact.
- Reviewer watch-outs: pressure-test whether the current `recent_transitions` shape is sufficient for downstream consumers or needs more fields later.

## What Changed
Added a new authenticated report endpoint backed by a single composition module, then pulled the duplicated target+state join into shared query helpers so both report and legacy status read from the same source of truth.

### Base Branch
```mermaid
graph TD
  A[Agent] --> B[/api/v1/status]
  A --> C[/api/v1/health-status]
  A --> D[/api/v1/query]
  A --> E[/api/v1/errors/:id]
  B --> F[Manual correlation in the client]
  C --> F
  D --> F
  E --> F
```

### This PR
```mermaid
graph TD
  A[Agent] --> B[/api/v1/report]
  B --> C[Canary.Report.generate/1]
  C --> D[Query.health_targets]
  C --> E[Query.error_groups]
  C --> F[Query.recent_transitions]
  C --> G[Status.combined]
  G --> H[Summary.combined_status]
```

### Architecture / State Change
```mermaid
sequenceDiagram
  participant Agent
  participant Controller as ReportController
  participant Report
  participant Query
  participant Status
  participant Summary

  Agent->>Controller: GET /api/v1/report?window=1h
  Controller->>Report: generate(window: "1h")
  Report->>Query: error_groups(window)
  Report->>Query: recent_transitions(window)
  Report->>Query: health_targets()
  Report->>Status: combined(window)
  Status->>Query: health_targets() |> legacy_target
  Status->>Query: error_summary(window)
  Status->>Summary: combined_status(...)
  Report-->>Controller: unified payload
  Controller-->>Agent: status + summary + targets + error_groups + recent_transitions
```

Why this is better:
- Agent consumers now have one bounded entrypoint instead of a fan-out query pattern.
- The target/state join is shared instead of duplicated in `Status` and `Query`.
- `/status` keeps its previous target shape while `/report` can carry richer target detail.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Source: [#73](https://github.com/misty-step/canary/issues/73)
- Intent: ship a single authenticated report endpoint that gives agents one bounded answer to "what's wrong?" without breaking existing APIs.
- Success conditions implemented: top-level `status`, `summary`, `targets`, `error_groups`, and `recent_transitions`; legacy `/status` coverage preserved.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `Canary.Report` to compose the agent-facing payload.
- Added `CanaryWeb.ReportController` and routed `GET /api/v1/report`.
- Extracted `Query.health_targets/0` from `Query.health_status/0`.
- Added `Query.error_groups/1`, `Query.error_summary/1`, and `Query.recent_transitions/1`.
- Refactored `Status.combined/1` to reuse shared query helpers while keeping the legacy `/status` target payload stable.
- Extended `Summary.combined_status/4` so report summaries reflect the selected window.
- Added report unit and controller coverage, including invalid-window handling and review-driven edge-case regression tests.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero new code.
- Downside: agents still need several API calls and manual correlation.
- Why rejected: this issue exists because that interface is the main adoption blocker.

### Option B — Build `/report` by stitching together existing controllers
- Upside: minimal new query code.
- Downside: pushes composition to a shallower layer and keeps duplicate query logic alive.
- Why rejected: it would preserve the structural problem the issue is trying to remove.

### Option C — Current approach
- Upside: one deep module at the domain boundary with shared query helpers and stable legacy behavior.
- Downside: adds a few reusable query functions.
- Why chosen: it simplifies the agent interface without inventing extra layers.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given the system has targets and errors, when the report endpoint is called, then the response contains `status`, `summary`, `targets`, `error_groups`, and `recent_transitions` in one JSON payload.
- [x] Given a target is degraded and errors exist for the same service, when `Report.generate/1` is called, then both signals appear in the same response under the correct service.
- [x] Given `window=6h`, when `Report.generate/1` runs, then error groups and transitions are scoped to the 6-hour window.
- [x] Given no errors and all targets healthy, when the report endpoint is called, then `status` is `healthy` and `error_groups` is empty.
- [x] Given the report endpoint exists, when the legacy `/status` endpoint is called, then it still works.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
mix test test/canary/report_test.exs test/canary_web/controllers/report_controller_test.exs
mix test
mix credo --strict
mix dialyzer
```
Expected:
- targeted report tests pass
- full suite passes
- Credo reports no issues
- Dialyzer reports success

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal evidence from real branch execution
- Artifact: targeted report tests, full suite, Credo, and Dialyzer all executed on this branch
- Claim: one authenticated endpoint now exposes the agent-first report without regressing `/status`
- Before / After scope: API request flow only; no UI surface changed
- Persistent verification: `[test/canary/report_test.exs](./test/canary/report_test.exs)` and `[test/canary_web/controllers/report_controller_test.exs](./test/canary_web/controllers/report_controller_test.exs)` plus `[test/canary_web/controllers/status_controller_test.exs](./test/canary_web/controllers/status_controller_test.exs)`
- Residual gap: no live Fly smoke test was run from this lane

Observed outputs:
```text
mix test
177 tests, 0 failures

mix credo --strict
found no issues

mix dialyzer
done (passed successfully)
```

</details>

<details>
<summary>Before / After</summary>

## Before / After
Before: an agent had to fan out across `/status`, `/health-status`, `/query`, and detail endpoints, then reconcile incompatible payloads itself.

After: `/api/v1/report` returns one bounded payload with system status, summary, targets, error groups, and recent transitions.

Screenshots are not included because this PR changes only authenticated JSON APIs.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `test/canary/report_test.exs`
  - same-service health + error composition
  - 6-hour scoping for error groups and recent transitions
  - invalid-window, empty-system, and unknown-target-state coverage
- `test/canary_web/controllers/report_controller_test.exs`
  - payload shape
  - healthy empty-error case
  - auth requirement
  - invalid window handling
- `test/canary_web/controllers/status_controller_test.exs`
  - preserved legacy `/status` behavior
- `test/canary/query_test.exs`
  - error-group ordering contract
- `test/canary/summary_test.exs`
  - non-default and fallback window-label coverage

Gap:
- no deployed-environment smoke test in this PR lane

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: targeted report tests, full `mix test`, `mix credo --strict`, and `mix dialyzer` all passed after the final refactor.
- Remaining uncertainty: production data may reveal demand for more transition metadata, but the current shape satisfies the issue contract.
- What could still go wrong: downstream consumers might want stronger guarantees around transition history than the current latest-transition snapshot.

</details>

