### PR TITLE
Add SQLite FTS search to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,34 @@ and correlated incidents in one bounded payload:
 }
 ```
 
+Optional free-text error search stays on the same endpoint:
+
+```bash
+curl "https://canary-obs.fly.dev/api/v1/report?window=1h&q=timeout" \
+  -H "Authorization: Bearer $CANARY_API_KEY"
+```
+
+When `q` is present, the response adds `search_results`, scoped to the same
+window as the rest of the report:
+
+```json
+{
+  "status": "degraded",
+  "summary": "2 targets monitored. 1 degraded (canary-triage). 14 errors across 1 service in the last hour.",
+  "search_results": [
+    {
+      "id": "ERR-a1b2c3",
+      "service": "canary-triage",
+      "error_class": "TimeoutError",
+      "message": "timeout while posting issue",
+      "group_hash": "sha256...",
+      "created_at": "2026-03-24T20:15:00Z",
+      "score": 1.73
+    }
+  ]
+}
+```
+
 ### Target Management
 
 ```bash

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -122,6 +122,8 @@ defmodule Canary.Query do
     end
   end
 
+  def search(query, opts \\ []), do: Canary.Query.Search.search(query, opts)
+
   defp build_error_detail(error) do
     group = Canary.Repos.read_repo().get(ErrorGroup, error.group_hash)
 

--- a/lib/canary/query.ex
+++ b/lib/canary/query.ex
@@ -18,10 +18,8 @@ defmodule Canary.Query do
 
   @incident_active_window_seconds 300
   @max_groups 50
