### PR TITLE
feat: password-gate dashboard behind DASHBOARD_PASSWORD

### DIFF
--- a/backlog.d/001-ramp-pattern.md
+++ b/backlog.d/001-ramp-pattern.md
@@ -1,0 +1,27 @@
+# Evolve toward Ramp-pattern autonomous maintenance
+
+Priority: high
+Status: blocked
+Estimate: XL
+
+## Goal
+Canary generates monitors per code change, auto-triages alerts, and proposes fixes — matching the Ramp Sheets self-maintaining pattern.
+
+## Non-Goals
+- Replace Datadog/Grafana (instrument, don't own the observability platform)
+- Full auto-merge of fixes (human review gate stays)
+
+## Oracle
+- [ ] On PR merge, agent reads diff and generates monitors
+- [ ] When monitor fires, agent is dispatched with alert context
+- [ ] Agent reproduces issue in sandbox, pushes fix PR
+- [ ] If alert is noise, agent tunes or deletes the monitor
+- [ ] State on monitor prevents duplicate work
+
+## Notes
+Blocked on: Cerberus CLI (needed for the fix-review loop).
+Reference: "How we made Ramp Sheets self-maintaining" (Ramp Labs, 2026-03-23).
+Current state: canary-watch synthesizes incidents into GitHub issues.
+Next step: close the loop so the triaging agent also proposes fixes.
+
+Source: spellbook simplification session 2026-03-25.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -31,9 +31,20 @@ if config_env() == :prod do
     http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: port],
     secret_key_base: secret_key_base
 
+  dashboard_password_hash =
+    case System.get_env("DASHBOARD_PASSWORD") do
+      nil ->
+        IO.puts("[canary] WARNING: DASHBOARD_PASSWORD not set — dashboard is publicly accessible")
+        nil
+
+      password ->
+        Bcrypt.hash_pwd_salt(password)
+    end
+
   config :canary,
     api_key_salt: System.get_env("API_KEY_SALT", secret_key_base),
     allow_private_targets: System.get_env("ALLOW_PRIVATE_TARGETS", "false") == "true",
     error_retention_days: String.to_integer(System.get_env("ERROR_RETENTION_DAYS", "30")),
-    check_retention_days: String.to_integer(System.get_env("CHECK_RETENTION_DAYS", "7"))
+    check_retention_days: String.to_integer(System.get_env("CHECK_RETENTION_DAYS", "7")),
+    dashboard_password_hash: dashboard_password_hash
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -37,6 +37,9 @@ if config_env() == :prod do
         IO.puts("[canary] WARNING: DASHBOARD_PASSWORD not set — dashboard is publicly accessible")
         nil
 
+      "" ->
+        raise "DASHBOARD_PASSWORD must not be empty"
+
       password ->
         Bcrypt.hash_pwd_salt(password)
     end

--- a/lib/canary_web/controllers/login_controller.ex
+++ b/lib/canary_web/controllers/login_controller.ex
@@ -20,7 +20,7 @@ defmodule CanaryWeb.LoginController do
           :ok ->
             if Bcrypt.verify_pass(password, hash) do
               conn
-              |> put_session("dashboard_auth_version", auth_version(hash))
+              |> put_session("dashboard_auth_version", CanaryWeb.DashboardAuth.auth_version(hash))
               |> redirect(to: "/dashboard")
             else
               conn
@@ -36,7 +36,4 @@ defmodule CanaryWeb.LoginController do
     |> put_flash(:error, "Password required")
     |> redirect(to: "/dashboard/login")
   end
-
-  @doc false
-  def auth_version(hash), do: :crypto.hash(:sha256, hash) |> Base.url_encode64(padding: false)
 end

--- a/lib/canary_web/controllers/login_controller.ex
+++ b/lib/canary_web/controllers/login_controller.ex
@@ -1,17 +1,23 @@
 defmodule CanaryWeb.LoginController do
   use CanaryWeb, :controller
 
+  alias Canary.Errors.RateLimiter
+
   def create(conn, %{"password" => password}) do
     case Application.get_env(:canary, :dashboard_password_hash) do
       nil ->
         redirect(conn, to: "/dashboard")
 
       hash ->
+        ip = to_string(:inet.ntoa(conn.remote_ip))
+
         if Bcrypt.verify_pass(password, hash) do
           conn
-          |> put_session("dashboard_authenticated", true)
+          |> put_session("dashboard_auth_version", auth_version(hash))
           |> redirect(to: "/dashboard")
         else
+          RateLimiter.check(ip, :auth_fail)
+
           conn
           |> put_flash(:error, "Invalid password")
           |> redirect(to: "/dashboard/login")
