### PR TITLE
Add semantic error classification to grouped reports

### DIFF
--- a/lib/canary/errors/classification.ex
+++ b/lib/canary/errors/classification.ex
@@ -58,7 +58,7 @@ defmodule Canary.Errors.Classification do
   rescue
     error in [ArgumentError, BadMapError, FunctionClauseError, KeyError] ->
       Logger.warning(
-        "classification_failed error_class=#{inspect(value(subject, :error_class))} " <>
+        "classification_failed error_class=#{inspect(safe_error_class(subject))} " <>
           "exception=#{inspect(error.__struct__)} message=#{Exception.message(error)}"
       )
 
@@ -86,4 +86,7 @@ defmodule Canary.Errors.Classification do
   defp value(subject, key) do
     Map.get(subject, key) || Map.get(subject, Atom.to_string(key)) || ""
   end
+
+  defp safe_error_class(subject) when is_map(subject), do: value(subject, :error_class)
+  defp safe_error_class(subject), do: subject
 end

--- a/lib/canary/errors/classification.ex
+++ b/lib/canary/errors/classification.ex
@@ -1,0 +1,81 @@
+defmodule Canary.Errors.Classification do
+  @moduledoc """
+  Deterministic, table-driven error classifier.
+  """
+
+  @type classification :: %{
+          category: :infrastructure | :application | :unknown,
+          persistence: :transient | :persistent | :unknown,
+          component: :database | :network | :runtime | :unknown
+        }
+
+  @type fields :: %{
+          error_class: String.t(),
+          message: String.t()
+        }
+
+  @type rule :: %{
+          required(:classification) => classification(),
+          optional(:error_class) => Regex.t(),
+          optional(:message) => Regex.t()
+        }
+
+  @unknown %{
+    category: :unknown,
+    persistence: :unknown,
+    component: :unknown
+  }
+
+  @rules [
+    %{
+      error_class: ~r/(^|\.)DBConnection\.ConnectionError$/,
+      classification: %{
+        category: :infrastructure,
+        persistence: :transient,
+        component: :database
+      }
+    },
+    %{
+      error_class: ~r/(^|\.)FunctionClauseError$/,
+      classification: %{
+        category: :application,
+        persistence: :persistent,
+        component: :runtime
+      }
+    }
+  ]
+
+  @spec classify(map() | struct()) :: classification()
+  @spec classify(map() | struct(), [rule()]) :: classification()
+  def classify(subject, rules \\ @rules) when is_list(rules) do
+    fields = normalize(subject)
+
+    Enum.find_value(rules, @unknown, fn rule ->
+      if matches?(fields, rule), do: rule.classification
+    end)
+  rescue
+    _ -> @unknown
+  end
+
+  defp normalize(subject) when is_map(subject) do
+    %{
+      error_class: value(subject, :error_class),
+      message: value(subject, :message)
+    }
+  end
+
+  defp normalize(_), do: %{error_class: "", message: ""}
+
+  defp matches?(fields, rule) do
+    Enum.all?([:error_class, :message], fn key ->
+      case Map.get(rule, key) do
+        nil -> true
+        pattern -> Regex.match?(pattern, Map.fetch!(fields, key))
+      end
+    end)
+  end
+
+  defp value(subject, key) do
+    Map.get(subject, key) || Map.get(subject, Atom.to_string(key)) || ""
+  end
+end

--- a/lib/canary/errors/classification.ex
+++ b/lib/canary/errors/classification.ex
@@ -1,0 +1,89 @@
+defmodule Canary.Errors.Classification do
+  require Logger
+
+  @moduledoc """
+  Deterministic, table-driven error classifier.
+  """
+
+  @type classification :: %{
+          category: :infrastructure | :application | :unknown,
+          persistence: :transient | :persistent | :unknown,
+          component: :database | :network | :runtime | :unknown
+        }
+
+  @type fields :: %{
+          error_class: String.t(),
+          message: String.t()
+        }
+
+  @type rule :: %{
+          required(:classification) => classification(),
+          optional(:error_class) => Regex.t(),
+          optional(:message) => Regex.t()
+        }
+
+  @unknown %{
+    category: :unknown,
+    persistence: :unknown,
+    component: :unknown
+  }
+
+  @rules [
+    %{
+      error_class: ~r/(^|\.)DBConnection\.ConnectionError$/,
+      classification: %{
+        category: :infrastructure,
+        persistence: :transient,
+        component: :database
+      }
+    },
+    %{
+      error_class: ~r/(^|\.)FunctionClauseError$/,
+      classification: %{
+        category: :application,
+        persistence: :persistent,
+        component: :runtime
+      }
+    }
+  ]
+
+  @spec classify(map() | struct()) :: classification()
+  @spec classify(map() | struct(), [rule()]) :: classification()
+  def classify(subject, rules \\ @rules) when is_list(rules) do
+    fields = normalize(subject)
+
+    Enum.find_value(rules, @unknown, fn rule ->
+      if matches?(fields, rule), do: rule.classification
+    end)
+  rescue
+    error in [ArgumentError, BadMapError, FunctionClauseError, KeyError] ->
+      Logger.warning(
+        "classification_failed error_class=#{inspect(value(subject, :error_class))} " <>
+          "exception=#{inspect(error.__struct__)} message=#{Exception.message(error)}"
+      )
+
+      @unknown
+  end
+
+  defp normalize(subject) when is_map(subject) do
+    %{
+      error_class: value(subject, :error_class),
+      message: value(subject, :message)
+    }
+  end
+
+  defp normalize(_), do: %{error_class: "", message: ""}
+
+  defp matches?(fields, rule) do
+    Enum.all?([:error_class, :message], fn key ->
+      case Map.get(rule, key) do
+        nil -> true
+        pattern -> Regex.match?(pattern, Map.fetch!(fields, key))
+      end
+    end)
+  end
+
+  defp value(subject, key) do
+    Map.get(subject, key) || Map.get(subject, Atom.to_string(key)) || ""
+  end
+end

