### PR TITLE
[codex] Add monorepo quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
-      fail-fast: false
       matrix:
         include:
           - name: triage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
+  root-quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       MIX_ENV: test
     steps:
@@ -28,15 +29,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: deps
-          key: deps-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
-          restore-keys: deps-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+          key: deps-root-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: deps-root-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
 
-      - name: Restore build cache
+      - name: Restore test build cache
         uses: actions/cache@v4
         with:
-          path: _build
-          key: build-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
-          restore-keys: build-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+          path: _build/test
+          key: build-root-test-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: build-root-test-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
 
       - name: Install dependencies
         run: mix deps.get
@@ -53,13 +54,42 @@ jobs:
       - name: Run tests
         run: mix test
 
+  root-dialyzer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: root-quality
+    steps:
+      - uses: actions/checkout@v4 # v4
+      - uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764 # v1
+        id: beam
+        with:
+          otp-version: "27"
+          elixir-version: "1.17"
+
+      - name: Restore deps cache
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: deps-root-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: deps-root-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Restore dev build cache
+        uses: actions/cache@v4
+        with:
+          path: _build/dev
+          key: build-root-dev-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: build-root-dev-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Install dependencies
+        run: mix deps.get
+
       - name: Restore PLT cache
         uses: actions/cache@v4
         id: plt-cache
         with:
           path: _build/dev/dialyxir_*.plt
-          key: plt-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
-          restore-keys: plt-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+          key: plt-root-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: plt-root-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
 
       - name: Build PLT
         if: steps.plt-cache.outputs.cache-hit != 'true'
@@ -71,3 +101,79 @@ jobs:
         env:
           MIX_ENV: dev
         run: mix dialyzer
+
+  elixir-packages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: triage
+            path: triage
+            lockfile: triage/mix.lock
+          - name: canary_sdk
+            path: canary_sdk
+            lockfile: canary_sdk/mix.lock
+    env:
+      MIX_ENV: test
+    name: elixir-${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4 # v4
+      - uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764 # v1
+        id: beam
+        with:
+          otp-version: "27"
+          elixir-version: "1.17"
+
+      - name: Restore deps cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ matrix.path }}/deps
+          key: deps-${{ matrix.name }}-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles(matrix.lockfile) }}
+          restore-keys: deps-${{ matrix.name }}-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ matrix.path }}/_build/test
+          key: build-${{ matrix.name }}-test-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles(matrix.lockfile) }}
+          restore-keys: build-${{ matrix.name }}-test-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.path }}
+        run: mix deps.get
+
+      - name: Compile (warnings as errors)
+        working-directory: ${{ matrix.path }}
+        run: mix compile --warnings-as-errors
+
+      - name: Check formatting
+        working-directory: ${{ matrix.path }}
+        run: mix format --check-formatted
+
+      - name: Run tests
+        working-directory: ${{ matrix.path }}
+        run: mix test
+
+  typescript-client:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: clients/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.15.0"
+          cache: npm
+          cache-dependency-path: clients/typescript/package-lock.json
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build
+        run: npm run build
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test

--- a/triage/config/runtime.exs
+++ b/triage/config/runtime.exs
@@ -6,8 +6,7 @@ end
 
 port = String.to_integer(System.get_env("PORT", "4001"))
 
-config :canary_triage, CanaryTriageWeb.Endpoint,
-  http: [port: port]
+config :canary_triage, CanaryTriageWeb.Endpoint, http: [port: port]
 
 if config_env() == :prod do
   secret_key_base =

--- a/triage/lib/canary_triage/dispatch.ex
+++ b/triage/lib/canary_triage/dispatch.ex
@@ -25,7 +25,8 @@ defmodule CanaryTriage.Dispatch do
     handle_recovery(extract_service(payload), payload)
   end
 
-  defp dispatch(%{"event" => "health_check." <> type} = payload) when type in ["degraded", "down"] do
+  defp dispatch(%{"event" => "health_check." <> type} = payload)
+       when type in ["degraded", "down"] do
     handle_degradation(extract_service(payload), payload)
   end
 