@@ -24,4 +30,7 @@ defmodule CanaryWeb.LoginController do
     |> put_flash(:error, "Password required")
     |> redirect(to: "/dashboard/login")
   end
+
+  @doc false
+  def auth_version(hash), do: :crypto.hash(:sha256, hash) |> Base.url_encode64(padding: false)
 end

--- a/lib/canary_web/controllers/login_controller.ex
+++ b/lib/canary_web/controllers/login_controller.ex
@@ -11,16 +11,22 @@ defmodule CanaryWeb.LoginController do
       hash ->
         ip = to_string(:inet.ntoa(conn.remote_ip))
 
-        if Bcrypt.verify_pass(password, hash) do
-          conn
-          |> put_session("dashboard_auth_version", auth_version(hash))
-          |> redirect(to: "/dashboard")
-        else
-          RateLimiter.check(ip, :auth_fail)
+        case RateLimiter.check(ip, :auth_fail) do
+          {:error, retry_after} ->
+            conn
+            |> put_flash(:error, "Too many attempts. Try again in #{retry_after}s.")
+            |> redirect(to: "/dashboard/login")
 
-          conn
-          |> put_flash(:error, "Invalid password")
-          |> redirect(to: "/dashboard/login")
+          :ok ->
+            if Bcrypt.verify_pass(password, hash) do
+              conn
+              |> put_session("dashboard_auth_version", auth_version(hash))
+              |> redirect(to: "/dashboard")
+            else
+              conn
+              |> put_flash(:error, "Invalid password")
+              |> redirect(to: "/dashboard/login")
+            end
         end
     end
   end

--- a/lib/canary_web/controllers/login_controller.ex
+++ b/lib/canary_web/controllers/login_controller.ex
@@ -1,0 +1,27 @@
+defmodule CanaryWeb.LoginController do
+  use CanaryWeb, :controller
+
+  def create(conn, %{"password" => password}) do
+    case Application.get_env(:canary, :dashboard_password_hash) do
+      nil ->
+        redirect(conn, to: "/dashboard")
+
+      hash ->
+        if Bcrypt.verify_pass(password, hash) do
+          conn
+          |> put_session("dashboard_authenticated", true)
+          |> redirect(to: "/dashboard")
+        else
+          conn
+          |> put_flash(:error, "Invalid password")
+          |> redirect(to: "/dashboard/login")
+        end
+    end
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_flash(:error, "Password required")
+    |> redirect(to: "/dashboard/login")
+  end
+end

--- a/lib/canary_web/live/dashboard_auth.ex
+++ b/lib/canary_web/live/dashboard_auth.ex
@@ -18,10 +18,13 @@ defmodule CanaryWeb.DashboardAuth do
 
   defp auth_disabled?, do: is_nil(Application.get_env(:canary, :dashboard_password_hash))
 
+  @doc false
+  def auth_version(hash), do: :crypto.hash(:sha256, hash) |> Base.url_encode64(padding: false)
+
   defp valid_session?(session) do
     with version when is_binary(version) <- session["dashboard_auth_version"],
          hash when is_binary(hash) <- Application.get_env(:canary, :dashboard_password_hash) do
-      version == CanaryWeb.LoginController.auth_version(hash)
+      version == auth_version(hash)
     else
       _ -> false
     end

--- a/lib/canary_web/live/dashboard_auth.ex
+++ b/lib/canary_web/live/dashboard_auth.ex
@@ -1,0 +1,15 @@
+defmodule CanaryWeb.DashboardAuth do
+  @moduledoc "LiveView on_mount hook that gates dashboard access behind DASHBOARD_PASSWORD."
+
+  import Phoenix.LiveView
+
+  def on_mount(:default, _params, session, socket) do
+    if auth_disabled?() or session["dashboard_authenticated"] do
+      {:cont, socket}
+    else
+      {:halt, redirect(socket, to: "/dashboard/login")}
+    end
+  end
+
+  defp auth_disabled?, do: is_nil(Application.get_env(:canary, :dashboard_password_hash))
+end

--- a/lib/canary_web/live/dashboard_auth.ex
+++ b/lib/canary_web/live/dashboard_auth.ex
@@ -4,7 +4,7 @@ defmodule CanaryWeb.DashboardAuth do
   import Phoenix.LiveView
 
   def on_mount(:default, _params, session, socket) do
-    if auth_disabled?() or session["dashboard_authenticated"] do
+    if auth_disabled?() or valid_session?(session) do
       {:cont, socket}
     else
       {:halt, redirect(socket, to: "/dashboard/login")}