--- a/lib/canary/errors/ingest.ex
+++ b/lib/canary/errors/ingest.ex
@@ -4,7 +4,7 @@ defmodule Canary.Errors.Ingest do
   Deep module: single public function, complex internal machinery.
   """
 
-  alias Canary.Errors.{DedupCache, Grouping}
+  alias Canary.Errors.{Classification, DedupCache, Grouping}
   alias Canary.{ID, Incidents, Repo}
   alias Canary.Schemas.{Error, ErrorGroup}
 
@@ -20,6 +20,7 @@ defmodule Canary.Errors.Ingest do
          :ok <- validate_context(attrs),
          :ok <- validate_fingerprint(attrs) do
       {group_hash, template} = Grouping.compute_group_hash(attrs)
+      classification = Classification.classify(attrs)
       now = DateTime.utc_now() |> DateTime.to_iso8601()
       error_id = ID.error_id()
 
@@ -35,6 +36,9 @@ defmodule Canary.Errors.Ingest do
         group_hash: group_hash,
         fingerprint: encode_fingerprint(attrs["fingerprint"]),
         region: attrs["region"],
+        classification_category: Atom.to_string(classification.category),
+        classification_persistence: Atom.to_string(classification.persistence),
+        classification_component: Atom.to_string(classification.component),
         created_at: now
       }
 

--- a/lib/canary/errors/ingest.ex
+++ b/lib/canary/errors/ingest.ex
@@ -4,7 +4,7 @@ defmodule Canary.Errors.Ingest do
   Deep module: single public function, complex internal machinery.
   """
 
-  alias Canary.Errors.{DedupCache, Grouping}
+  alias Canary.Errors.{Classification, DedupCache, Grouping}
   alias Canary.{ID, Repo}
   alias Canary.Schemas.{Error, ErrorGroup}
 
@@ -18,6 +18,7 @@ defmodule Canary.Errors.Ingest do
          :ok <- validate_context(attrs),
          :ok <- validate_fingerprint(attrs) do
       {group_hash, template} = Grouping.compute_group_hash(attrs)
+      classification = Classification.classify(attrs)
       now = DateTime.utc_now() |> DateTime.to_iso8601()
       error_id = ID.error_id()
 
@@ -33,6 +34,9 @@ defmodule Canary.Errors.Ingest do
         group_hash: group_hash,
         fingerprint: encode_fingerprint(attrs["fingerprint"]),
         region: attrs["region"],
+        classification_category: Atom.to_string(classification.category),
+        classification_persistence: Atom.to_string(classification.persistence),
+        classification_component: Atom.to_string(classification.component),
         created_at: now
       }
 

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -30,7 +30,7 @@ defmodule Canary.Query do
         )
 
       query = apply_cursor(query, cursor)
-      groups = Canary.Repos.read_repo().all(query)
+      groups = query |> select_group_with_classification() |> Canary.Repos.read_repo().all()
 
       total = Enum.reduce(groups, 0, &(&1.total_count + &2))
 
@@ -72,7 +72,7 @@ defmodule Canary.Query do
         end
 
       query = apply_cursor(query, cursor)
-      groups = Canary.Repos.read_repo().all(query)
+      groups = query |> select_group_with_classification() |> Canary.Repos.read_repo().all()
       total = Enum.reduce(groups, 0, &(&1.total_count + &2))
 
       summary =
@@ -296,7 +296,8 @@ defmodule Canary.Query do
       last_seen: g.last_seen_at,
       sample_message: g.message_template,
       severity: g.severity,
-      status: g.status
+      status: g.status,
+      classification: format_classification(g)
     }
   end
 
@@ -314,8 +315,45 @@ defmodule Canary.Query do
       order_by: [desc: g.total_count, asc: g.service, asc: g.error_class],
       limit: ^@max_groups
     )
+    |> select_group_with_classification()
     |> Canary.Repos.read_repo().all()
     |> Enum.map(&format_group/1)
