### PR TITLE
feat: token-efficient report responses

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,4 +41,8 @@ config :logger, :default_formatter,
 
 config :phoenix, :json_library, Jason
 
+config :mime, :types, %{
+  "text/csv" => ["csv"]
+}
+
 import_config "#{config_env()}.exs"

--- a/docs/walkthroughs/issue-77-report-pagination.md
+++ b/docs/walkthroughs/issue-77-report-pagination.md
@@ -1,0 +1,70 @@
+# Issue 77 Walkthrough: Token-Efficient Report Responses
+
+## Scenario
+
+Verify that `/api/v1/report` now supports:
+
+- bounded JSON pages with `limit`
+- opaque cursor pagination without duplicates
+- CSV serialization for `targets` and `error_groups`
+
+## Commands
+
+```bash
+mix test test/canary/report_test.exs test/canary_web/controllers/report_controller_test.exs
+mix test
+mix credo --strict
+mix dialyzer
+```
+
+Runtime spot check:
+
+```bash
+mix ecto.create && mix ecto.migrate
+mix run -e 'Application.ensure_all_started(:canary); {:ok, _key, raw_key} = Canary.Auth.generate_key("runtime-check"); IO.puts(raw_key)'
+mix phx.server
+```
+
+Then, with the emitted key:
+
+```bash
+curl -X POST http://127.0.0.1:4000/api/v1/targets \
+  -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"alpha","url":"https://example.com/","interval_ms":60000}'
+
+curl -X POST http://127.0.0.1:4000/api/v1/errors \
+  -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"service":"alpha","error_class":"ConnectionError","message":"database unavailable"}'
+
+curl -H "Authorization: Bearer $KEY" \
+  -H "Accept: text/csv" \
+  "http://127.0.0.1:4000/api/v1/report?limit=5"
+```
+
+## Expected Output
+
+JSON report responses include top-level pagination metadata:
+
+```json
+{
+  "truncated": true,
+  "cursor": "<opaque-token>"
+}
+```
+
+CSV responses include one header row and rows for both sections:
+
+```csv
+section,position,id,name,service,error_class,url,state,count,first_seen,last_seen,severity,status,consecutive_failures,last_checked_at,cursor,truncated
+targets,1,TGT-...,alpha,,,https://example.com/,unknown,,,,,,0,,,false
+error_groups,1,,,alpha,ConnectionError,,active,1,2026-03-25T...,2026-03-25T...,error,active,,,,false
+```
+
+## Persistent Verification
+
+- `test/canary/report_test.exs`
+- `test/canary_web/controllers/report_controller_test.exs`
+
+These tests cover default truncation, cursor paging, duplicate prevention, and CSV negotiation.

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -5,23 +5,114 @@ defmodule Canary.Report do
 
   alias Canary.{Query, Status}
 
-  @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_window}
+  @default_error_group_limit 25
+
+  @type generate_error :: :invalid_cursor | :invalid_limit | :invalid_window
+
+  @spec generate(keyword()) :: {:ok, map()} | {:error, generate_error()}
   def generate(opts \\ []) do
     window = Keyword.get(opts, :window) || "1h"
 
-    with {:ok, slice} <- Query.report_slice(window) do
+    with {:ok, pagination} <- pagination_opts(opts),
+         {:ok, slice} <- Query.report_slice(window) do
       targets = Query.health_targets()
       status = Status.from_snapshot(targets, slice.error_summary, window)
+      {targets, next_targets_offset} = paginate_targets(targets, pagination)
+
+      {error_groups, next_error_groups_offset} =
+        paginate_error_groups(slice.error_groups, pagination)
+
+      truncated = not is_nil(next_targets_offset) or not is_nil(next_error_groups_offset)
 
       {:ok,
        %{
          status: status.overall,
          summary: status.summary,
          targets: targets,
-         error_groups: slice.error_groups,
+         error_groups: error_groups,
          incidents: slice.incidents,
-         recent_transitions: slice.recent_transitions
+         recent_transitions: slice.recent_transitions,
+         truncated: truncated,
+         cursor: encode_cursor(next_targets_offset, next_error_groups_offset)
        }}
     end