-  @allowed_windows ~w(1h 6h 24h 7d 30d)
-
   def errors_by_service(service, window, cursor \\ nil) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       query =
         from(g in ErrorGroup,
           where: g.service == ^service and g.last_seen_at >= ^cutoff,
@@ -55,7 +53,7 @@ defmodule Canary.Query do
   end
 
   def errors_by_error_class(error_class, window, opts \\ []) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       cursor = Keyword.get(opts, :cursor)
 
       query =
@@ -96,7 +94,7 @@ defmodule Canary.Query do
   end
 
   def errors_by_class(window) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       groups =
         from(g in ErrorGroup,
           where: g.last_seen_at >= ^cutoff,
@@ -122,7 +120,17 @@ defmodule Canary.Query do
     end
   end
 
-  def search(query, opts \\ []), do: Canary.Query.Search.search(query, opts)
+  def search(query, opts \\ []) do
+    case Keyword.get(opts, :window) do
+      nil ->
+        Canary.Query.Search.search(query, opts)
+
+      window ->
+        with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
+          Canary.Query.Search.search(query, Keyword.put(opts, :cutoff, cutoff))
+        end
+    end
+  end
 
   defp build_error_detail(error) do
     group = Canary.Repos.read_repo().get(ErrorGroup, error.group_hash)
@@ -215,25 +223,25 @@ defmodule Canary.Query do
   end
 
   def error_groups(window) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       {:ok, error_groups_since(cutoff)}
     end
   end
 
   def error_summary(window) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       {:ok, error_summary_since(cutoff)}
     end
   end
 
   def recent_transitions(window) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       {:ok, recent_transitions_since(cutoff)}
     end
   end
 
   def report_slice(window) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       {:ok,
        %{
          error_groups: error_groups_since(cutoff),
@@ -273,7 +281,7 @@ defmodule Canary.Query do
   end
 
   def target_checks(target_id, window) do
-    with {:ok, cutoff} <- window_to_cutoff(window) do
+    with {:ok, cutoff} <- Canary.Query.Window.to_cutoff(window) do
       checks =
         from(c in TargetCheck,
           where: c.target_id == ^target_id and c.checked_at >= ^cutoff,
@@ -450,26 +458,6 @@ defmodule Canary.Query do
       _ -> false
     end
   end
-
-  defp window_to_cutoff(window) when window in @allowed_windows do
-    seconds =
-      case window do
-        "1h" -> 3_600
-        "6h" -> 21_600
-        "24h" -> 86_400
-        "7d" -> 604_800
-        "30d" -> 2_592_000
-      end
-
-    cutoff =
-      DateTime.utc_now()
-      |> DateTime.add(-seconds, :second)
-      |> DateTime.to_iso8601()
-
-    {:ok, cutoff}
-  end
-
-  defp window_to_cutoff(_), do: {:error, :invalid_window}
 
   defp apply_cursor(query, nil), do: query
 

--- a/lib/canary/query/search.ex
+++ b/lib/canary/query/search.ex
@@ -64,6 +64,7 @@ defmodule Canary.Query.Search do
     {clauses ++ [clause], params ++ [value]}
   end
 
+  # format_result/1 must stay in the same column order as search_sql/4.
   defp format_result([id, service, error_class, message, group_hash, created_at, score]) do
     %{
       id: id,

--- a/lib/canary/query/search.ex
+++ b/lib/canary/query/search.ex
@@ -1,5 +1,6 @@
 defmodule Canary.Query.Search do
   @moduledoc false
+  require Logger
 
   @default_limit 20
   @bm25_weights "1.0, 2.0, 5.0, 1.0"
@@ -16,44 +17,51 @@ defmodule Canary.Query.Search do
     end
   end
 
+  def search(_query, _opts), do: {:error, :invalid_query}
+
   defp run_search(query, opts) do
     service = Keyword.get(opts, :service)
+    cutoff = Keyword.get(opts, :cutoff)
     limit = Keyword.get(opts, :limit, @default_limit)
 
-    {sql, params} = search_sql(quoted_query(query), service, limit)
-    result = Canary.Repos.read_repo().query!(sql, params)
+    {sql, params} = search_sql(quoted_query(query), service, cutoff, limit)
 
-    {:ok, Enum.map(result.rows, &format_result/1)}
+    case Canary.Repos.read_repo().query(sql, params) do
+      {:ok, result} ->
+        {:ok, Enum.map(result.rows, &format_result/1)}
+
+      {:error, reason} ->
+        Logger.warning("Search query failed: #{inspect(reason)}")
+        {:error, :search_failed}
+    end
   end
 
-  defp search_sql(query, nil, limit) do
+  defp search_sql(query, service, cutoff, limit) do
+    {clauses, params} =
+      {["errors_fts MATCH ?"], [query]}
+      |> maybe_add_clause(service, "e.service = ?")
+      |> maybe_add_clause(cutoff, "e.created_at >= ?")
+
     {"""
      SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
             -bm25(errors_fts, #{@bm25_weights}) AS score
      FROM errors_fts
      JOIN errors AS e ON e.rowid = errors_fts.rowid
-     WHERE errors_fts MATCH ?
+     WHERE #{Enum.join(clauses, "\n       AND ")}
      ORDER BY score DESC, e.created_at DESC
      LIMIT ?
-     """, [query, limit]}
-  end
-
-  defp search_sql(query, service, limit) do
-    {"""
-     SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
-            -bm25(errors_fts, #{@bm25_weights}) AS score
-     FROM errors_fts
-     JOIN errors AS e ON e.rowid = errors_fts.rowid
-     WHERE errors_fts MATCH ?
-       AND e.service = ?
-     ORDER BY score DESC, e.created_at DESC
-     LIMIT ?
-     """, [query, service, limit]}
+     """, params ++ [limit]}
   end
 
   defp quoted_query(query) do
     escaped = String.replace(query, "\"", "\"\"")
     ~s("#{escaped}")
+  end
+
+  defp maybe_add_clause({clauses, params}, nil, _clause), do: {clauses, params}
+
+  defp maybe_add_clause({clauses, params}, value, clause) do
+    {clauses ++ [clause], params ++ [value]}
   end
 
   defp format_result([id, service, error_class, message, group_hash, created_at, score]) do

--- a/lib/canary/query/search.ex
+++ b/lib/canary/query/search.ex
@@ -2,6 +2,7 @@ defmodule Canary.Query.Search do
   @moduledoc false
 
   @default_limit 20
+  @bm25_weights "1.0, 2.0, 5.0, 1.0"
 
   def search(query, opts \\ [])
 
@@ -28,7 +29,7 @@ defmodule Canary.Query.Search do
   defp search_sql(query, nil, limit) do
     {"""
      SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
-            -bm25(errors_fts, 1.0, 2.0, 5.0, 1.0) AS score
+            -bm25(errors_fts, #{@bm25_weights}) AS score
      FROM errors_fts
      JOIN errors AS e ON e.rowid = errors_fts.rowid
      WHERE errors_fts MATCH ?
@@ -40,7 +41,7 @@ defmodule Canary.Query.Search do
   defp search_sql(query, service, limit) do
     {"""
      SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
-            -bm25(errors_fts, 1.0, 2.0, 5.0, 1.0) AS score
+            -bm25(errors_fts, #{@bm25_weights}) AS score
      FROM errors_fts
      JOIN errors AS e ON e.rowid = errors_fts.rowid
      WHERE errors_fts MATCH ?

--- a/lib/canary/query/search.ex
+++ b/lib/canary/query/search.ex
@@ -1,0 +1,69 @@
+defmodule Canary.Query.Search do
+  @moduledoc false
+
+  @default_limit 20
+
+  def search(query, opts \\ [])
+
+  def search(query, opts) when is_binary(query) do
+    trimmed = String.trim(query)
+
+    if trimmed == "" do
+      {:ok, []}
+    else
+      run_search(trimmed, opts)
+    end
+  end
+
+  defp run_search(query, opts) do
+    service = Keyword.get(opts, :service)
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    {sql, params} = search_sql(quoted_query(query), service, limit)
+    result = Canary.Repos.read_repo().query!(sql, params)
+
+    {:ok, Enum.map(result.rows, &format_result/1)}
+  end
+
+  defp search_sql(query, nil, limit) do
+    {"""
+     SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
+            -bm25(errors_fts, 1.0, 2.0, 5.0, 1.0) AS score
+     FROM errors_fts
+     JOIN errors AS e ON e.rowid = errors_fts.rowid
+     WHERE errors_fts MATCH ?
+     ORDER BY score DESC, e.created_at DESC
+     LIMIT ?
+     """, [query, limit]}
+  end
+
+  defp search_sql(query, service, limit) do
+    {"""
+     SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
+            -bm25(errors_fts, 1.0, 2.0, 5.0, 1.0) AS score
+     FROM errors_fts
+     JOIN errors AS e ON e.rowid = errors_fts.rowid
+     WHERE errors_fts MATCH ?
+       AND e.service = ?
+     ORDER BY score DESC, e.created_at DESC
+     LIMIT ?
+     """, [query, service, limit]}
+  end
+
+  defp quoted_query(query) do
+    escaped = String.replace(query, "\"", "\"\"")
+    ~s("#{escaped}")
+  end
+
+  defp format_result([id, service, error_class, message, group_hash, created_at, score]) do
+    %{
+      id: id,
+      service: service,
+      error_class: error_class,
+      message: message,
+      group_hash: group_hash,
+      created_at: created_at,
+      score: score
+    }
+  end
+end

--- a/lib/canary/query/window.ex
+++ b/lib/canary/query/window.ex
@@ -1,0 +1,25 @@
+defmodule Canary.Query.Window do
+  @moduledoc false
+
+  @allowed_windows ~w(1h 6h 24h 7d 30d)
+
+  def to_cutoff(window) when window in @allowed_windows do
+    seconds =
+      case window do
+        "1h" -> 3_600
+        "6h" -> 21_600
+        "24h" -> 86_400
+        "7d" -> 604_800
+        "30d" -> 2_592_000
+      end
+
+    cutoff =
+      DateTime.utc_now()
+      |> DateTime.add(-seconds, :second)
+      |> DateTime.to_iso8601()
+
+    {:ok, cutoff}
+  end
+
+  def to_cutoff(_window), do: {:error, :invalid_window}
+end

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -8,20 +8,36 @@ defmodule Canary.Report do
   @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_window}
   def generate(opts \\ []) do
     window = Keyword.get(opts, :window) || "1h"
+    search_query = Keyword.get(opts, :q)
 
     with {:ok, slice} <- Query.report_slice(window) do
       targets = Query.health_targets()
       status = Status.from_snapshot(targets, slice.error_summary, window)
+      search_results = search_results(search_query)
 
       {:ok,
-       %{
-         status: status.overall,
-         summary: status.summary,
-         targets: targets,
-         error_groups: slice.error_groups,
-         incidents: slice.incidents,
-         recent_transitions: slice.recent_transitions
-       }}
+       maybe_put_search_results(
+         %{
+           status: status.overall,
+           summary: status.summary,
+           targets: targets,
+           error_groups: slice.error_groups,
+           incidents: slice.incidents,
+           recent_transitions: slice.recent_transitions
+         },
+         search_results
+       )}
     end
   end
+
+  defp search_results(nil), do: nil
+
+  defp search_results(query) do
+    case Query.search(query) do
+      {:ok, results} -> results
+    end
+  end
+
+  defp maybe_put_search_results(report, nil), do: report
+  defp maybe_put_search_results(report, results), do: Map.put(report, :search_results, results)
 end

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -10,10 +10,10 @@ defmodule Canary.Report do
     window = Keyword.get(opts, :window) || "1h"
     search_query = Keyword.get(opts, :q)
 
-    with {:ok, slice} <- Query.report_slice(window) do
+    with {:ok, slice} <- Query.report_slice(window),
+         {:ok, search_results} <- search_results(search_query, window) do
       targets = Query.health_targets()
       status = Status.from_snapshot(targets, slice.error_summary, window)
-      search_results = search_results(search_query)
 
       {:ok,
        maybe_put_search_results(
@@ -30,11 +30,13 @@ defmodule Canary.Report do
     end
   end
 
-  defp search_results(nil), do: nil
+  defp search_results(nil, _window), do: {:ok, nil}
 
-  defp search_results(query) do
-    case Query.search(query) do
-      {:ok, results} -> results
+  defp search_results(query, window) do
+    case Query.search(query, window: window) do
+      {:ok, results} -> {:ok, results}
+      {:error, :search_failed} -> {:ok, []}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -5,7 +5,7 @@ defmodule Canary.Report do
 
   alias Canary.{Query, Status}
 
-  @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_window}
+  @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_query | :invalid_window}
   def generate(opts \\ []) do
     window = Keyword.get(opts, :window) || "1h"
     search_query = Keyword.get(opts, :q)

--- a/lib/canary_web/controllers/report_controller.ex
+++ b/lib/canary_web/controllers/report_controller.ex
@@ -10,6 +10,7 @@ defmodule CanaryWeb.ReportController do
     case Report.generate(window: window, q: q) do
       {:ok, report} -> json(conn, report)
       {:error, :invalid_window} -> render_invalid_window(conn)
+      {:error, :invalid_query} -> render_invalid_query(conn)
     end
   end
 
@@ -20,6 +21,16 @@ defmodule CanaryWeb.ReportController do
       "validation_error",
       "Invalid window. Allowed: 1h, 6h, 24h, 7d, 30d",
       %{errors: %{window: ["must be one of: 1h, 6h, 24h, 7d, 30d"]}}
+    )
+  end
+
+  defp render_invalid_query(conn) do
+    CanaryWeb.Plugs.ProblemDetails.render_error(
+      conn,
+      422,
+      "validation_error",
+      "Invalid q parameter. Must be a string.",
+      %{errors: %{q: ["must be a string"]}}
     )
   end
 end

--- a/lib/canary_web/controllers/report_controller.ex
+++ b/lib/canary_web/controllers/report_controller.ex
@@ -5,8 +5,9 @@ defmodule CanaryWeb.ReportController do
 
   def index(conn, params) do
     window = Map.get(params, "window", "1h")
+    q = Map.get(params, "q")
 
-    case Report.generate(window: window) do
+    case Report.generate(window: window, q: q) do
       {:ok, report} -> json(conn, report)
       {:error, :invalid_window} -> render_invalid_window(conn)
     end

--- a/priv/repo/migrations/20260324121000_add_error_search_fts.exs
+++ b/priv/repo/migrations/20260324121000_add_error_search_fts.exs
@@ -1,0 +1,55 @@
+defmodule Canary.Repo.Migrations.AddErrorSearchFts do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE VIRTUAL TABLE errors_fts USING fts5(
+      service,
+      error_class,
+      message,
+      stack_trace,
+      content='errors',
+      content_rowid='rowid'
+    )
+    """
+
+    execute """
+    CREATE TRIGGER errors_fts_insert
+    AFTER INSERT ON errors
+    BEGIN
+      INSERT INTO errors_fts(rowid, service, error_class, message, stack_trace)
+      VALUES (new.rowid, new.service, new.error_class, new.message, new.stack_trace);
+    END
+    """
+
+    execute """
+    CREATE TRIGGER errors_fts_delete
+    AFTER DELETE ON errors
+    BEGIN
+      INSERT INTO errors_fts(errors_fts, rowid, service, error_class, message, stack_trace)
+      VALUES ('delete', old.rowid, old.service, old.error_class, old.message, old.stack_trace);
+    END
+    """
+
+    execute """
+    CREATE TRIGGER errors_fts_update
+    AFTER UPDATE ON errors
+    BEGIN
+      INSERT INTO errors_fts(errors_fts, rowid, service, error_class, message, stack_trace)
+      VALUES ('delete', old.rowid, old.service, old.error_class, old.message, old.stack_trace);
+
+      INSERT INTO errors_fts(rowid, service, error_class, message, stack_trace)
+      VALUES (new.rowid, new.service, new.error_class, new.message, new.stack_trace);
+    END
+    """
+
+    execute "INSERT INTO errors_fts(errors_fts) VALUES ('rebuild')"
+  end
+
+  def down do
+    execute "DROP TRIGGER IF EXISTS errors_fts_update"
+    execute "DROP TRIGGER IF EXISTS errors_fts_delete"
+    execute "DROP TRIGGER IF EXISTS errors_fts_insert"
+    execute "DROP TABLE IF EXISTS errors_fts"
+  end
+end

--- a/test/canary/query_search_test.exs
+++ b/test/canary/query_search_test.exs
@@ -1,0 +1,71 @@
+defmodule Canary.QuerySearchTest do
+  use Canary.DataCase
+
+  alias Canary.Errors.Ingest
+  alias Canary.Query
+
+  defp ingest_error!(attrs) do
+    defaults = %{
+      "service" => "canary",
+      "error_class" => "RuntimeError",
+      "message" => "request timeout while calling upstream",
+      "stack_trace" =>
+        "RuntimeError: boom\n    lib/canary/query.ex:1: Canary.Query.error_detail/1"
+    }
+
+    {:ok, result} = Ingest.ingest(Map.merge(defaults, attrs))
+    result
+  end
+
+  describe "search/2" do
+    test "returns matching errors ranked by relevance" do
+      ingest_error!(%{
+        "message" => "timeout timeout while calling upstream service",
+        "stack_trace" => "RuntimeError: timeout timeout"
+      })
+
+      ingest_error!(%{"message" => "timeout while calling upstream service"})
+      ingest_error!(%{"message" => "database connection dropped"})
+
+      assert {:ok, results} = Query.search("timeout")
+      assert length(results) == 2
+
+      assert [%{message: first_message}, %{message: second_message}] = results
+      assert String.contains?(first_message, "timeout timeout")
+      assert String.contains?(second_message, "timeout while")
+    end
+
+    test "filters matches by service" do
+      ingest_error!(%{
+        "service" => "canary-triage",
+        "message" => "connection refused when posting issue"
+      })
+
+      ingest_error!(%{
+        "service" => "canary-obs",
+        "message" => "connection refused while calling webhook"
+      })
+
+      assert {:ok, [result]} = Query.search("connection refused", service: "canary-triage")
+      assert result.service == "canary-triage"
+    end
+
+    test "indexes newly ingested errors immediately" do
+      {:ok, summary} =
+        Ingest.ingest(%{
+          "service" => "canary-triage",
+          "error_class" => "TimeoutError",
+          "message" => "searchable immediately after ingest"
+        })
+
+      assert {:ok, [result]} = Query.search("searchable")
+      assert result.id == summary.id
+    end
+
+    test "returns an empty list when nothing matches" do
+      ingest_error!(%{"message" => "database connection dropped"})
+
+      assert {:ok, []} = Query.search("nonexistent")
+    end
+  end
+end

--- a/test/canary/query_search_test.exs
+++ b/test/canary/query_search_test.exs
@@ -3,6 +3,7 @@ defmodule Canary.QuerySearchTest do
 
   alias Canary.Errors.Ingest
   alias Canary.Query
+  alias Canary.Schemas.Error
 
   defp ingest_error!(attrs) do
     defaults = %{
@@ -66,6 +67,37 @@ defmodule Canary.QuerySearchTest do
       ingest_error!(%{"message" => "database connection dropped"})
 
       assert {:ok, []} = Query.search("nonexistent")
+    end
+
+    test "returns an empty list for a blank query" do
+      ingest_error!(%{"message" => "timeout while calling upstream service"})
+
+      assert {:ok, []} = Query.search("   ")
+    end
+
+    test "updates search results when an error changes" do
+      %{id: error_id} = ingest_error!(%{"message" => "stale timeout message"})
+      error = Repo.get!(Error, error_id)
+
+      error
+      |> Ecto.Changeset.change(message: "fresh connection failure")
+      |> Repo.update!()
+
+      assert {:ok, []} = Query.search("timeout")
+
+      assert {:ok, [%{id: ^error_id, message: "fresh connection failure"}]} =
+               Query.search("connection")
+    end
+
+    test "removes search results when an error is deleted" do
+      %{id: error_id} = ingest_error!(%{"message" => "timeout before delete"})
+      error = Repo.get!(Error, error_id)
+
+      assert {:ok, [%{id: ^error_id}]} = Query.search("delete")
+
+      Repo.delete!(error)
+
+      assert {:ok, []} = Query.search("delete")
     end
   end
 end

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -52,6 +52,21 @@ defmodule CanaryWeb.ReportControllerTest do
       assert is_binary(body["summary"])
     end
 
+    test "includes search_results when q is provided", %{conn: conn} do
+      {:ok, _result} =
+        Canary.Errors.Ingest.ingest(%{
+          "service" => "volume",
+          "error_class" => "TimeoutError",
+          "message" => "timeout while reporting health"
+        })
+
+      conn = get(conn, "/api/v1/report?q=timeout")
+      body = json_response(conn, 200)
+
+      assert [%{"service" => "volume", "message" => "timeout while reporting health"}] =
+               body["search_results"]
+    end
+
     test "returns 401 without auth", %{conn: conn} do
       conn =
         conn

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -3,6 +3,7 @@ defmodule CanaryWeb.ReportControllerTest do
 
   import Canary.Fixtures
   alias Canary.Incidents
+  alias Canary.Schemas.{Error, ErrorGroup}
 
   setup %{conn: conn} do
     clean_status_tables()
@@ -65,6 +66,42 @@ defmodule CanaryWeb.ReportControllerTest do
 
       assert [%{"service" => "volume", "message" => "timeout while reporting health"}] =
                body["search_results"]
+    end
+
+    test "scopes search_results to the requested window", %{conn: conn} do
+      two_hours_ago =
+        DateTime.utc_now()
+        |> DateTime.add(-7_200, :second)
+        |> DateTime.to_iso8601()
+
+      {:ok, result} =
+        Canary.Errors.Ingest.ingest(%{
+          "service" => "volume",
+          "error_class" => "TimeoutError",
+          "message" => "timeout from two hours ago"
+        })
+
+      Canary.Repo.get!(Error, result.id)
+      |> Ecto.Changeset.change(created_at: two_hours_ago)
+      |> Canary.Repo.update!()
+
+      Canary.Repo.get!(ErrorGroup, result.group_hash)
+      |> Ecto.Changeset.change(first_seen_at: two_hours_ago, last_seen_at: two_hours_ago)
+      |> Canary.Repo.update!()
+
+      conn = get(conn, "/api/v1/report?window=1h&q=timeout")
+      body = json_response(conn, 200)
+
+      assert body["error_groups"] == []
+      assert body["search_results"] == []
+    end
+
+    test "returns 422 for an invalid q shape", %{conn: conn} do
+      conn = get(conn, "/api/v1/report", %{"q" => ["timeout"]})
+      body = json_response(conn, 422)
+
+      assert body["code"] == "validation_error"
+      assert body["errors"]["q"] == ["must be a string"]
     end
 
     test "returns 401 without auth", %{conn: conn} do


### PR DESCRIPTION
## Reviewer Evidence
- Start here: `mix test`
- Walkthrough notes: backend-only change; terminal proof and targeted endpoint behavior are below.
- Fast claim: `/api/v1/report?q=...` now returns ranked matching raw errors from a SQLite FTS5 index, scoped to the same report window, and malformed `q` input fails with a validation error instead of a 500.

<details>
<summary>Terminal proof</summary>

```text
$ mix test
197 tests, 0 failures

$ mix credo --strict
552 mods/funs, found no issues.
```

</details>

## Why This Matters
- Problem: agents could only filter errors by exact class or service, which made natural investigation of production incidents unnecessarily rigid.
- Value: Canary can now answer content-based error questions with ranked raw matches using its existing SQLite deployment model, while keeping those matches aligned to the requested report window.
- Why now: issue [#76](https://github.com/misty-step/canary/issues/76) is a small, launch-relevant API improvement that compounds the value of the unified report endpoint.
- Issue: closes [#76](https://github.com/misty-step/canary/issues/76)

## Trade-offs / Risks
- Value gained: free-text error search and report-level search results without a new endpoint or service.
- Cost / risk incurred: one new SQLite virtual table plus maintenance triggers, one small query-window helper, and one more optional branch in report generation.
- Why this is still the right trade: the storage/runtime cost is tiny relative to the investigation value, and the default report shape stays unchanged when `q` is absent.
- Reviewer watch-outs: search DB failures now degrade to an empty `search_results` list for resilience; if we later want richer error surfacing, that should be a deliberate API decision.

## What Changed
The report endpoint now has an optional search lane. Without `q`, the request still returns the same health/error summary it did before. With `q`, the report also includes ranked matching errors sourced from a SQLite FTS5 index that is backfilled on migration and kept current with triggers. The search lane now shares the report window, validates malformed `q` input, and degrades safely if the FTS query itself fails.

### Base Branch
```mermaid
graph TD
  A["GET /api/v1/report"] --> B["Report.generate(window)"]
  B --> C["Query.report_slice(window)"]
  B --> D["Query.health_targets()"]
  C --> E["error groups / incidents / transitions"]
  D --> F["targets"]
  E --> G["JSON report"]
  F --> G
```

### This PR
```mermaid
graph TD
  A["GET /api/v1/report?q=timeout"] --> B["Report.generate(window, q)"]
  B --> C["Query.report_slice(window)"]
  B --> D["Query.health_targets()"]
  B --> H["Query.search(q, window)"]
  H --> I["errors_fts MATCH query"]
  I --> J["join ranked hits back to errors"]
  H --> K["invalid q -> 422"]
  H --> L["search failure -> []"]
  C --> G["JSON report"]
  D --> G
  J --> G
```

### Architecture / State Change
```mermaid
sequenceDiagram
  participant Client
  participant Controller as ReportController
  participant Report
  participant Query as Canary.Query
  participant Search as Query.Search
  participant DB as SQLite errors + errors_fts

  Client->>Controller: GET /api/v1/report?window=1h&q=timeout
  Controller->>Report: generate(window: "1h", q: "timeout")
  Report->>Query: search("timeout", window: "1h")
  Query->>Query: window -> cutoff
  Query->>Search: search("timeout", cutoff: ...)
  Search->>DB: MATCH against errors_fts and join errors
  DB-->>Search: ranked error rows
  Search-->>Report: {:ok, search_results}
  Report-->>Controller: report map + search_results
  Controller-->>Client: JSON response
```

Why this is better:
- It preserves the existing report contract for callers that do not need search.
- It keeps search indexing in SQLite, which fits Canary's single-binary deployment model.
- It aligns `search_results` with the same requested time horizon as the rest of the report, which removes inconsistent payloads.
- It hides the SQL-heavy logic behind `Query.search/2` and small focused helper modules instead of bloating the main query module.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue [#76](https://github.com/misty-step/canary/issues/76) now includes a locked intent contract:
- Intent: make recent errors searchable by free text without adding a new service or endpoint.
- Success conditions: ranked `Canary.Query.search/2`, immediate searchability for new ingests, and `/api/v1/report?q=...` returning `search_results`.
- Hard boundaries: SQLite only, existing report endpoint preserved, no LLM logic on the request path.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `errors_fts` plus insert/update/delete triggers in a new Ecto migration, including an initial rebuild from existing `errors` rows.
- Added `Canary.Query.Search` for ranked FTS queries and `Canary.Query.Window` for shared report/query cutoff handling.
- Extended `Canary.Report.generate/1` and `CanaryWeb.ReportController` to thread `q`, scope search to the requested window, and return a 422 validation error for malformed `q` input.
- Made report search resilient to FTS query failures by logging and returning an empty `search_results` list instead of crashing the report request.
- Added search-specific coverage for blank queries, trigger update/delete behavior, window scoping, and invalid `q` shapes.
- Updated `README.md` with the new report search example.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: no schema or query complexity.
- Downside: agents remain limited to exact-class filters for raw error investigation.
- Why rejected: it leaves the issue's core operator workflow unsolved.

### Option B — Add a separate search endpoint
- Upside: isolates search behavior from the report path.
- Downside: expands the API surface and duplicates context an investigating agent already needs from the report endpoint.
- Why rejected: the issue explicitly preferred the existing report endpoint and Canary benefits from fewer interfaces.

### Option C — Current approach
- Upside: additive behavior, narrow public API, and zero external dependencies.
- Downside: introduces FTS trigger maintenance in the schema and a small amount of defensive branching around search failures.
- Why chosen: it delivers the capability with the smallest product and operational footprint while keeping the primary report endpoint resilient.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given errors exist with message containing `timeout`, when `Query.search("timeout")` is called, then matching errors are returned ranked by relevance.
- [x] Given errors exist across services, when `Query.search("connection refused", service: "canary-triage")` is called, then only matching errors from that service are returned.
- [x] Given the FTS5 index is populated, when the report endpoint is called with `q=timeout`, then the report includes a `search_results` section with matching errors.
- [x] Given a new error is ingested, when the FTS5 triggers fire, then the error is immediately searchable.
- [x] Given a search query matches zero errors, when `Query.search("nonexistent")` is called, then an empty list is returned.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
1. `mix test`
   Expected: `197 tests, 0 failures`
2. `mix credo --strict`
   Expected: `found no issues`
3. `mix test test/canary/query_search_test.exs test/canary_web/controllers/report_controller_test.exs`
   Expected: search contract, trigger coverage, invalid `q` handling, and report passthrough tests stay green.
4. Optional local endpoint check after booting the app: `curl -H "Authorization: Bearer $CANARY_API_KEY" "http://localhost:4000/api/v1/report?window=1h&q=timeout" | jq '.search_results'`
   Expected: array of matching error rows or `[]` when there are no matches.
5. Optional malformed-input check: `curl -H "Authorization: Bearer $CANARY_API_KEY" "http://localhost:4000/api/v1/report?q[]=timeout"`
   Expected: `422` validation response for `q`.

</details>

## Walkthrough
- Renderer: terminal capture in this PR body.
- Artifact: passing repo-wide and targeted test output from this branch.
- Claim: search now exists as a first-class report option backed by SQLite FTS5 and aligned to the report window.
- Before / After scope: before, report requests could not return content-based raw error matches and malformed `q` input could crash; after, search is window-aware, validated, and resilient.
- Persistent verification: `mix test` plus the focused search/report tests protect the demonstrated path.
- Residual gap: I did not capture a live HTTP screenshot because this is backend-only and the changed behavior is directly covered by controller tests.

## Before / After
Before: `/api/v1/report` returned health, grouped errors, incidents, and transitions only. There was no way to ask for content-based raw error evidence through the existing API, and malformed `q` shapes were not handled.

After: `/api/v1/report` still returns the same default payload, but adding `q` also returns ranked `search_results` from the error corpus, constrained to the same window as the rest of the report. Invalid `q` shapes now return a validation error instead of crashing the request. No screenshots are needed because the user-facing delta is JSON behavior rather than a visual surface.

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `test/canary/query_search_test.exs`
  Covers relevance ordering, service scoping, blank-query behavior, update/delete trigger synchronization, immediate post-ingest searchability, and zero-result behavior.
- `test/canary_web/controllers/report_controller_test.exs`
  Covers report `q` passthrough, window scoping, invalid `q` validation, and response shape.
- `mix test`
  Confirms the broader query/report/error-ingest surfaces still behave correctly.

Gap: there is no separate end-to-end curl harness in the repo today; controller coverage is the durable check for the endpoint behavior.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high.
- Strongest evidence: new targeted search tests plus a full green `mix test` run and clean `mix credo --strict`.
- Remaining uncertainty: report search now degrades safely on DB/FTS failures, so the remaining risk is mostly around production-only SQLite capabilities rather than request-path crashes.
- What could still go wrong after merge: a production SQLite build without FTS5 support would still need operational attention, though the repo assumptions, migrations, and local test behavior all indicate support is present.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-text search on reports via the q parameter; returns ranked, detailed matching errors and respects service and window filtering; report responses include search_results when applicable.
* **Database**
  * Added an FTS index and triggers to keep error records searchable and up-to-date.
* **Validation / Error Handling**
  * Invalid q requests now return a 422 validation response; search failures yield empty results in reports.
* **Tests**
  * Added tests for ranking, service/window filtering, ingest/update/delete visibility, and blank-query behavior.
* **Documentation**
  * README updated with q usage and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->