+  end
+
+  defp select_group_with_classification(query) do
+    from(g in query,
+      left_join: e in Error,
+      on: e.id == g.last_error_id,
+      select: %{
+        group_hash: g.group_hash,
+        error_class: g.error_class,
+        service: g.service,
+        total_count: g.total_count,
+        first_seen_at: g.first_seen_at,
+        last_seen_at: g.last_seen_at,
+        message_template: g.message_template,
+        severity: g.severity,
+        status: g.status,
+        classification_category: e.classification_category,
+        classification_persistence: e.classification_persistence,
+        classification_component: e.classification_component
+      }
+    )
+  end
+
+  defp format_classification(group) do
+    %{
+      category: classification_value(group, :classification_category),
+      persistence: classification_value(group, :classification_persistence),
+      component: classification_value(group, :classification_component)
+    }
+  end
+
+  defp classification_value(group, key) do
+    case Map.get(group, key) do
+      value when value in [nil, ""] -> "unknown"
+      value -> value
+    end
   end
 
   defp error_summary_since(cutoff) do

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -20,7 +20,7 @@ defmodule Canary.Query do
         )
 
       query = apply_cursor(query, cursor)
-      groups = Canary.Repos.read_repo().all(query)
+      groups = query |> select_group_with_classification() |> Canary.Repos.read_repo().all()
 
       total = Enum.reduce(groups, 0, &(&1.total_count + &2))
 
@@ -62,7 +62,7 @@ defmodule Canary.Query do
         end
 
       query = apply_cursor(query, cursor)
-      groups = Canary.Repos.read_repo().all(query)
+      groups = query |> select_group_with_classification() |> Canary.Repos.read_repo().all()
       total = Enum.reduce(groups, 0, &(&1.total_count + &2))
 
       summary =
@@ -285,7 +285,8 @@ defmodule Canary.Query do
       last_seen: g.last_seen_at,
       sample_message: g.message_template,
       severity: g.severity,
-      status: g.status
+      status: g.status,
+      classification: format_classification(g)
     }
   end
 
@@ -303,8 +304,42 @@ defmodule Canary.Query do
       order_by: [desc: g.total_count, asc: g.service, asc: g.error_class],
       limit: ^@max_groups
     )
+    |> select_group_with_classification()
     |> Canary.Repos.read_repo().all()
     |> Enum.map(&format_group/1)
+  end
+
+  defp select_group_with_classification(query) do
+    from(g in query,
+      left_join: e in Error,
+      on: e.id == g.last_error_id,
+      select: %{
+        group_hash: g.group_hash,
+        error_class: g.error_class,
+        service: g.service,
+        total_count: g.total_count,
+        first_seen_at: g.first_seen_at,
+        last_seen_at: g.last_seen_at,
+        message_template: g.message_template,
+        severity: g.severity,
+        status: g.status,
+        classification_category: e.classification_category,
+        classification_persistence: e.classification_persistence,
+        classification_component: e.classification_component
+      }
+    )
+  end
+
+  defp format_classification(group) do
+    %{
+      category: classification_value(group, :classification_category),
+      persistence: classification_value(group, :classification_persistence),
+      component: classification_value(group, :classification_component)
+    }
+  end
+
+  defp classification_value(group, key) do
+    Map.get(group, key) || "unknown"
   end
 
   defp error_summary_since(cutoff) do

--- a/lib/canary/schemas/error.ex
+++ b/lib/canary/schemas/error.ex
@@ -15,11 +15,25 @@ defmodule Canary.Schemas.Error do
     field :group_hash, :string
     field :fingerprint, :string
     field :region, :string
+    field :classification_category, :string
+    field :classification_persistence, :string
+    field :classification_component, :string
     field :created_at, :string
   end
 
   @required ~w(service error_class message group_hash created_at)a
-  @optional ~w(message_template stack_trace context severity environment fingerprint region)a
+  @optional ~w(
+    message_template
+    stack_trace
+    context
+    severity
+    environment
+    fingerprint
+    region
+    classification_category
+    classification_persistence
+    classification_component
+  )a
   @severities ~w(error warning info)
 
   def changeset(error, attrs) do

--- a/lib/canary/schemas/error.ex
+++ b/lib/canary/schemas/error.ex
@@ -35,12 +35,18 @@ defmodule Canary.Schemas.Error do
     classification_component
   )a
   @severities ~w(error warning info)
+  @classification_categories ~w(infrastructure application unknown)
+  @classification_persistences ~w(transient persistent unknown)
+  @classification_components ~w(database network runtime unknown)
 
   def changeset(error, attrs) do
     error
     |> cast(attrs, @required ++ @optional)
     |> validate_required(@required)
     |> validate_inclusion(:severity, @severities)
+    |> validate_inclusion(:classification_category, @classification_categories)
+    |> validate_inclusion(:classification_persistence, @classification_persistences)
+    |> validate_inclusion(:classification_component, @classification_components)
     |> validate_length(:message, max: 4_096)
     |> validate_length(:stack_trace, max: 32_768)
   end