+  end
+
+  defp pagination_opts(opts) do
+    with {:ok, limit} <- parse_limit(Keyword.get(opts, :limit)),
+         {:ok, cursor} <- decode_cursor(Keyword.get(opts, :cursor)) do
+      {:ok,
+       %{
+         limit: limit,
+         target_offset: cursor.targets_offset,
+         error_group_offset: cursor.error_groups_offset
+       }}
+    end
+  end
+
+  defp parse_limit(nil), do: {:ok, nil}
+  defp parse_limit(limit) when is_integer(limit) and limit > 0, do: {:ok, limit}
+
+  defp parse_limit(limit) when is_binary(limit) do
+    case Integer.parse(limit) do
+      {value, ""} when value > 0 -> {:ok, value}
+      _ -> {:error, :invalid_limit}
+    end
+  end
+
+  defp parse_limit(_), do: {:error, :invalid_limit}
+
+  defp decode_cursor(nil), do: {:ok, %{targets_offset: 0, error_groups_offset: 0}}
+  defp decode_cursor(""), do: {:ok, %{targets_offset: 0, error_groups_offset: 0}}
+
+  defp decode_cursor(cursor) when is_binary(cursor) do
+    with {:ok, decoded} <- Base.url_decode64(cursor, padding: false),
+         {:ok, offsets} <- Jason.decode(decoded),
+         {:ok, targets_offset} <- parse_cursor_offset(Map.get(offsets, "targets_offset")),
+         {:ok, error_groups_offset} <-
+           parse_cursor_offset(Map.get(offsets, "error_groups_offset")) do
+      {:ok, %{targets_offset: targets_offset, error_groups_offset: error_groups_offset}}
+    else
+      _ -> {:error, :invalid_cursor}
+    end
+  end
+
+  defp decode_cursor(_), do: {:error, :invalid_cursor}
+
+  defp parse_cursor_offset(value) when is_integer(value) and value >= 0, do: {:ok, value}
+  defp parse_cursor_offset(nil), do: {:ok, nil}
+  defp parse_cursor_offset(_), do: {:error, :invalid_cursor}
+
+  defp paginate_targets(_targets, %{target_offset: nil}), do: {[], nil}
+
+  defp paginate_targets(targets, %{limit: nil, target_offset: offset}),
+    do: {Enum.drop(targets, offset), nil}
+
+  defp paginate_targets(targets, %{limit: limit, target_offset: offset}),
+    do: paginate(targets, limit, offset)
+
+  defp paginate_error_groups(_error_groups, %{error_group_offset: nil}), do: {[], nil}
+
+  defp paginate_error_groups(error_groups, %{limit: nil, error_group_offset: offset}),
+    do: paginate(error_groups, @default_error_group_limit, offset)
+
+  defp paginate_error_groups(error_groups, %{limit: limit, error_group_offset: offset}),
+    do: paginate(error_groups, limit, offset)
+
+  defp paginate(items, limit, offset) do
+    page = items |> Enum.drop(offset) |> Enum.take(limit)
+    next_offset = if length(items) > offset + length(page), do: offset + length(page)
+    {page, next_offset}
+  end
+
+  defp encode_cursor(nil, nil), do: nil
+
+  defp encode_cursor(targets_offset, error_groups_offset) do
+    %{
+      targets_offset: targets_offset,
+      error_groups_offset: error_groups_offset
+    }
+    |> Jason.encode!()
+    |> Base.url_encode64(padding: false)
   end
 end

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -5,30 +5,89 @@ defmodule Canary.Report do
 
   alias Canary.{Query, Status}
 
-  @spec generate(keyword()) :: {:ok, map()} | {:error, :invalid_query | :invalid_window}
+  @default_error_group_limit 25
+
+  @type generate_error :: :invalid_cursor | :invalid_limit | :invalid_query | :invalid_window
+
+  @spec generate(keyword()) :: {:ok, map()} | {:error, generate_error()}
+  @doc """
+  Builds the report payload with optional free-text search, pagination, and CSV-ready metadata.
+  """
   def generate(opts \\ []) do
     window = Keyword.get(opts, :window) || "1h"
     search_query = Keyword.get(opts, :q)
 
-    with {:ok, slice} <- Query.report_slice(window),
+    with {:ok, pagination} <- pagination_opts(opts),
+         {:ok, slice} <- Query.report_slice(window),
          {:ok, search_results} <- search_results(search_query, window) do
       targets = Query.health_targets()
       status = Status.from_snapshot(targets, slice.error_summary, window)
+      {targets, next_targets_offset} = paginate_targets(targets, pagination)
+
+      {error_groups, next_error_groups_offset} =
+        paginate_error_groups(slice.error_groups, pagination)
+
+      truncated = not is_nil(next_targets_offset) or not is_nil(next_error_groups_offset)
 
       {:ok,
-       maybe_put_search_results(
-         %{
-           status: status.overall,
-           summary: status.summary,
-           targets: targets,
-           error_groups: slice.error_groups,
-           incidents: slice.incidents,
-           recent_transitions: slice.recent_transitions
-         },
-         search_results
-       )}
+       %{
+         status: status.overall,
+         summary: status.summary,
+         targets: targets,
+         error_groups: error_groups,
+         incidents: slice.incidents,
+         recent_transitions: slice.recent_transitions,
+         truncated: truncated,
+         cursor: encode_cursor(next_targets_offset, next_error_groups_offset)
+       }
+       |> maybe_put_search_results(search_results)}
     end
   end
