### PR TITLE
[codex] map triage repos for canary integrations

### DIFF
--- a/triage/fly.toml
+++ b/triage/fly.toml
@@ -11,7 +11,17 @@ kill_timeout = "10s"
   PORT = "4001"
   PHX_SERVER = "true"
   GITHUB_ORG = "misty-step"
-  SERVICE_REPOS = "{\"consumer-portal\":\"adminifi-ai/consumer-portal\",\"web\":\"adminifi-ai/web\",\"time-tracker\":\"adminifi-ai/time-tracker\",\"vulcan\":\"adminifi-ai/vulcan\",\"volume\":\"misty-step/volume\",\"chrondle\":\"misty-step/chrondle\",\"linejam\":\"misty-step/linejam\"}"
+  SERVICE_REPOS = """
+{
+  "consumer-portal": "adminifi-ai/consumer-portal",
+  "web": "adminifi-ai/web",
+  "time-tracker": "adminifi-ai/time-tracker",
+  "vulcan": "adminifi-ai/vulcan",
+  "volume": "misty-step/volume",
+  "chrondle": "misty-step/chrondle",
+  "linejam": "misty-step/linejam"
+}
+"""
   CANARY_ENDPOINT = "https://canary-obs.fly.dev"
 
 [http_service]

--- a/triage/fly.toml
+++ b/triage/fly.toml
@@ -11,6 +11,7 @@ kill_timeout = "10s"
   PORT = "4001"
   PHX_SERVER = "true"
   GITHUB_ORG = "misty-step"
+  SERVICE_REPOS = "{\"consumer-portal\":\"adminifi-ai/consumer-portal\",\"web\":\"adminifi-ai/web\",\"time-tracker\":\"adminifi-ai/time-tracker\",\"vulcan\":\"adminifi-ai/vulcan\",\"volume\":\"misty-step/volume\",\"chrondle\":\"misty-step/chrondle\",\"linejam\":\"misty-step/linejam\"}"
   CANARY_ENDPOINT = "https://canary-obs.fly.dev"
 
 [http_service]


### PR DESCRIPTION
## What changed
- add explicit `SERVICE_REPOS` mappings for the newly integrated Adminifi and Misty Step services in Canary Triage

## Why
- triage needs deterministic service-to-repo routing so Canary alerts land in the correct GitHub repository

## Validation
- `flyctl deploy --app canary-triage --remote-only`
- verified real webhook delivery by observing triage create issue `#91` for `error.new_class`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration settings to support multiple service integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->