--- a/priv/repo/migrations/20260322164500_add_error_classification_to_errors.exs
+++ b/priv/repo/migrations/20260322164500_add_error_classification_to_errors.exs
@@ -1,0 +1,11 @@
+defmodule Canary.Repo.Migrations.AddErrorClassificationToErrors do
+  use Ecto.Migration
+
+  def change do
+    alter table(:errors) do
+      add :classification_category, :string
+      add :classification_persistence, :string
+      add :classification_component, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20260322164500_add_error_classification_to_errors.exs
+++ b/priv/repo/migrations/20260322164500_add_error_classification_to_errors.exs
@@ -1,0 +1,26 @@
+defmodule Canary.Repo.Migrations.AddErrorClassificationToErrors do
+  use Ecto.Migration
+
+  def change do
+    alter table(:errors) do
+      add :classification_category, :string
+      add :classification_persistence, :string
+      add :classification_component, :string
+    end
+
+    create constraint(:errors, :classification_category_valid,
+             check:
+               "classification_category IS NULL OR classification_category IN ('infrastructure','application','unknown')"
+           )
+
+    create constraint(:errors, :classification_persistence_valid,
+             check:
+               "classification_persistence IS NULL OR classification_persistence IN ('transient','persistent','unknown')"
+           )
+
+    create constraint(:errors, :classification_component_valid,
+             check:
+               "classification_component IS NULL OR classification_component IN ('database','network','runtime','unknown')"
+           )
+  end
+end

--- a/priv/repo/migrations/20260322164500_add_error_classification_to_errors.exs
+++ b/priv/repo/migrations/20260322164500_add_error_classification_to_errors.exs
@@ -7,20 +7,5 @@ defmodule Canary.Repo.Migrations.AddErrorClassificationToErrors do
       add :classification_persistence, :string
       add :classification_component, :string
     end
-
-    create constraint(:errors, :classification_category_valid,
-             check:
-               "classification_category IS NULL OR classification_category IN ('infrastructure','application','unknown')"
-           )
-
-    create constraint(:errors, :classification_persistence_valid,
-             check:
-               "classification_persistence IS NULL OR classification_persistence IN ('transient','persistent','unknown')"
-           )
-
-    create constraint(:errors, :classification_component_valid,
-             check:
-               "classification_component IS NULL OR classification_component IN ('database','network','runtime','unknown')"
-           )
   end
 end

--- a/test/canary/errors/classification_test.exs
+++ b/test/canary/errors/classification_test.exs
@@ -1,7 +1,15 @@
 defmodule Canary.Errors.ClassificationTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Canary.Errors.Classification
+
+  @unknown %{
+    category: :unknown,
+    persistence: :unknown,
+    component: :unknown
+  }
 
   describe "classify/1" do
     test "classifies database connection errors as transient infrastructure" do
@@ -21,11 +29,7 @@ defmodule Canary.Errors.ClassificationTest do
     end
 
     test "falls back to unknown for unmatched classes" do
-      assert Classification.classify(%{"error_class" => "TotallyNewError"}) == %{
-               category: :unknown,
-               persistence: :unknown,
-               component: :unknown
-             }
+      assert Classification.classify(%{"error_class" => "TotallyNewError"}) == @unknown
     end
 
     test "applies custom table rules without matcher changes" do
@@ -45,6 +49,47 @@ defmodule Canary.Errors.ClassificationTest do
                persistence: :transient,
                component: :network
              }
+    end
+
+    test "matches custom rules against the error message" do
+      rules = [
+        %{
+          message: ~r/connection reset by peer/,
+          classification: %{
+            category: :infrastructure,
+            persistence: :transient,
+            component: :network
+          }
+        }
+      ]
+
+      assert Classification.classify(%{"message" => "connection reset by peer"}, rules) == %{
+               category: :infrastructure,
+               persistence: :transient,
+               component: :network
+             }
+    end
+
+    test "returns unknown and logs when matcher rules raise for non-map subjects" do
+      rules = [
+        %{
+          message: "not-a-regex",
+          classification: %{
+            category: :infrastructure,
+            persistence: :transient,
+            component: :network
+          }
+        }
+      ]
+
+      log =
+        capture_log(fn ->
+          assert Classification.classify("socket closed", rules) == @unknown
+        end)
+
+      assert log =~ "classification_failed"
+      assert log =~ "FunctionClauseError"
+      assert log =~ ~s(error_class="socket closed")
     end
   end
 end

--- a/test/canary/errors/classification_test.exs
+++ b/test/canary/errors/classification_test.exs
@@ -1,0 +1,50 @@
+defmodule Canary.Errors.ClassificationTest do
+  use ExUnit.Case, async: true
+
+  alias Canary.Errors.Classification
+
+  describe "classify/1" do
+    test "classifies database connection errors as transient infrastructure" do
+      assert Classification.classify(%{"error_class" => "DBConnection.ConnectionError"}) == %{
+               category: :infrastructure,
+               persistence: :transient,
+               component: :database
+             }
+    end
+
+    test "classifies runtime clause errors as persistent application failures" do
+      assert Classification.classify(%{"error_class" => "FunctionClauseError"}) == %{
+               category: :application,
+               persistence: :persistent,
+               component: :runtime
+             }
+    end
+
+    test "falls back to unknown for unmatched classes" do
+      assert Classification.classify(%{"error_class" => "TotallyNewError"}) == %{
+               category: :unknown,
+               persistence: :unknown,
+               component: :unknown
+             }
+    end
+
+    test "applies custom table rules without matcher changes" do
+      rules = [
+        %{
+          error_class: ~r/(^|\.)Mint\.TransportError$/,
+          classification: %{
+            category: :infrastructure,
+            persistence: :transient,
+            component: :network
+          }
+        }
+      ]
+
+      assert Classification.classify(%{"error_class" => "Mint.TransportError"}, rules) == %{
+               category: :infrastructure,
+               persistence: :transient,
+               component: :network
+             }
+    end
+  end
+end