@@ -12,4 +12,13 @@ defmodule CanaryWeb.DashboardAuth do
   end
 
   defp auth_disabled?, do: is_nil(Application.get_env(:canary, :dashboard_password_hash))
+
+  defp valid_session?(session) do
+    with version when is_binary(version) <- session["dashboard_auth_version"],
+         hash when is_binary(hash) <- Application.get_env(:canary, :dashboard_password_hash) do
+      version == CanaryWeb.LoginController.auth_version(hash)
+    else
+      _ -> false
+    end
+  end
 end

--- a/lib/canary_web/live/dashboard_auth.ex
+++ b/lib/canary_web/live/dashboard_auth.ex
@@ -4,11 +4,16 @@ defmodule CanaryWeb.DashboardAuth do
   import Phoenix.LiveView
 
   def on_mount(:default, _params, session, socket) do
-    if auth_disabled?() or valid_session?(session) do
+    if authenticated?(session) do
       {:cont, socket}
     else
       {:halt, redirect(socket, to: "/dashboard/login")}
     end
+  end
+
+  @doc "Returns true when no password is configured or the session holds a valid auth version."
+  def authenticated?(session) do
+    auth_disabled?() or valid_session?(session)
   end
 
   defp auth_disabled?, do: is_nil(Application.get_env(:canary, :dashboard_password_hash))

--- a/lib/canary_web/live/login_live.ex
+++ b/lib/canary_web/live/login_live.ex
@@ -3,7 +3,7 @@ defmodule CanaryWeb.LoginLive do
 
   @impl true
   def mount(_params, session, socket) do
-    if session["dashboard_auth_version"] do
+    if CanaryWeb.DashboardAuth.authenticated?(session) do
       {:ok, redirect(socket, to: "/dashboard")}
     else
       {:ok, socket}

--- a/lib/canary_web/live/login_live.ex
+++ b/lib/canary_web/live/login_live.ex
@@ -6,7 +6,7 @@ defmodule CanaryWeb.LoginLive do
     if session["dashboard_authenticated"] do
       {:ok, redirect(socket, to: "/dashboard")}
     else
-      {:ok, assign(socket, :error, nil)}
+      {:ok, socket}
     end
   end
 
@@ -16,8 +16,7 @@ defmodule CanaryWeb.LoginLive do
     <div style="display:flex;align-items:center;justify-content:center;min-height:60vh;">
       <div class="card" style="width:100%;max-width:360px;">
         <div class="card-header">Authenticate</div>
-        <p :if={@error} class="flash-error"><%= @error %></p>
-        <form method="post" action="/dashboard/login" style="display:flex;flex-direction:column;gap:12px;margin-top:8px;">
+        <form method="post" action={~p"/dashboard/login"} style="display:flex;flex-direction:column;gap:12px;margin-top:8px;">
           <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
           <input
             type="password"

--- a/lib/canary_web/live/login_live.ex
+++ b/lib/canary_web/live/login_live.ex
@@ -1,0 +1,41 @@
+defmodule CanaryWeb.LoginLive do
+  use CanaryWeb, :live_view
+
+  @impl true
+  def mount(_params, session, socket) do
+    if session["dashboard_authenticated"] do
+      {:ok, redirect(socket, to: "/dashboard")}
+    else
+      {:ok, assign(socket, :error, nil)}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div style="display:flex;align-items:center;justify-content:center;min-height:60vh;">
+      <div class="card" style="width:100%;max-width:360px;">
+        <div class="card-header">Authenticate</div>
+        <p :if={@error} class="flash-error"><%= @error %></p>
+        <form method="post" action="/dashboard/login" style="display:flex;flex-direction:column;gap:12px;margin-top:8px;">
+          <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+          <input
+            type="password"
+            name="password"
+            placeholder="Password"
+            autofocus
+            autocomplete="current-password"
+            style="background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);padding:8px 12px;font-family:var(--font);font-size:12px;"
+          />
+          <button
+            type="submit"
+            style="background:var(--amber);color:var(--bg);border:none;border-radius:var(--radius);padding:8px 12px;font-family:var(--font);font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:1px;cursor:pointer;"
+          >
+            Enter
+          </button>
+        </form>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/canary_web/live/login_live.ex
+++ b/lib/canary_web/live/login_live.ex
@@ -3,7 +3,7 @@ defmodule CanaryWeb.LoginLive do
 
   @impl true
   def mount(_params, session, socket) do
-    if session["dashboard_authenticated"] do
+    if session["dashboard_auth_version"] do
       {:ok, redirect(socket, to: "/dashboard")}
     else
       {:ok, socket}