+
+  defp pagination_opts(opts) do
+    with {:ok, limit} <- parse_limit(Keyword.get(opts, :limit)),
+         {:ok, cursor} <- decode_cursor(Keyword.get(opts, :cursor)) do
+      {:ok,
+       %{
+         limit: limit,
+         target_offset: cursor.targets_offset,
+         error_group_offset: cursor.error_groups_offset
+       }}
+    end
+  end
+
+  defp parse_limit(nil), do: {:ok, nil}
+  defp parse_limit(limit) when is_integer(limit) and limit > 0, do: {:ok, limit}
+
+  defp parse_limit(limit) when is_binary(limit) do
+    case Integer.parse(limit) do
+      {value, ""} when value > 0 -> {:ok, value}
+      _ -> {:error, :invalid_limit}
+    end
+  end
+
+  defp parse_limit(_), do: {:error, :invalid_limit}
+
+  defp decode_cursor(nil), do: {:ok, %{targets_offset: 0, error_groups_offset: 0}}
+  defp decode_cursor(""), do: {:ok, %{targets_offset: 0, error_groups_offset: 0}}
+
+  defp decode_cursor(cursor) when is_binary(cursor) do
+    with {:ok, decoded} <- Base.url_decode64(cursor, padding: false),
+         {:ok, offsets} <- Jason.decode(decoded),
+         {:ok, targets_offset} <- parse_cursor_offset(Map.get(offsets, "targets_offset")),
+         {:ok, error_groups_offset} <-
+           parse_cursor_offset(Map.get(offsets, "error_groups_offset")) do
+      {:ok, %{targets_offset: targets_offset, error_groups_offset: error_groups_offset}}
+    else
+      _ -> {:error, :invalid_cursor}
+    end
+  end
+
+  defp decode_cursor(_), do: {:error, :invalid_cursor}
+
+  defp parse_cursor_offset(value) when is_integer(value) and value >= 0, do: {:ok, value}
+  defp parse_cursor_offset(nil), do: {:ok, nil}
+  defp parse_cursor_offset(_), do: {:error, :invalid_cursor}
 
   defp search_results(nil, _window), do: {:ok, nil}
 
@@ -42,4 +101,38 @@ defmodule Canary.Report do
 
   defp maybe_put_search_results(report, nil), do: report
   defp maybe_put_search_results(report, results), do: Map.put(report, :search_results, results)
+
+  defp paginate_targets(_targets, %{target_offset: nil}), do: {[], nil}
+
+  defp paginate_targets(targets, %{limit: nil, target_offset: offset}),
+    do: {Enum.drop(targets, offset), nil}
+
+  defp paginate_targets(targets, %{limit: limit, target_offset: offset}),
+    do: paginate(targets, limit, offset)
+
+  defp paginate_error_groups(_error_groups, %{error_group_offset: nil}), do: {[], nil}
+
+  defp paginate_error_groups(error_groups, %{limit: nil, error_group_offset: offset}),
+    do: paginate(error_groups, @default_error_group_limit, offset)
+
+  defp paginate_error_groups(error_groups, %{limit: limit, error_group_offset: offset}),
+    do: paginate(error_groups, limit, offset)
+
+  defp paginate(items, limit, offset) do
+    remaining = Enum.drop(items, offset)
+    {page, rest} = Enum.split(remaining, limit)
+    next_offset = if rest != [], do: offset + Enum.count(page)
+    {page, next_offset}
+  end
+
+  defp encode_cursor(nil, nil), do: nil
+
+  defp encode_cursor(targets_offset, error_groups_offset) do
+    %{
+      targets_offset: targets_offset,
+      error_groups_offset: error_groups_offset
+    }
+    |> Jason.encode!()
+    |> Base.url_encode64(padding: false)
+  end
 end

--- a/lib/canary/report.ex
+++ b/lib/canary/report.ex
@@ -73,7 +73,7 @@ defmodule Canary.Report do
 
   defp decode_cursor(cursor) when is_binary(cursor) do
     with {:ok, decoded} <- Base.url_decode64(cursor, padding: false),
-         {:ok, offsets} <- Jason.decode(decoded),
+         {:ok, offsets} <- decode_cursor_payload(decoded),
          {:ok, targets_offset} <- parse_cursor_offset(Map.get(offsets, "targets_offset")),
          {:ok, error_groups_offset} <-
            parse_cursor_offset(Map.get(offsets, "error_groups_offset")) do
@@ -84,6 +84,13 @@ defmodule Canary.Report do
   end
 
   defp decode_cursor(_), do: {:error, :invalid_cursor}
+
+  defp decode_cursor_payload(decoded) do
+    case Jason.decode(decoded) do
+      {:ok, offsets} when is_map(offsets) -> {:ok, offsets}
+      _ -> {:error, :invalid_cursor}
+    end
+  end
 
   defp parse_cursor_offset(value) when is_integer(value) and value >= 0, do: {:ok, value}
   defp parse_cursor_offset(nil), do: {:ok, nil}

--- a/lib/canary_web/controllers/report_controller.ex
+++ b/lib/canary_web/controllers/report_controller.ex
@@ -2,15 +2,32 @@ defmodule CanaryWeb.ReportController do
   use CanaryWeb, :controller
 
   alias Canary.Report
+  alias CanaryWeb.CsvView
 
   def index(conn, params) do
-    window = Map.get(params, "window", "1h")
-    q = Map.get(params, "q")
+    opts = [
+      window: Map.get(params, "window", "1h"),
+      q: Map.get(params, "q"),
+      limit: Map.get(params, "limit"),
+      cursor: Map.get(params, "cursor")
+    ]
 
-    case Report.generate(window: window, q: q) do
-      {:ok, report} -> json(conn, report)
+    case Report.generate(opts) do
+      {:ok, report} -> render_report(conn, report)
+      {:error, :invalid_cursor} -> render_invalid_cursor(conn)
+      {:error, :invalid_limit} -> render_invalid_limit(conn)
       {:error, :invalid_window} -> render_invalid_window(conn)
       {:error, :invalid_query} -> render_invalid_query(conn)
+    end
+  end
+
+  defp render_report(conn, report) do
+    if get_format(conn) == "csv" do
+      conn
+      |> put_resp_content_type("text/csv")
+      |> send_resp(200, CsvView.report(report))
+    else
+      json(conn, report)
     end
   end
 