--- a/test/canary/errors/ingest_test.exs
+++ b/test/canary/errors/ingest_test.exs
@@ -63,6 +63,17 @@ defmodule Canary.Errors.IngestTest do
       assert error.environment == "production"
     end
 
+    test "stores classification on the error record" do
+      attrs = Map.put(@valid_attrs, "error_class", "DBConnection.ConnectionError")
+
+      {:ok, result} = Ingest.ingest(attrs)
+      error = Repo.get(Error, result.id)
+
+      assert error.classification_category == "infrastructure"
+      assert error.classification_persistence == "transient"
+      assert error.classification_component == "database"
+    end
+
     test "accepts custom severity" do
       attrs = Map.put(@valid_attrs, "severity", "warning")
       {:ok, result} = Ingest.ingest(attrs)

--- a/test/canary/query_test.exs
+++ b/test/canary/query_test.exs
@@ -3,7 +3,7 @@ defmodule Canary.QueryTest do
 
   alias Canary.Errors.Ingest
   alias Canary.Query
-  alias Canary.Schemas.{ErrorGroup, Target, TargetCheck, TargetState}
+  alias Canary.Schemas.{Error, ErrorGroup, Target, TargetCheck, TargetState}
 
   defp insert_group!(attrs) do
     now = DateTime.utc_now() |> DateTime.to_iso8601()
@@ -22,6 +22,23 @@ defmodule Canary.QueryTest do
 
     %ErrorGroup{}
     |> ErrorGroup.changeset(Map.merge(defaults, attrs))
+    |> Canary.Repo.insert!()
+  end
+
+  defp insert_error!(attrs \\ %{}) do
+    id = Canary.ID.error_id()
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    defaults = %{
+      service: "test-svc",
+      error_class: "RuntimeError",
+      message: "boom",
+      group_hash: "grp-#{id}",
+      created_at: now
+    }
+
+    %Error{id: id}
+    |> Error.changeset(Map.merge(defaults, attrs))
     |> Canary.Repo.insert!()
   end
 
@@ -208,6 +225,24 @@ defmodule Canary.QueryTest do
                category: "infrastructure",
                persistence: "transient",
                component: "database"
+             }
+    end
+
+    test "falls back to unknown classification for legacy rows" do
+      error = insert_error!()
+
+      insert_group!(%{
+        service: error.service,
+        error_class: error.error_class,
+        last_error_id: error.id
+      })
+
+      assert {:ok, [group]} = Query.error_groups("24h")
+
+      assert group.classification == %{
+               category: "unknown",
+               persistence: "unknown",
+               component: "unknown"
              }
     end
   end

--- a/test/canary/query_test.exs
+++ b/test/canary/query_test.exs
@@ -1,6 +1,7 @@
 defmodule Canary.QueryTest do
   use Canary.DataCase
 
+  alias Canary.Errors.Ingest
   alias Canary.Query
   alias Canary.Schemas.{ErrorGroup, Target, TargetCheck, TargetState}
 
@@ -191,6 +192,23 @@ defmodule Canary.QueryTest do
                {3, "alpha", "BetaError"},
                {3, "beta", "ZedError"}
              ]
+    end
+
+    test "includes classification from the latest error in the group" do
+      {:ok, _} =
+        Ingest.ingest(%{
+          "service" => "volume",
+          "error_class" => "DBConnection.ConnectionError",
+          "message" => "database unavailable"
+        })
+
+      assert {:ok, [group]} = Query.error_groups("24h")
+
+      assert group.classification == %{
+               category: "infrastructure",
+               persistence: "transient",
+               component: "database"
+             }
     end
   end
 end

--- a/test/canary/report_test.exs
+++ b/test/canary/report_test.exs
@@ -1,6 +1,7 @@
 defmodule Canary.ReportTest do
   use Canary.DataCase
 
+  alias Canary.Errors.Ingest
   alias Canary.Report
   alias Canary.Schemas.{Target, TargetState}
   alias Canary.Incidents
@@ -73,6 +74,24 @@ defmodule Canary.ReportTest do
 
     test "returns invalid_window for unsupported window" do
       assert {:error, :invalid_window} = Report.generate(window: "99h")
+    end
+
+    test "includes classification on each error group" do
+      {:ok, _} =
+        Ingest.ingest(%{
+          "service" => "volume",
+          "error_class" => "DBConnection.ConnectionError",
+          "message" => "database unavailable"
+        })
+
+      assert {:ok, result} = Report.generate(window: "1h")
+      assert [group] = result.error_groups
+
+      assert group.classification == %{
+               category: "infrastructure",
+               persistence: "transient",
+               component: "database"
+             }
     end
 
     test "returns empty status when no targets or errors exist" do