@@ -21,8 +21,10 @@ defmodule CanaryWeb.LoginLive do
           <input
             type="password"
             name="password"
+            aria-label="Password"
             placeholder="Password"
             autofocus
+            required
             autocomplete="current-password"
             style="background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);padding:8px 12px;font-family:var(--font);font-size:12px;"
           />

--- a/lib/canary_web/router.ex
+++ b/lib/canary_web/router.ex
@@ -40,13 +40,23 @@ defmodule CanaryWeb.Router do
     get "/readyz", HealthController, :readyz
   end
 
-  # Dashboard (no auth — internal network)
+  # Dashboard login (outside live_session — no on_mount gate)
   scope "/dashboard", CanaryWeb do
     pipe_through :browser
 
-    live "/", DashboardLive, :index
-    live "/errors", ErrorsLive, :index
-    live "/errors/:id", ErrorDetailLive, :show
+    live "/login", LoginLive, :index
+    post "/login", LoginController, :create
+  end
+
+  # Dashboard (password-gated via on_mount hook)
+  scope "/dashboard", CanaryWeb do
+    pipe_through :browser
+
+    live_session :dashboard, on_mount: [CanaryWeb.DashboardAuth] do
+      live "/", DashboardLive, :index
+      live "/errors", ErrorsLive, :index
+      live "/errors/:id", ErrorDetailLive, :show
+    end
   end
 
   # Authenticated API

--- a/test/canary_web/live/dashboard_auth_test.exs
+++ b/test/canary_web/live/dashboard_auth_test.exs
@@ -9,7 +9,12 @@ defmodule CanaryWeb.DashboardAuthTest do
     hash = Bcrypt.hash_pwd_salt(@password)
     original = Application.get_env(:canary, :dashboard_password_hash)
     Application.put_env(:canary, :dashboard_password_hash, hash)
-    on_exit(fn -> Application.put_env(:canary, :dashboard_password_hash, original) end)
+
+    on_exit(fn ->
+      Application.put_env(:canary, :dashboard_password_hash, original)
+      :ets.match_delete(:canary_rate_limits, {{:auth_fail, :_}, :_, :_})
+    end)
+
     :ok
   end
 
@@ -62,6 +67,20 @@ defmodule CanaryWeb.DashboardAuthTest do
 
       # Old session should be rejected
       assert {:error, {:redirect, %{to: "/dashboard/login"}}} = live(conn, "/dashboard")
+    end
+  end
+
+  describe "rate limiting" do
+    test "blocks login after too many failed attempts", %{conn: conn} do
+      # Exhaust the rate limit (10 attempts)
+      for _ <- 1..10 do
+        post(build_conn(), "/dashboard/login", %{"password" => "wrong"})
+      end
+
+      # Next attempt should be rate-limited
+      conn = post(conn, "/dashboard/login", %{"password" => "wrong"})
+      assert redirected_to(conn) == "/dashboard/login"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Too many attempts"
     end
   end
 

--- a/test/canary_web/live/dashboard_auth_test.exs
+++ b/test/canary_web/live/dashboard_auth_test.exs
@@ -1,0 +1,68 @@
+defmodule CanaryWeb.DashboardAuthTest do
+  use CanaryWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  @password "test-password-123"
+
+  setup do
+    hash = Bcrypt.hash_pwd_salt(@password)
+    original = Application.get_env(:canary, :dashboard_password_hash)
+    Application.put_env(:canary, :dashboard_password_hash, hash)
+    on_exit(fn -> Application.put_env(:canary, :dashboard_password_hash, original) end)
+    :ok
+  end
+
+  describe "unauthenticated" do
+    test "redirects /dashboard to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/dashboard/login"}}} = live(conn, "/dashboard")
+    end
+
+    test "redirects /dashboard/errors to login", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/dashboard/login"}}} = live(conn, "/dashboard/errors")
+    end
+
+    test "login page renders", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/dashboard/login")
+      assert html =~ "Authenticate"
+      assert html =~ "password"
+    end
+  end
+
+  describe "login" do
+    test "correct password sets session and redirects", %{conn: conn} do
+      conn = post(conn, "/dashboard/login", %{"password" => @password})
+      assert redirected_to(conn) == "/dashboard"
+
+      conn = get(recycle(conn), "/dashboard")
+      assert html_response(conn, 200) =~ "Health Targets"
+    end
+
+    test "wrong password redirects back to login", %{conn: conn} do
+      conn = post(conn, "/dashboard/login", %{"password" => "wrong"})
+      assert redirected_to(conn) == "/dashboard/login"
+    end
+
+    test "missing password redirects back to login", %{conn: conn} do
+      conn = post(conn, "/dashboard/login", %{})
+      assert redirected_to(conn) == "/dashboard/login"
+    end
+  end
+
+  describe "auth disabled" do
+    setup do
+      Application.put_env(:canary, :dashboard_password_hash, nil)
+      :ok
+    end
+
+    test "dashboard accessible without login", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/dashboard")
+      assert html =~ "Health Targets"
+    end
+
+    test "login page redirects to dashboard when auth disabled", %{conn: conn} do
+      conn = post(conn, "/dashboard/login", %{"password" => "anything"})
+      assert redirected_to(conn) == "/dashboard"
+    end
+  end
+end