@@ -21,6 +38,26 @@ defmodule CanaryWeb.ReportController do
       "validation_error",
       "Invalid window. Allowed: 1h, 6h, 24h, 7d, 30d",
       %{errors: %{window: ["must be one of: 1h, 6h, 24h, 7d, 30d"]}}
+    )
+  end
+
+  defp render_invalid_limit(conn) do
+    CanaryWeb.Plugs.ProblemDetails.render_error(
+      conn,
+      422,
+      "validation_error",
+      "Invalid limit. Expected a positive integer.",
+      %{errors: %{limit: ["must be a positive integer"]}}
+    )
+  end
+
+  defp render_invalid_cursor(conn) do
+    CanaryWeb.Plugs.ProblemDetails.render_error(
+      conn,
+      422,
+      "validation_error",
+      "Invalid cursor.",
+      %{errors: %{cursor: ["must be a valid pagination cursor"]}}
     )
   end
 

--- a/lib/canary_web/controllers/report_controller.ex
+++ b/lib/canary_web/controllers/report_controller.ex
@@ -2,13 +2,30 @@ defmodule CanaryWeb.ReportController do
   use CanaryWeb, :controller
 
   alias Canary.Report
+  alias CanaryWeb.CsvView
 
   def index(conn, params) do
-    window = Map.get(params, "window", "1h")
+    opts = [
+      window: Map.get(params, "window", "1h"),
+      limit: Map.get(params, "limit"),
+      cursor: Map.get(params, "cursor")
+    ]
 
-    case Report.generate(window: window) do
-      {:ok, report} -> json(conn, report)
+    case Report.generate(opts) do
+      {:ok, report} -> render_report(conn, report)
+      {:error, :invalid_cursor} -> render_invalid_cursor(conn)
+      {:error, :invalid_limit} -> render_invalid_limit(conn)
       {:error, :invalid_window} -> render_invalid_window(conn)
+    end
+  end
+
+  defp render_report(conn, report) do
+    if get_format(conn) == "csv" do
+      conn
+      |> put_resp_content_type("text/csv")
+      |> send_resp(200, CsvView.report(report))
+    else
+      json(conn, report)
     end
   end
 
@@ -19,6 +36,26 @@ defmodule CanaryWeb.ReportController do
       "validation_error",
       "Invalid window. Allowed: 1h, 6h, 24h, 7d, 30d",
       %{errors: %{window: ["must be one of: 1h, 6h, 24h, 7d, 30d"]}}
+    )
+  end
+
+  defp render_invalid_limit(conn) do
+    CanaryWeb.Plugs.ProblemDetails.render_error(
+      conn,
+      422,
+      "validation_error",
+      "Invalid limit. Expected a positive integer.",
+      %{errors: %{limit: ["must be a positive integer"]}}
+    )
+  end
+
+  defp render_invalid_cursor(conn) do
+    CanaryWeb.Plugs.ProblemDetails.render_error(
+      conn,
+      422,
+      "validation_error",
+      "Invalid cursor.",
+      %{errors: %{cursor: ["must be a valid pagination cursor"]}}
     )
   end
 end

--- a/lib/canary_web/router.ex
+++ b/lib/canary_web/router.ex
@@ -2,7 +2,7 @@ defmodule CanaryWeb.Router do
   use CanaryWeb, :router
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug :accepts, ["json", "csv"]
 
     plug Plug.Parsers,
       parsers: [:json],

--- a/lib/canary_web/views/csv_view.ex
+++ b/lib/canary_web/views/csv_view.ex
@@ -1,0 +1,103 @@
+defmodule CanaryWeb.CsvView do
+  @moduledoc false
+
+  @headers [
+    "section",
+    "position",
+    "id",
+    "name",
+    "service",
+    "error_class",
+    "url",
+    "state",
+    "count",
+    "first_seen",
+    "last_seen",
+    "severity",
+    "status",
+    "consecutive_failures",
+    "last_checked_at",
+    "cursor",
+    "truncated"
+  ]
+
+  def report(data) do
+    rows =
+      [@headers]
+      |> Kernel.++(target_rows(data))
+      |> Kernel.++(error_group_rows(data))
+
+    Enum.map_join(rows, "\n", &encode_row/1)
+  end
+
+  defp target_rows(data) do
+    Enum.with_index(data.targets, 1)
+    |> Enum.map(fn {target, position} ->
+      [
+        "targets",
+        position,
+        target.id,
+        target.name,
+        nil,
+        nil,
+        target.url,
+        target.state,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        target.consecutive_failures,
+        target.last_checked_at,
+        data.cursor,
+        data.truncated
+      ]
+    end)
+  end
+
+  defp error_group_rows(data) do
+    Enum.with_index(data.error_groups, 1)
+    |> Enum.map(fn {group, position} ->
+      [
+        "error_groups",
+        position,
+        nil,
+        nil,
+        group.service,
+        group.error_class,
+        nil,
+        group.status,
+        group.count,
+        group.first_seen,
+        group.last_seen,
+        group.severity,
+        group.status,
+        nil,
+        nil,
+        data.cursor,
+        data.truncated
+      ]
+    end)
+  end
+
+  defp encode_row(values) do
+    values
+    |> Enum.map(&encode_value/1)
+    |> Enum.join(",")
+  end
+
+  defp encode_value(nil), do: ""
+  defp encode_value(true), do: "true"
+  defp encode_value(false), do: "false"
+  defp encode_value(value) when is_integer(value), do: Integer.to_string(value)
+
+  defp encode_value(value) do
+    string = to_string(value)
+
+    if String.contains?(string, [",", "\"", "\n", "\r"]) do
+      "\"" <> String.replace(string, "\"", "\"\"") <> "\""
+    else
+      string
+    end
+  end
+end