--- a/test/canary/report_test.exs
+++ b/test/canary/report_test.exs
@@ -1,6 +1,7 @@
 defmodule Canary.ReportTest do
   use Canary.DataCase
 
+  alias Canary.Errors.Ingest
   alias Canary.Report
   alias Canary.Schemas.{Target, TargetState}
   import Canary.Fixtures
@@ -62,6 +63,24 @@ defmodule Canary.ReportTest do
 
     test "returns invalid_window for unsupported window" do
       assert {:error, :invalid_window} = Report.generate(window: "99h")
+    end
+
+    test "includes classification on each error group" do
+      {:ok, _} =
+        Ingest.ingest(%{
+          "service" => "volume",
+          "error_class" => "DBConnection.ConnectionError",
+          "message" => "database unavailable"
+        })
+
+      assert {:ok, result} = Report.generate(window: "1h")
+      assert [group] = result.error_groups
+
+      assert group.classification == %{
+               category: "infrastructure",
+               persistence: "transient",
+               component: "database"
+             }
     end
 
     test "returns empty status when no targets or errors exist" do

--- a/test/canary/schemas/error_test.exs
+++ b/test/canary/schemas/error_test.exs
@@ -1,0 +1,43 @@
+defmodule Canary.Schemas.ErrorTest do
+  use Canary.DataCase, async: true
+
+  alias Canary.Schemas.Error
+
+  test "accepts known classification domains" do
+    changeset =
+      Error.changeset(%Error{}, %{
+        service: "svc",
+        error_class: "RuntimeError",
+        message: "boom",
+        group_hash: "group-hash",
+        created_at: "2026-03-24T00:00:00Z",
+        classification_category: "infrastructure",
+        classification_persistence: "transient",
+        classification_component: "database"
+      })
+
+    assert changeset.valid?
+  end
+
+  test "rejects invalid classification domains" do
+    changeset =
+      Error.changeset(%Error{}, %{
+        service: "svc",
+        error_class: "RuntimeError",
+        message: "boom",
+        group_hash: "group-hash",
+        created_at: "2026-03-24T00:00:00Z",
+        classification_category: "oops",
+        classification_persistence: "forever",
+        classification_component: "kernel"
+      })
+
+    refute changeset.valid?
+
+    assert errors_on(changeset) == %{
+             classification_category: ["is invalid"],
+             classification_component: ["is invalid"],
+             classification_persistence: ["is invalid"]
+           }
+  end
+end

--- a/test/canary/schemas/error_test.exs
+++ b/test/canary/schemas/error_test.exs
@@ -3,34 +3,57 @@ defmodule Canary.Schemas.ErrorTest do
 
   alias Canary.Schemas.Error
 
-  test "accepts known classification domains" do
-    changeset =
-      Error.changeset(%Error{}, %{
+  defp error_attrs(overrides) do
+    Map.merge(
+      %{
         service: "svc",
         error_class: "RuntimeError",
         message: "boom",
         group_hash: "group-hash",
-        created_at: "2026-03-24T00:00:00Z",
-        classification_category: "infrastructure",
-        classification_persistence: "transient",
-        classification_component: "database"
-      })
+        created_at: "2026-03-24T00:00:00Z"
+      },
+      overrides
+    )
+  end
+
+  test "accepts known classification domains" do
+    changeset =
+      Error.changeset(
+        %Error{},
+        error_attrs(%{
+          classification_category: "infrastructure",
+          classification_persistence: "transient",
+          classification_component: "database"
+        })
+      )
+
+    assert changeset.valid?
+  end
+
+  test "accepts unknown classification domains" do
+    changeset =
+      Error.changeset(
+        %Error{},
+        error_attrs(%{
+          classification_category: "unknown",
+          classification_persistence: "unknown",
+          classification_component: "unknown"
+        })
+      )
 
     assert changeset.valid?
   end
 
   test "rejects invalid classification domains" do
     changeset =
-      Error.changeset(%Error{}, %{
-        service: "svc",
-        error_class: "RuntimeError",
-        message: "boom",
-        group_hash: "group-hash",
-        created_at: "2026-03-24T00:00:00Z",
-        classification_category: "oops",
-        classification_persistence: "forever",
-        classification_component: "kernel"
-      })
+      Error.changeset(
+        %Error{},
+        error_attrs(%{
+          classification_category: "oops",
+          classification_persistence: "forever",
+          classification_component: "kernel"
+        })
+      )
 
     refute changeset.valid?
 

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -32,6 +32,25 @@ defmodule CanaryWeb.ReportControllerTest do
       assert is_list(body["recent_transitions"])
     end
 
+    test "includes classification for each error group", %{conn: conn} do
+      post(conn, "/api/v1/errors", %{
+        "service" => "volume",
+        "error_class" => "DBConnection.ConnectionError",
+        "message" => "database unavailable"
+      })
+
+      conn = get(conn, "/api/v1/report?window=1h")
+      body = json_response(conn, 200)
+
+      assert [%{"classification" => classification}] = body["error_groups"]
+
+      assert classification == %{
+               "category" => "infrastructure",
+               "persistence" => "transient",
+               "component" => "database"
+             }
+    end
+
     test "returns healthy status and no error groups when everything is healthy", %{conn: conn} do
       for name <- ["alpha", "bravo"], do: create_target_with_state(name, "up")
 

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -39,6 +39,25 @@ defmodule CanaryWeb.ReportControllerTest do
       assert is_list(body["recent_transitions"])
     end
 