--- a/test/canary_web/live/dashboard_auth_test.exs
+++ b/test/canary_web/live/dashboard_auth_test.exs
@@ -68,6 +68,20 @@ defmodule CanaryWeb.DashboardAuthTest do
       # Old session should be rejected
       assert {:error, {:redirect, %{to: "/dashboard/login"}}} = live(conn, "/dashboard")
     end
+
+    test "stale session shows login form instead of redirect loop", %{conn: conn} do
+      # Log in
+      conn = post(conn, "/dashboard/login", %{"password" => @password})
+      conn = recycle(conn)
+
+      # Rotate password
+      new_hash = Bcrypt.hash_pwd_salt("new-password-456")
+      Application.put_env(:canary, :dashboard_password_hash, new_hash)
+
+      # Login page should show form, not redirect to /dashboard
+      {:ok, _view, html} = live(conn, "/dashboard/login")
+      assert html =~ "Authenticate"
+    end
   end
 
   describe "rate limiting" do

--- a/test/canary_web/live/dashboard_auth_test.exs
+++ b/test/canary_web/live/dashboard_auth_test.exs
@@ -49,6 +49,22 @@ defmodule CanaryWeb.DashboardAuthTest do
     end
   end
 
+  describe "password rotation" do
+    test "old session rejected after password change", %{conn: conn} do
+      # Log in with original password
+      conn = post(conn, "/dashboard/login", %{"password" => @password})
+      assert redirected_to(conn) == "/dashboard"
+      conn = recycle(conn)
+
+      # Rotate password
+      new_hash = Bcrypt.hash_pwd_salt("new-password-456")
+      Application.put_env(:canary, :dashboard_password_hash, new_hash)
+
+      # Old session should be rejected
+      assert {:error, {:redirect, %{to: "/dashboard/login"}}} = live(conn, "/dashboard")
+    end
+  end
+
   describe "auth disabled" do
     setup do
       Application.put_env(:canary, :dashboard_password_hash, nil)


### PR DESCRIPTION
## Summary
- Dashboard LiveView routes (`/dashboard/*`) were publicly accessible to anyone with the URL
- Adds session-based password auth: `DASHBOARD_PASSWORD` env var → bcrypt hash at boot → login page → session cookie → `on_mount` hook
- Auth disabled when env var unset (dev/test default), with boot warning in prod

## Files
- `lib/canary_web/live/dashboard_auth.ex` — `on_mount` hook, checks session
- `lib/canary_web/live/login_live.ex` — password form, matches dashboard aesthetic
- `lib/canary_web/controllers/login_controller.ex` — POST handler, bcrypt verify, sets session
- `lib/canary_web/router.ex` — `live_session :dashboard` with on_mount gate
- `config/runtime.exs` — reads + hashes `DASHBOARD_PASSWORD` at boot
- `test/canary_web/live/dashboard_auth_test.exs` — 8 tests

## Activation
```bash
flyctl secrets set DASHBOARD_PASSWORD=<password> --app canary-obs
```

## Test plan
- [x] 225 tests pass (0 failures)
- [x] Unauthenticated requests to `/dashboard` redirect to `/dashboard/login`
- [x] Correct password sets session and grants access
- [x] Wrong password stays on login page
- [x] Dashboard open when `DASHBOARD_PASSWORD` unset
- [ ] Verify login page renders correctly in prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional password-protected dashboard: when configured via env var, users must authenticate via a login page; sessions preserve authentication and support password rotation. Empty password values are rejected; leaving auth unset enables public access.
* **Routing / UX**
  * Dashboard routes now enforce the login flow and redirect unauthenticated users to the login page; successful login returns to the dashboard.
* **Security**
  * Login attempts are rate-limited to prevent brute-force attempts.
* **Tests**
  * Added automated tests for auth flows, password rotation, rate-limiting, and the auth-disabled case.
* **Documentation**
  * Added a backlog entry describing a future Ramp-pattern initiative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->