--- a/lib/canary_web/views/csv_view.ex
+++ b/lib/canary_web/views/csv_view.ex
@@ -1,0 +1,106 @@
+defmodule CanaryWeb.CsvView do
+  @moduledoc false
+
+  @headers [
+    "section",
+    "position",
+    "id",
+    "name",
+    "service",
+    "error_class",
+    "url",
+    "state",
+    "count",
+    "first_seen",
+    "last_seen",
+    "severity",
+    "status",
+    "consecutive_failures",
+    "last_checked_at",
+    "cursor",
+    "truncated"
+  ]
+
+  @doc """
+  Serializes the report's tabular sections as a single CSV table.
+  """
+  def report(data) do
+    rows =
+      [@headers]
+      |> Kernel.++(target_rows(data))
+      |> Kernel.++(error_group_rows(data))
+
+    Enum.map_join(rows, "\n", &encode_row/1) <> "\n"
+  end
+
+  defp target_rows(data) do
+    Enum.with_index(data.targets, 1)
+    |> Enum.map(fn {target, position} ->
+      [
+        "targets",
+        position,
+        target.id,
+        target.name,
+        nil,
+        nil,
+        target.url,
+        target.state,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        target.consecutive_failures,
+        target.last_checked_at,
+        data.cursor,
+        data.truncated
+      ]
+    end)
+  end
+
+  defp error_group_rows(data) do
+    Enum.with_index(data.error_groups, 1)
+    |> Enum.map(fn {group, position} ->
+      [
+        "error_groups",
+        position,
+        nil,
+        nil,
+        group.service,
+        group.error_class,
+        nil,
+        nil,
+        group.count,
+        group.first_seen,
+        group.last_seen,
+        group.severity,
+        group.status,
+        nil,
+        nil,
+        data.cursor,
+        data.truncated
+      ]
+    end)
+  end
+
+  defp encode_row(values) do
+    values
+    |> Enum.map(&encode_value/1)
+    |> Enum.join(",")
+  end
+
+  defp encode_value(nil), do: ""
+  defp encode_value(true), do: "true"
+  defp encode_value(false), do: "false"
+  defp encode_value(value) when is_integer(value), do: Integer.to_string(value)
+
+  defp encode_value(value) do
+    string = to_string(value)
+
+    if String.contains?(string, [",", "\"", "\n", "\r"]) do
+      "\"" <> String.replace(string, "\"", "\"\"") <> "\""
+    else
+      string
+    end
+  end
+end

--- a/test/canary/report_test.exs
+++ b/test/canary/report_test.exs
@@ -102,6 +102,8 @@ defmodule Canary.ReportTest do
       assert result.error_groups == []
       assert result.recent_transitions == []
       assert result.summary == "No services configured."
+      assert result.truncated == false
+      assert result.cursor == nil
     end
 
     test "reports unknown state for targets without a state record" do
@@ -116,6 +118,74 @@ defmodule Canary.ReportTest do
 
       assert {:ok, result} = Report.generate(window: "1h")
       assert [%{name: "orphan", state: "unknown"}] = result.targets