+    test "includes classification for each error group", %{conn: conn} do
+      post(conn, "/api/v1/errors", %{
+        "service" => "volume",
+        "error_class" => "DBConnection.ConnectionError",
+        "message" => "database unavailable"
+      })
+
+      conn = get(conn, "/api/v1/report?window=1h")
+      body = json_response(conn, 200)
+
+      assert [%{"classification" => classification}] = body["error_groups"]
+
+      assert classification == %{
+               "category" => "infrastructure",
+               "persistence" => "transient",
+               "component" => "database"
+             }
+    end
+
     test "returns healthy status and no error groups when everything is healthy", %{conn: conn} do
       for name <- ["alpha", "bravo"], do: create_target_with_state(name, "up")
 


### PR DESCRIPTION
## Reviewer Evidence
- Start here: `lib/canary/errors/classification.ex` and `lib/canary/query.ex`
- Direct video download: not applicable for this backend/API change
- Walkthrough notes: local branch execution proved ingest persistence and report exposure over HTTP on `http://127.0.0.1:4001`
- Fast claim: Canary now classifies ingested errors once, stores that classification on `errors`, and includes a nested `classification` object in grouped report/query responses.

```text
$ mix test
197 tests, 0 failures

$ mix credo --strict
544 mods/funs, found no issues.

$ mix dialyzer
Total errors: 0, Skipped: 0, Unnecessary Skips: 0

$ curl -sS 'http://127.0.0.1:4001/api/v1/report?window=1h' -H 'Authorization: Bearer ...' | jq -c '.error_groups[] | select(.service=="autopilot-local") | .classification'
{"category":"infrastructure","component":"database","persistence":"transient"}
```