--- a/triage/lib/canary_triage/error_reporter.ex
+++ b/triage/lib/canary_triage/error_reporter.ex
@@ -9,8 +9,12 @@ defmodule CanaryTriage.ErrorReporter do
   @spec attach() :: :ok
   def attach do
     case :logger.add_handler(:canary_triage_reporter, __MODULE__, %{}) do
-      :ok -> :ok
-      {:error, {:already_exist, _}} -> :ok
+      :ok ->
+        :ok
+
+      {:error, {:already_exist, _}} ->
+        :ok
+
       {:error, reason} ->
         Logger.warning("Failed to attach error reporter: #{inspect(reason)}")
         :ok

--- a/triage/lib/canary_triage/github.ex
+++ b/triage/lib/canary_triage/github.ex
@@ -11,7 +11,8 @@ defmodule CanaryTriage.GitHub do
     labels = Map.get(issue, "labels", [])
     repo = resolve_repo(service)
 
-    case Req.post("https://api.github.com/repos/#{repo}/issues",
+    case Req.post(
+           "https://api.github.com/repos/#{repo}/issues",
            [json: %{title: title, body: body, labels: labels}] ++ common_opts()
          ) do
       {:ok, %{status: 201, body: resp}} ->
@@ -32,7 +33,8 @@ defmodule CanaryTriage.GitHub do
   def find_open_health_issue(service) do
     repo = resolve_repo(service)
 
-    case Req.get("https://api.github.com/repos/#{repo}/issues",
+    case Req.get(
+           "https://api.github.com/repos/#{repo}/issues",
            [params: [labels: "health-check", state: "open", per_page: 10]] ++ common_opts()
          ) do
       {:ok, %{status: 200, body: issues}} when is_list(issues) ->
@@ -56,7 +58,8 @@ defmodule CanaryTriage.GitHub do
     repo = resolve_repo(service)
 
     with {:ok, _} <- comment_on_issue(service, issue_number, comment) do
-      case Req.patch("https://api.github.com/repos/#{repo}/issues/#{issue_number}",
+      case Req.patch(
+             "https://api.github.com/repos/#{repo}/issues/#{issue_number}",
              [json: %{state: "closed", state_reason: "completed"}] ++ common_opts()
            ) do
         {:ok, %{status: 200, body: resp}} ->
@@ -78,7 +81,8 @@ defmodule CanaryTriage.GitHub do
   def comment_on_issue(service, issue_number, comment) do
     repo = resolve_repo(service)
 
-    case Req.post("https://api.github.com/repos/#{repo}/issues/#{issue_number}/comments",
+    case Req.post(
+           "https://api.github.com/repos/#{repo}/issues/#{issue_number}/comments",
            [json: %{body: comment}] ++ common_opts()
          ) do
       {:ok, %{status: 201, body: resp}} ->

--- a/triage/lib/canary_triage/synthesizer.ex
+++ b/triage/lib/canary_triage/synthesizer.ex
@@ -45,12 +45,13 @@ defmodule CanaryTriage.Synthesizer do
     4. Verify endpoint: `curl -I #{url}`
     """
 
-    {:ok, %{
-      "title" => title,
-      "body" => body,
-      "labels" => ["health-check", priority_label(state)],
-      "priority" => priority_from_state(state)
-    }}
+    {:ok,
+     %{
+       "title" => title,
+       "body" => body,
+       "labels" => ["health-check", priority_label(state)],
+       "priority" => priority_from_state(state)
+     }}
   end
 
   @spec build_health_check_comment(map()) :: String.t()
@@ -132,7 +133,9 @@ defmodule CanaryTriage.Synthesizer do
 
   defp build_prompt(payload, detail) do
     event = payload["event"] || "unknown"
-    service = get_in(payload, ["error", "service"]) || get_in(payload, ["target", "name"]) || "unknown"
+
+    service =
+      get_in(payload, ["error", "service"]) || get_in(payload, ["target", "name"]) || "unknown"
 
     context =
       case {event, detail} do

--- a/triage/lib/canary_triage/webhook.ex
+++ b/triage/lib/canary_triage/webhook.ex
@@ -6,7 +6,8 @@ defmodule CanaryTriage.Webhook do
   @spec verify(binary(), binary(), binary()) :: :ok | {:error, :invalid_signature}
   def verify(body, secret, signature)
       when is_binary(body) and is_binary(secret) and is_binary(signature) do
-    expected = "sha256=" <> (:crypto.mac(:hmac, :sha256, secret, body) |> Base.encode16(case: :lower))
+    expected =
+      "sha256=" <> (:crypto.mac(:hmac, :sha256, secret, body) |> Base.encode16(case: :lower))
 
     if Plug.Crypto.secure_compare(expected, signature) do
       :ok

--- a/triage/lib/canary_triage_web/router.ex
+++ b/triage/lib/canary_triage_web/router.ex
@@ -3,6 +3,7 @@ defmodule CanaryTriageWeb.Router do
 
   pipeline :webhook do
     plug :accepts, ["json"]
+
     plug Plug.Parsers,
       parsers: [:json],
       pass: ["application/json"],

--- a/triage/test/canary_triage/dispatch_test.exs
+++ b/triage/test/canary_triage/dispatch_test.exs
@@ -36,8 +36,16 @@ defmodule CanaryTriage.DispatchTest do
 
       stub_github(fn conn ->
         case conn.method do
-          "GET" -> Req.Test.json(conn, [])
-          "POST" -> conn |> Plug.Conn.put_status(201) |> Req.Test.json(%{"number" => 1, "html_url" => "https://github.com/misty-step/canary/issues/1"})
+          "GET" ->
+            Req.Test.json(conn, [])
+
+          "POST" ->
+            conn
+            |> Plug.Conn.put_status(201)
+            |> Req.Test.json(%{
+              "number" => 1,
+              "html_url" => "https://github.com/misty-step/canary/issues/1"
+            })
         end
       end)
 
@@ -52,7 +60,11 @@ defmodule CanaryTriage.DispatchTest do
         case conn.method do
           "GET" ->
             Req.Test.json(conn, [
-              %{"number" => 42, "title" => "Health Check Degraded: canary-triage", "html_url" => "https://github.com/misty-step/canary/issues/42"}
+              %{
+                "number" => 42,
+                "title" => "Health Check Degraded: canary-triage",
+                "html_url" => "https://github.com/misty-step/canary/issues/42"
+              }
             ])
 
           "POST" ->
@@ -73,7 +85,11 @@ defmodule CanaryTriage.DispatchTest do
         case conn.method do
           "GET" ->
             Req.Test.json(conn, [
-              %{"number" => 42, "title" => "Health Check Degraded: canary-triage", "html_url" => "https://github.com/misty-step/canary/issues/42"}
+              %{
+                "number" => 42,
+                "title" => "Health Check Degraded: canary-triage",
+                "html_url" => "https://github.com/misty-step/canary/issues/42"
+              }
             ])
 
           "POST" ->
@@ -107,7 +123,10 @@ defmodule CanaryTriage.DispatchTest do
 
       stub_github(fn conn ->
         "GET" = conn.method
-        conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"message" => "Internal Server Error"})
+
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"message" => "Internal Server Error"})
       end)
 
       assert {:error, {:github, 500, _}} = Dispatch.handle(body, payload, sign(body))
@@ -119,8 +138,13 @@ defmodule CanaryTriage.DispatchTest do
 
       stub_github(fn conn ->
         case conn.method do
-          "GET" -> Req.Test.json(conn, [])
-          "POST" -> conn |> Plug.Conn.put_status(422) |> Req.Test.json(%{"message" => "Validation Failed"})
+          "GET" ->
+            Req.Test.json(conn, [])
+
+          "POST" ->
+            conn
+            |> Plug.Conn.put_status(422)
+            |> Req.Test.json(%{"message" => "Validation Failed"})
         end
       end)
 
@@ -135,7 +159,11 @@ defmodule CanaryTriage.DispatchTest do
         case conn.method do
           "GET" ->
             Req.Test.json(conn, [
-              %{"number" => 42, "title" => "Health Check Degraded: canary-triage", "html_url" => "url"}
+              %{
+                "number" => 42,
+                "title" => "Health Check Degraded: canary-triage",
+                "html_url" => "url"
+              }
             ])
 
           "POST" ->
@@ -154,14 +182,20 @@ defmodule CanaryTriage.DispatchTest do
         case conn.method do
           "GET" ->
             Req.Test.json(conn, [
-              %{"number" => 42, "title" => "Health Check Degraded: canary-triage", "html_url" => "url"}
+              %{
+                "number" => 42,
+                "title" => "Health Check Degraded: canary-triage",
+                "html_url" => "url"
+              }
             ])
 
           "POST" ->
             conn |> Plug.Conn.put_status(201) |> Req.Test.json(%{"id" => 1})
 
           "PATCH" ->
-            conn |> Plug.Conn.put_status(422) |> Req.Test.json(%{"message" => "Validation Failed"})
+            conn
+            |> Plug.Conn.put_status(422)
+            |> Req.Test.json(%{"message" => "Validation Failed"})
         end
       end)
 

--- a/triage/test/canary_triage/github_test.exs
+++ b/triage/test/canary_triage/github_test.exs
@@ -15,7 +15,11 @@ defmodule CanaryTriage.GitHubTest do
     test "returns issue when matching title found" do
       stub_github(fn conn ->
         Req.Test.json(conn, [
-          %{"number" => 42, "title" => "Health Check Degraded: my-service", "html_url" => "https://github.com/misty-step/canary/issues/42"}
+          %{
+            "number" => 42,
+            "title" => "Health Check Degraded: my-service",
+            "html_url" => "https://github.com/misty-step/canary/issues/42"
+          }
         ])
       end)
 
@@ -50,7 +54,9 @@ defmodule CanaryTriage.GitHubTest do
 
     test "returns error on API failure" do
       stub_github(fn conn ->
-        conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"message" => "Internal Server Error"})
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"message" => "Internal Server Error"})
       end)
 
       assert {:error, {:github, 500, _}} = GitHub.find_open_health_issue("my-service")
@@ -109,7 +115,10 @@ defmodule CanaryTriage.GitHubTest do
     test "creates issue and returns response" do
       stub_github(fn conn ->
         assert conn.method == "POST"
-        conn |> Plug.Conn.put_status(201) |> Req.Test.json(%{"number" => 10, "html_url" => "https://example.com"})
+
+        conn
+        |> Plug.Conn.put_status(201)
+        |> Req.Test.json(%{"number" => 10, "html_url" => "https://example.com"})
       end)
 
       issue = %{"title" => "Test", "body" => "Body", "labels" => ["bug"]}


### PR DESCRIPTION
## Summary
- expand CI into explicit monorepo quality gates for the root app, `triage`, `canary_sdk`, and `clients/typescript`
- preserve the existing root quality bar, including Dialyzer, while adding package-specific validation for the nested apps
- fix the existing `triage` formatter debt so the new formatter gate can be enabled immediately

## Why
The agent-readiness assessment found that CI only validated the root Phoenix app even though this repo ships multiple packages. That left `triage`, `canary_sdk`, and the TypeScript client outside automated PR protection.

## Impact
- pull requests now validate every shipped package in the monorepo
- root keeps compile, format, Credo, test, and Dialyzer gates
- `triage` and `canary_sdk` now run compile, format, and test in CI
- `clients/typescript` now runs install, build, typecheck, and test in CI

## Root Cause
The repository's CI model lagged behind the repository's actual package boundaries. The workflow treated the root app as the whole system, so regressions in nested packages could land without automated feedback.

## Validation
- `mix compile --warnings-as-errors && mix format --check-formatted && mix credo --strict && mix test && mix dialyzer`
- `(cd triage && mix compile --warnings-as-errors && mix format --check-formatted && mix test)`
- `(cd canary_sdk && mix compile --warnings-as-errors && mix format --check-formatted && mix test)`
- `(cd clients/typescript && npm ci --ignore-scripts && npm run build && npm run typecheck && npm test)`

Closes #99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI pipeline improved with more reliable caching and timeouts, plus new package-level test jobs and a TypeScript client validation job to catch regressions earlier.

* **Style**
  * Project-wide code and test formatting refinements for more consistent, readable source and test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->