+    end
+
+    test "applies a default limit to error groups but not targets" do
+      for name <- ~w(alpha bravo), do: create_target_with_state(name, "up")
+
+      for index <- 1..30 do
+        create_error_group("svc-#{index}", "Error#{index}", 100 - index)
+      end
+
+      assert {:ok, result} = Report.generate(window: "1h")
+
+      assert length(result.targets) == 2
+      assert length(result.error_groups) == 25
+      assert result.truncated == true
+      assert is_binary(result.cursor)
+    end
+
+    test "paginates targets and error groups without duplicates" do
+      for name <- ~w(alpha bravo charlie delta echo foxtrot golf) do
+        create_target_with_state(name, "up")
+      end
+
+      for {service, count} <- Enum.zip(~w(svc-a svc-b svc-c svc-d svc-e svc-f svc-g), 70..64//-1) do
+        create_error_group(service, "ConnectionError", count)
+      end
+
+      assert {:ok, first_page} = Report.generate(window: "1h", limit: 5)
+
+      assert Enum.map(first_page.targets, & &1.name) == ~w(alpha bravo charlie delta echo)
+      assert Enum.map(first_page.error_groups, & &1.service) == ~w(svc-a svc-b svc-c svc-d svc-e)
+      assert first_page.truncated == true
+      assert is_binary(first_page.cursor)
+
+      assert {:ok, second_page} =
+               Report.generate(window: "1h", limit: 5, cursor: first_page.cursor)
+
+      assert Enum.map(second_page.targets, & &1.name) == ~w(foxtrot golf)
+      assert Enum.map(second_page.error_groups, & &1.service) == ~w(svc-f svc-g)
+      assert second_page.truncated == false
+      assert second_page.cursor == nil
+
+      assert MapSet.disjoint?(
+               MapSet.new(Enum.map(first_page.targets, & &1.id)),
+               MapSet.new(Enum.map(second_page.targets, & &1.id))
+             )
+
+      assert MapSet.disjoint?(
+               MapSet.new(Enum.map(first_page.error_groups, & &1.group_hash)),
+               MapSet.new(Enum.map(second_page.error_groups, & &1.group_hash))
+             )
+    end
+
+    test "does not replay targets after they are exhausted on an earlier page" do
+      create_target_with_state("alpha", "up")
+
+      for index <- 1..8 do
+        create_error_group("svc-#{index}", "Error#{index}", 100 - index)
+      end
+
+      assert {:ok, first_page} = Report.generate(window: "1h", limit: 5)
+      assert Enum.map(first_page.targets, & &1.name) == ["alpha"]
+      assert is_binary(first_page.cursor)
+
+      assert {:ok, second_page} =
+               Report.generate(window: "1h", limit: 5, cursor: first_page.cursor)
+
+      assert second_page.targets == []
+      assert length(second_page.error_groups) == 3
     end
   end
 

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -146,6 +146,14 @@ defmodule CanaryWeb.ReportControllerTest do
       assert body["errors"]["window"] == ["must be one of: 1h, 6h, 24h, 7d, 30d"]
     end
 
+    test "returns 422 for a cursor payload that is valid json but not an object", %{conn: conn} do
+      conn = get(conn, "/api/v1/report?cursor=W10")
+      body = json_response(conn, 422)
+
+      assert body["code"] == "validation_error"
+      assert body["errors"]["cursor"] == ["must be a valid pagination cursor"]
+    end
+
     test "applies limit and cursor pagination to targets and error groups", %{conn: conn} do
       for name <- ~w(alpha bravo charlie delta echo foxtrot golf) do
         create_target_with_state(name, "up")

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -24,12 +24,14 @@ defmodule CanaryWeb.ReportControllerTest do
       body = json_response(conn, 200)
 
       assert Enum.sort(Map.keys(body)) == [
+               "cursor",
                "error_groups",
                "incidents",
                "recent_transitions",
                "status",
                "summary",
-               "targets"
+               "targets",
+               "truncated"
              ]
 
       assert body["status"] == "degraded"
@@ -37,6 +39,8 @@ defmodule CanaryWeb.ReportControllerTest do
       assert [%{"service" => "volume", "signal_count" => 2}] = body["incidents"]
       assert is_list(body["targets"])
       assert is_list(body["recent_transitions"])
+      assert body["truncated"] == false
+      assert is_nil(body["cursor"])
     end
 
     test "includes classification for each error group", %{conn: conn} do
@@ -69,6 +73,8 @@ defmodule CanaryWeb.ReportControllerTest do
       assert body["incidents"] == []
       assert length(body["targets"]) == 2
       assert is_binary(body["summary"])
+      assert body["truncated"] == false
+      assert is_nil(body["cursor"])
     end
 
     test "returns 401 without auth", %{conn: conn} do
@@ -86,6 +92,49 @@ defmodule CanaryWeb.ReportControllerTest do
 
       assert body["code"] == "validation_error"
       assert body["errors"]["window"] == ["must be one of: 1h, 6h, 24h, 7d, 30d"]
+    end
+
+    test "applies limit and cursor pagination to targets and error groups", %{conn: conn} do
+      for name <- ~w(alpha bravo charlie delta echo foxtrot golf) do
+        create_target_with_state(name, "up")
+      end
+
+      for {service, count} <- Enum.zip(~w(svc-a svc-b svc-c svc-d svc-e svc-f svc-g), 70..64//-1) do
+        create_error_group(service, "ConnectionError", count)
+      end
+
+      first_conn = get(conn, "/api/v1/report?limit=5")
+      first_body = json_response(first_conn, 200)
+
+      assert first_body["truncated"] == true
+      assert is_binary(first_body["cursor"])
+      assert Enum.map(first_body["targets"], & &1["name"]) == ~w(alpha bravo charlie delta echo)
+
+      assert Enum.map(first_body["error_groups"], & &1["service"]) ==
+               ~w(svc-a svc-b svc-c svc-d svc-e)
+
+      second_conn = get(conn, "/api/v1/report?limit=5&cursor=#{first_body["cursor"]}")
+      second_body = json_response(second_conn, 200)
+
+      assert second_body["truncated"] == false
+      assert is_nil(second_body["cursor"])
+      assert Enum.map(second_body["targets"], & &1["name"]) == ~w(foxtrot golf)
+      assert Enum.map(second_body["error_groups"], & &1["service"]) == ~w(svc-f svc-g)
+    end
+
+    test "returns csv when requested", %{conn: conn} do
+      create_target_with_state("alpha", "degraded")
+      create_error_group("volume", "ConnectionError", 12)
+
+      conn =
+        conn
+        |> put_req_header("accept", "text/csv")
+        |> get("/api/v1/report?limit=5")
+
+      assert get_resp_header(conn, "content-type") == ["text/csv; charset=utf-8"]
+      assert response(conn, 200) =~ "section,position,id,name,service,error_class,url,state,count"
+      assert response(conn, 200) =~ "targets,1,TGT-alpha,alpha"
+      assert response(conn, 200) =~ "error_groups,1,"
     end
   end
 

--- a/test/canary_web/controllers/report_controller_test.exs
+++ b/test/canary_web/controllers/report_controller_test.exs
@@ -25,12 +25,14 @@ defmodule CanaryWeb.ReportControllerTest do
       body = json_response(conn, 200)
 
       assert Enum.sort(Map.keys(body)) == [
+               "cursor",
                "error_groups",
                "incidents",
                "recent_transitions",
                "status",
                "summary",
-               "targets"
+               "targets",
+               "truncated"
              ]
 
       assert body["status"] == "degraded"
@@ -38,6 +40,8 @@ defmodule CanaryWeb.ReportControllerTest do
       assert [%{"service" => "volume", "signal_count" => 2}] = body["incidents"]
       assert is_list(body["targets"])
       assert is_list(body["recent_transitions"])
+      assert body["truncated"] == false
+      assert is_nil(body["cursor"])
     end
 
     test "includes classification for each error group", %{conn: conn} do
@@ -70,6 +74,8 @@ defmodule CanaryWeb.ReportControllerTest do
       assert body["incidents"] == []
       assert length(body["targets"]) == 2
       assert is_binary(body["summary"])
+      assert body["truncated"] == false
+      assert is_nil(body["cursor"])
     end
 
     test "includes search_results when q is provided", %{conn: conn} do
@@ -138,6 +144,49 @@ defmodule CanaryWeb.ReportControllerTest do
 
       assert body["code"] == "validation_error"
       assert body["errors"]["window"] == ["must be one of: 1h, 6h, 24h, 7d, 30d"]
+    end
+
+    test "applies limit and cursor pagination to targets and error groups", %{conn: conn} do
+      for name <- ~w(alpha bravo charlie delta echo foxtrot golf) do
+        create_target_with_state(name, "up")
+      end
+
+      for {service, count} <- Enum.zip(~w(svc-a svc-b svc-c svc-d svc-e svc-f svc-g), 70..64//-1) do
+        create_error_group(service, "ConnectionError", count)
+      end
+
+      first_conn = get(conn, "/api/v1/report?limit=5")
+      first_body = json_response(first_conn, 200)
+
+      assert first_body["truncated"] == true
+      assert is_binary(first_body["cursor"])
+      assert Enum.map(first_body["targets"], & &1["name"]) == ~w(alpha bravo charlie delta echo)
+
+      assert Enum.map(first_body["error_groups"], & &1["service"]) ==
+               ~w(svc-a svc-b svc-c svc-d svc-e)
+
+      second_conn = get(conn, "/api/v1/report?limit=5&cursor=#{first_body["cursor"]}")
+      second_body = json_response(second_conn, 200)
+
+      assert second_body["truncated"] == false
+      assert is_nil(second_body["cursor"])
+      assert Enum.map(second_body["targets"], & &1["name"]) == ~w(foxtrot golf)
+      assert Enum.map(second_body["error_groups"], & &1["service"]) == ~w(svc-f svc-g)
+    end
+
+    test "returns csv when requested", %{conn: conn} do
+      create_target_with_state("alpha", "degraded")
+      create_error_group("volume", "ConnectionError", 12)
+
+      conn =
+        conn
+        |> put_req_header("accept", "text/csv")
+        |> get("/api/v1/report?limit=5")
+
+      assert get_resp_header(conn, "content-type") == ["text/csv; charset=utf-8"]
+      assert response(conn, 200) =~ "section,position,id,name,service,error_class,url,state,count"
+      assert response(conn, 200) =~ "targets,1,TGT-alpha,alpha"
+      assert response(conn, 200) =~ "error_groups,1,"
     end
   end
 


### PR DESCRIPTION
## Why This Matters

Canary is supposed to be agent-first, but the report endpoint still returned unbounded JSON on the success path. This change gives agents a way to ask for smaller pages and cheaper CSV tables, which keeps the primary "what's wrong?" endpoint usable under real token budgets. Fixes #77.

## Trade-offs / Risks

- CSV support is intentionally limited to the report's tabular sections (`targets` and `error_groups`) instead of inventing a second complete report schema.
- Pagination is offset-based behind an opaque cursor, which is simple and reversible, but it is not designed for perfect stability under concurrent writes.
- Accepting `csv` at the API router level means other endpoints may receive `Accept: text/csv` and still answer with JSON; this lane only adds CSV behavior to `/api/v1/report`.

## Intent Reference

Intent summary derived from [#77](https://github.com/misty-step/canary/issues/77): let agents bound report responses with `limit`, continue with an opaque `cursor` without duplicates, and request cheaper tabular output via `Accept: text/csv`, while keeping JSON as the default and defaulting to 25 error groups plus all targets.

## Changes

- Added top-level report pagination metadata: `truncated` and opaque `cursor`.
- Added explicit `limit` / `cursor` handling in [`lib/canary/report.ex`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/lib/canary/report.ex) with regression coverage for exhausted collections.
- Added CSV content negotiation in [`lib/canary_web/controllers/report_controller.ex`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/lib/canary_web/controllers/report_controller.ex) and router MIME support in [`config/config.exs`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/config/config.exs) and [`lib/canary_web/router.ex`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/lib/canary_web/router.ex).
- Added [`lib/canary_web/views/csv_view.ex`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/lib/canary_web/views/csv_view.ex) to serialize `targets` and `error_groups` as one valid CSV table that still carries pagination metadata.
- Added walkthrough artifact at [`docs/walkthroughs/issue-77-report-pagination.md`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/docs/walkthroughs/issue-77-report-pagination.md).

## Alternatives Considered

- Do nothing: keeps the current unbounded JSON payloads and misses the issue's token-budget goal.
- Keyset pagination by group hash / target name: more stable under writes, but it complicates a mixed report payload and was not necessary for this small API surface.
- Multiple CSV sections or multipart output: rejected because one flat CSV table is easier to consume and remains valid CSV.

## Acceptance Criteria

- [x] Given `limit=5` is passed to the report endpoint, when errors and targets exceed 5, then only the top 5 of each are returned with a `truncated: true` flag and a `cursor` for pagination
- [x] Given `Accept: text/csv` header is sent, when the report endpoint responds, then tabular data (targets, error groups) is returned as CSV with headers
- [x] Given the default response (no limit), when the report endpoint is called, then a reasonable default limit is applied (25 error groups, all targets)
- [x] Given `Accept: text/csv` is sent, when `curl -H "Authorization: Bearer $KEY" -H "Accept: text/csv" "http://127.0.0.1:4000/api/v1/report?limit=5"` is run locally, then the response is valid CSV
- [x] Given an agent uses the cursor to paginate, when it fetches page 2, then it receives the next batch without duplicates

## Manual QA

1. `mix test test/canary/report_test.exs test/canary_web/controllers/report_controller_test.exs`
2. `mix test`
3. `mix credo --strict`
4. `mix dialyzer`
5. `mix ecto.create && mix ecto.migrate`
6. `mix run -e 'Application.ensure_all_started(:canary); {:ok, _key, raw_key} = Canary.Auth.generate_key("runtime-check"); IO.puts(raw_key)'`
7. `mix phx.server`
8. `curl -X POST http://127.0.0.1:4000/api/v1/targets -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"name":"alpha","url":"https://example.com/","interval_ms":60000}'`
9. `curl -X POST http://127.0.0.1:4000/api/v1/errors -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"service":"alpha","error_class":"ConnectionError","message":"database unavailable"}'`
10. `curl -H "Authorization: Bearer $KEY" -H "Accept: text/csv" "http://127.0.0.1:4000/api/v1/report?limit=5"`

Expected final output includes:

```csv
section,position,id,name,service,error_class,url,state,count,first_seen,last_seen,severity,status,consecutive_failures,last_checked_at,cursor,truncated
targets,1,TGT-...,alpha,,,https://example.com/,unknown,,,,,,0,,,false
error_groups,1,,,alpha,ConnectionError,,active,1,...
```

## What Changed

Base branch flow:

```mermaid
flowchart LR
  A["GET /api/v1/report"] --> B["Report.generate(window)"]
  B --> C["Query health + error slice"]
  C --> D["Return full JSON payload"]
```

This PR flow:

```mermaid
flowchart LR
  A["GET /api/v1/report?limit=&cursor="] --> B["Report.generate(opts)"]
  B --> C["Paginate targets + error_groups"]
  C --> D["Attach truncated/cursor metadata"]
  D --> E["JSON default or CSV table"]
```

Data-shape diagram:

```mermaid
flowchart TD
  A["Report data"] --> B["targets page"]
  A --> C["error_groups page"]
  B --> D["JSON response"]
  C --> D
  B --> E["CSV row set"]
  C --> E
```

The new shape is better because the report module now owns pagination as one deep concern, while the controller only negotiates output format.

## Before / After

Before: `/api/v1/report` always returned full JSON lists with no success-path token controls and no CSV option.

After: `/api/v1/report` returns bounded pages with explicit pagination metadata, keeps a sane default limit for error groups, and can emit valid CSV for agent-friendly tabular consumption.

## Walkthrough

Walkthrough artifact: [`docs/walkthroughs/issue-77-report-pagination.md`](https://github.com/misty-step/canary/blob/cx/issue-77-token-efficient-report/docs/walkthroughs/issue-77-report-pagination.md)

Persistent verification protecting the demonstrated path:

- `test/canary/report_test.exs`
- `test/canary_web/controllers/report_controller_test.exs`

## Test Coverage

- `test/canary/report_test.exs`
  Covers default truncation, cursor paging, and no-duplicate regression when one collection exhausts before the other.
- `test/canary_web/controllers/report_controller_test.exs`
  Covers JSON response shape, CSV negotiation, and paginated request handling.

No known coverage gaps for the shipped behavior beyond live concurrent-write pagination stability, which is outside this issue's scope.

## Merge Confidence

High. Evidence includes the targeted report/controller tests, full `mix test`, `mix credo --strict`, `mix dialyzer`, and a live local `curl` proving the CSV route through auth, router negotiation, and serialization. Residual risk is limited to the expected behavior of offset-style pagination under concurrent mutations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report pagination with limit and cursor-based navigation; responses include `truncated` and `cursor`
  * CSV export for reports via Accept: text/csv; API now accepts CSV in addition to JSON
  * Validation for invalid cursor/limit inputs returning 422 validation errors

* **Documentation**
  * New walkthrough describing report pagination verification and CSV/JSON behaviors

* **Tests**
  * Added tests for pagination mechanics, cursor behavior, duplicate prevention, and CSV output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->