## Why This Matters
- Problem: Canary grouped errors for deduplication, but every agent still had to reinterpret `error_class` and `message` to decide whether something was infra vs app, and transient vs persistent.
- Value: The server now does that work once at ingest time and exposes the result directly in grouped responses, which reduces repeated downstream reasoning and makes retry/escalation decisions cheaper.
- Why now: Issue [#75](https://github.com/misty-step/canary/issues/75) is an isolated API improvement that strengthens agent-first querying without changing the request path to use an LLM.
- Issue: [#75](https://github.com/misty-step/canary/issues/75)

## Trade-offs / Risks
- Value gained: Deterministic semantic classification is now stored and queryable without reparsing error names.
- Cost / risk incurred: The starter rule table is intentionally small, so coverage is limited to known classes until more rules are added.
- Why this is still the right trade: The matcher control flow stays fixed and the rule table is the only thing that grows, which keeps the module simple and reversible.
- Reviewer watch-outs: Pressure-test whether joining `error_groups.last_error_id` to `errors` is the right single source of truth versus denormalizing classification onto groups.

## What Changed
This branch adds a dedicated deterministic classifier, persists its output on each ingested error row, and threads that stored data into grouped report/query payloads with an `unknown` fallback for legacy rows.

### Base Branch
```mermaid
graph TD
  Ingest[Ingest payload] --> Grouping[Grouping.compute_group_hash]
  Grouping --> Errors[(errors)]
  Grouping --> Groups[(error_groups)]
  Groups --> Report[Query report groups]
  Report --> Agents[Agent reparses error class and message]
```

### This PR
```mermaid
graph TD
  Ingest[Ingest payload] --> Classify[Classification.classify]
  Classify --> Errors[(errors + classification columns)]
  Ingest --> Groups[(error_groups)]
  Groups --> Report[Query groups + latest error classification]
  Errors --> Report
  Report --> Agents[Agent reads classification object directly]
```

### Architecture / State Change
```mermaid
sequenceDiagram
  participant Client
  participant Ingest as Canary.Errors.Ingest
  participant Classifier as Canary.Errors.Classification
  participant Repo as Canary.Repo
  participant Query as Canary.Query

  Client->>Ingest: ingest(error attrs)
  Ingest->>Classifier: classify(error_class, message)
  Classifier-->>Ingest: category/persistence/component
  Ingest->>Repo: insert error with classification
  Ingest->>Repo: upsert error_group
  Query->>Repo: read group + latest error classification
  Repo-->>Query: grouped response with classification object
```

Why this is better:
- The classifier is a deep, single-purpose module instead of scattered regex checks at read sites.
- Classification is written once and reused on reads, so grouped responses do not have to rediscover semantics every time.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue [#75](https://github.com/misty-step/canary/issues/75) locked this contract: classify known error classes deterministically, never crash on unknown classes, persist classification on the error record, and include a `classification` object in the report response.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `Canary.Errors.Classification` as a table-driven classifier with a small starter rule set and safe `unknown` fallback.
- Persisted `classification_category`, `classification_persistence`, and `classification_component` on `errors` during ingest.
- Added a SQLite-safe migration for the new columns.
- Enforced classification domains in the `Canary.Schemas.Error` changeset with targeted schema coverage.
- Narrowed the classifier fallback rescue to expected exception shapes and log a warning before returning `unknown`.
- Extended grouped query/report formatting to join the latest stored error and expose nested classification data.
- Added targeted tests for classifier behavior, ingest persistence, report generation, and report controller JSON output.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: No schema change and no new rule maintenance.
- Downside: Every agent keeps reparsing raw error text.
- Why rejected: It preserves duplicated semantic work in the exact API path Canary is supposed to simplify.

### Option B — Store classification on `error_groups`
- Upside: Report reads stay group-only.
- Downside: Creates a second semantic source of truth in addition to `errors`.
- Why rejected: Classification is a property of an ingested error, and joining via `last_error_id` keeps the write path singular.

### Option C — Current approach
- Upside: Single write source of truth, simple deterministic rule table, safe fallback for legacy rows.
- Downside: Grouped reads now include a join.
- Why chosen: The join is small and well-covered by tests, while the write model stays cleaner.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] [test] Given an error with class `DBConnection.ConnectionError`, when `Classification.classify/1` is called, then it returns `%{category: :infrastructure, persistence: :transient, component: :database}`
- [x] [test] Given an error with class `FunctionClauseError`, when classified, then it returns `%{category: :application, persistence: :persistent, component: :runtime}`
- [x] [test] Given an error with an unknown class, when classified, then it returns `%{category: :unknown, persistence: :unknown, component: :unknown}` (never crashes)
- [x] [test] Given classification rules are table-driven, when a new rule is added to the classification table, then it takes effect without code changes
- [x] [command] Given errors exist, when `curl -H "Authorization: Bearer $KEY" "http://127.0.0.1:4001/api/v1/report?window=1h"`, then each error group includes a `classification` object
- [x] [test] Given an error is ingested, when it's persisted, then `classification_category` and `classification_persistence` are stored on the error record

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
mix ecto.create
mix ecto.migrate
mix run -e 'Application.ensure_all_started(:canary); {:ok, _key, raw_key} = Canary.Auth.generate_key("autopilot-local"); IO.puts(raw_key)'
PORT=4001 mix phx.server
curl -X POST 'http://127.0.0.1:4001/api/v1/errors' \
  -H "Authorization: Bearer $KEY" \
  -H 'content-type: application/json' \
  -d '{"service":"autopilot-local","error_class":"DBConnection.ConnectionError","message":"database unavailable"}'
curl -sS 'http://127.0.0.1:4001/api/v1/report?window=1h' \
  -H "Authorization: Bearer $KEY" | jq '.error_groups[] | select(.service=="autopilot-local") | .classification'
```
Expected result:
- ingest returns `201`
- report output includes `{"category":"infrastructure","persistence":"transient","component":"database"}` for the seeded service

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal output + local request/response trace
- Artifact: the `mix test` / `mix credo --strict` / `mix dialyzer` outputs plus the local `curl .../report` classification response shown above
- Claim: grouped report responses now expose persisted semantic classification
- Before / After scope: before this branch, grouped responses exposed only class/message metadata; after this branch they include a nested `classification` object derived from stored columns
- Persistent verification: `mix test test/canary/errors/classification_test.exs test/canary/errors/ingest_test.exs test/canary/query_test.exs test/canary/report_test.exs test/canary_web/controllers/report_controller_test.exs`
- Residual gap: the starter rule table is intentionally minimal, so broader class coverage is future work rather than part of this lane

</details>

<details>
<summary>Before / After</summary>

## Before / After
Before: `error_groups` responses exposed grouping metadata only, so clients still had to infer whether an error was transient infrastructure or persistent application logic.

After: `error_groups` responses include a `classification` object populated from the last stored error in the group, with `unknown` fallback for legacy rows.

Screenshots are not included because this is an internal API/backend change rather than a visual surface change.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `test/canary/errors/classification_test.exs`
- `test/canary/errors/ingest_test.exs`
- `test/canary/query_test.exs`
- `test/canary/report_test.exs`
- `test/canary_web/controllers/report_controller_test.exs`
- Full suite: `mix test`
- Static analysis: `mix credo --strict`, `mix dialyzer`

Gap:
- The current rule set only covers the initial database/runtime cases plus custom-rule extensibility, not a broad catalog of network/runtime classes. The persistence domains are now enforced in the `Canary.Schemas.Error` changeset and covered by a focused schema test.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: 197-test green suite, strict Credo, clean Dialyzer, and a local authenticated HTTP trace showing the new report payload
- Remaining uncertainty: future rule expansion may want a richer classification catalog and more domain-specific coverage
- What could still go wrong after merge: legacy groups without matching error rows will continue to surface `unknown`, which is intentional but worth remembering when reading older data

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic error classification (category, persistence, component) added and surfaced in ingestion, group listings, reports, and API responses.

* **Database**
  * Three new nullable columns to store classification values; persisted values validated against allowed domains.

* **Tests**
  * New unit and integration tests covering classification logic, ingestion, querying, reporting, and controller responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

