### PR TITLE
Add webhook delivery ledger and stable delivery IDs

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,2 +1,3 @@
 {"date":"2026-04-01","pr":116,"correctness":8,"depth":7,"simplicity":9,"craft":8,"verdict":"ship"}
 {"date":"2026-04-01","pr":115,"correctness":6,"depth":7,"simplicity":3,"craft":5,"verdict":"dont-ship"}
+{"date":"2026-04-02","pr":null,"correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship"}

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ curl -X POST https://canary-obs.fly.dev/api/v1/webhooks \
   -H "Authorization: Bearer $CANARY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com/hook", "events": ["health_check.down", "error.new_class"]}'
+
+curl "https://canary-obs.fly.dev/api/v1/webhook-deliveries?webhook_id=WHK-abc123&limit=20" \
+  -H "Authorization: Bearer $CANARY_API_KEY"
 ```
 
 ### API Key Management
@@ -252,6 +255,13 @@ curl -X POST https://canary-obs.fly.dev/api/v1/keys \
 
 All webhooks are HMAC-SHA256 signed. Secret returned on subscription creation.
 `POST /api/v1/webhooks/:id/test` sends a non-business `canary.ping` payload and does not write to the timeline.
+
+### Webhook Consumer Contract
+
+- Deliveries are at-least-once. Deduplicate on `X-Delivery-Id`.
+- `X-Delivery-Id` is stable across retries for the same logical delivery.
+- Webhooks are wake-up hints, not the source of truth. Query `/api/v1/timeline` or the relevant read API for correctness.
+- `GET /api/v1/webhook-deliveries` exposes operator-visible delivery outcomes, attempt counts, reasons, and cursor-paginated history.
 
 ## Self-Observability
 

--- a/backlog.d/012-webhook-delivery-ledger.md
+++ b/backlog.d/012-webhook-delivery-ledger.md
@@ -1,7 +1,7 @@
 # Webhook delivery ledger and idempotency
 
 Priority: high
-Status: ready
+Status: in-progress
 Estimate: M
 
 ## Goal

--- a/backlog.d/012-webhook-delivery-ledger.md
+++ b/backlog.d/012-webhook-delivery-ledger.md
@@ -1,7 +1,7 @@
 # Webhook delivery ledger and idempotency
 
 Priority: high
-Status: in-progress
+Status: done
 Estimate: M
 
 ## Goal
@@ -15,10 +15,10 @@ visibility, and a documented consumer idempotency contract.
 - Webhook replay API in this item — ledger enables it, separate item delivers it
 
 ## Oracle
-- [ ] Given a webhook delivery is retried by Oban, when the consumer inspects `x-delivery-id`, then the ID is identical across all attempts for the same logical event
-- [ ] Given a webhook delivery succeeds or is discarded, when an operator queries the delivery ledger, then the attempt count, final status, and timestamps are visible
-- [ ] Given circuit breaker or cooldown suppresses a delivery, when the ledger is queried, then the suppression reason is recorded (not silently dropped)
-- [ ] Given the agent integration guide (011) exists, then the idempotency contract (deduplicate on `x-delivery-id`, treat webhooks as wake-up hints, replay from timeline for correctness) is documented
+- [x] Given a webhook delivery is retried by Oban, when the consumer inspects `x-delivery-id`, then the ID is identical across all attempts for the same logical event
+- [x] Given a webhook delivery succeeds or is discarded, when an operator queries the delivery ledger, then the attempt count, final status, and timestamps are visible
+- [x] Given circuit breaker or cooldown suppresses a delivery, when the ledger is queried, then the suppression reason is recorded (not silently dropped)
+- [x] Given the agent integration guide (011) exists, then the idempotency contract (deduplicate on `x-delivery-id`, treat webhooks as wake-up hints, replay from timeline for correctness) is documented
 
 ## Notes
 Identified as the #1 architectural gap by all three external reviewers (Thinktank, Codex, Gemini) during the 2026-04-01 audit.
@@ -32,3 +32,13 @@ Codex recommended expanding to a full delivery ledger + stable IDs + DLQ. This i
 covers the ledger and stable IDs; replay/DLQ is a follow-up.
 
 Load-bearing for the triage sprite (bb/011) and the ramp pattern north star (010).
+
+## What Was Built
+- Added a persistent `webhook_deliveries` ledger with one row per logical delivery, status transitions, attempt counters, timestamps, and reason metadata.
+- Generated `DLV-*` delivery IDs at enqueue time, reused them across retries, and derived deterministic fallback IDs for legacy jobs that were already queued without a delivery ID.
+- Recorded cooldown and circuit-open suppressions in the ledger instead of silently dropping them, and tightened cooldown keys so distinct same-type payloads do not collide behind `webhook_id:event`.
+- Added `GET /api/v1/webhook-deliveries` with validated filters and cursor pagination for operator visibility into delivery history.
+- Updated webhook contract docs in `README.md` and `spec.md` to document stable delivery IDs, wake-up-hint semantics, replay guidance, and the delivery ledger endpoint.
+
+## Workarounds
+- Local test verification required `MIX_ENV=test mix ecto.reset` once after renaming the new ledger reason column during implementation, because the uncommitted test SQLite schema had already been migrated with the earlier column name.

--- a/lib/canary/schemas/webhook_delivery_ledger.ex
+++ b/lib/canary/schemas/webhook_delivery_ledger.ex
@@ -1,0 +1,38 @@
+defmodule Canary.Schemas.WebhookDeliveryLedger do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @statuses ~w(pending retrying delivered discarded suppressed)
+
+  @primary_key {:delivery_id, :string, autogenerate: false}
+  schema "webhook_deliveries" do
+    field :webhook_id, :string
+    field :event, :string
+    field :status, :string
+    field :attempt_count, :integer, default: 0
+    field :reason, :string
+    field :first_attempt_at, :string
+    field :last_attempt_at, :string
+    field :delivered_at, :string
+    field :discarded_at, :string
+    field :created_at, :string
+    field :updated_at, :string
+  end
+
+  @required ~w(webhook_id event status attempt_count created_at updated_at)a
+  @optional ~w(
+    reason
+    first_attempt_at
+    last_attempt_at
+    delivered_at
+    discarded_at
+  )a
+
+  def changeset(ledger, attrs) do
+    ledger
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required)
+    |> validate_number(:attempt_count, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:status, @statuses)
+  end
+end

--- a/lib/canary/schemas/webhook_delivery_ledger.ex
+++ b/lib/canary/schemas/webhook_delivery_ledger.ex
@@ -2,6 +2,8 @@ defmodule Canary.Schemas.WebhookDeliveryLedger do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   @statuses ~w(pending retrying delivered discarded suppressed)
 
   @primary_key {:delivery_id, :string, autogenerate: false}

--- a/lib/canary/webhook_deliveries.ex
+++ b/lib/canary/webhook_deliveries.ex
@@ -1,0 +1,239 @@
+defmodule Canary.WebhookDeliveries do
+  @moduledoc """
+  Persistence API for outbound webhook delivery attempts and outcomes.
+  """
+
+  import Ecto.Query
+
+  alias Canary.Repo
+  alias Canary.Schemas.WebhookDeliveryLedger
+
+  require Logger
+
+  @default_limit 50
+  @max_limit 200
+  @statuses ~w(pending retrying delivered discarded suppressed)
+
+  @spec statuses() :: [String.t()]
+  def statuses, do: @statuses
+
+  @spec create_pending(String.t(), String.t(), String.t(), String.t()) :: :ok
+  def create_pending(delivery_id, webhook_id, event, now) do
+    attrs = %{
+      webhook_id: webhook_id,
+      event: event,
+      status: "pending",
+      attempt_count: 0,
+      created_at: now,
+      updated_at: now
+    }
+
+    %WebhookDeliveryLedger{delivery_id: delivery_id}
+    |> WebhookDeliveryLedger.changeset(attrs)
+    |> Repo.insert(on_conflict: :nothing, conflict_target: :delivery_id)
+    |> log_result("create pending webhook delivery #{delivery_id}")
+  end
+
+  @spec create_suppressed(String.t(), String.t(), String.t(), String.t(), String.t()) :: :ok
+  def create_suppressed(delivery_id, webhook_id, event, reason, now) do
+    attrs = %{
+      webhook_id: webhook_id,
+      event: event,
+      status: "suppressed",
+      attempt_count: 0,
+      reason: reason,
+      created_at: now,
+      updated_at: now
+    }
+
+    %WebhookDeliveryLedger{delivery_id: delivery_id}
+    |> WebhookDeliveryLedger.changeset(attrs)
+    |> Repo.insert(
+      on_conflict: [set: [status: "suppressed", reason: reason, updated_at: now]],
+      conflict_target: :delivery_id
+    )
+    |> log_result("mark webhook delivery #{delivery_id} as suppressed")
+  end
+
+  @spec mark_attempt(String.t(), String.t()) :: :ok
+  def mark_attempt(delivery_id, now) do
+    case Repo.get(WebhookDeliveryLedger, delivery_id) do
+      nil ->
+        :ok
+
+      row ->
+        attrs = %{
+          status: if(row.status in ["pending", "retrying"], do: "retrying", else: row.status),
+          attempt_count: row.attempt_count + 1,
+          first_attempt_at: row.first_attempt_at || now,
+          last_attempt_at: now,
+          updated_at: now
+        }
+
+        persist_update(row, attrs)
+    end
+  end
+
+  @spec mark_delivered(String.t(), String.t()) :: :ok
+  def mark_delivered(delivery_id, now) do
+    case Repo.get(WebhookDeliveryLedger, delivery_id) do
+      nil ->
+        :ok
+
+      row ->
+        persist_update(row, %{status: "delivered", delivered_at: now, updated_at: now})
+    end
+  end
+
+  @spec mark_discarded(String.t(), String.t(), String.t()) :: :ok
+  def mark_discarded(delivery_id, reason, now) do
+    case Repo.get(WebhookDeliveryLedger, delivery_id) do
+      nil ->
+        :ok
+
+      row ->
+        persist_update(row, %{
+          status: "discarded",
+          reason: reason,
+          discarded_at: now,
+          updated_at: now
+        })
+    end
+  end
+
+  @spec list(keyword()) :: [WebhookDeliveryLedger.t()]
+  def list(opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    opts
+    |> base_query()
+    |> limit(^limit)
+    |> Canary.Repos.read_repo().all()
+  end
+
+  @spec page(keyword()) ::
+          {:ok,
+           %{
+             deliveries: [WebhookDeliveryLedger.t()],
+             returned_count: non_neg_integer(),
+             cursor: String.t() | nil
+           }}
+          | {:error, :invalid_limit | :invalid_cursor}
+  def page(opts \\ []) do
+    with {:ok, limit} <- parse_limit(Keyword.get(opts, :limit)),
+         {:ok, cursor} <- decode_cursor(Keyword.get(opts, :cursor)) do
+      rows =
+        opts
+        |> base_query()
+        |> maybe_apply_cursor(cursor)
+        |> limit(^(limit + 1))
+        |> Canary.Repos.read_repo().all()
+
+      {deliveries, next_cursor} = paginate(rows, limit)
+
+      {:ok,
+       %{
+         deliveries: deliveries,
+         returned_count: length(deliveries),
+         cursor: next_cursor
+       }}
+    end
+  end
+
+  defp base_query(opts) do
+    from(d in WebhookDeliveryLedger, order_by: [desc: d.created_at, desc: d.delivery_id])
+    |> maybe_filter_delivery_id(Keyword.get(opts, :delivery_id))
+    |> maybe_filter_webhook_id(Keyword.get(opts, :webhook_id))
+    |> maybe_filter_event(Keyword.get(opts, :event))
+    |> maybe_filter_status(Keyword.get(opts, :status))
+  end
+
+  defp maybe_filter_delivery_id(query, nil), do: query
+
+  defp maybe_filter_delivery_id(query, delivery_id),
+    do: from(d in query, where: d.delivery_id == ^delivery_id)
+
+  defp maybe_filter_webhook_id(query, nil), do: query
+
+  defp maybe_filter_webhook_id(query, webhook_id),
+    do: from(d in query, where: d.webhook_id == ^webhook_id)
+
+  defp maybe_filter_event(query, nil), do: query
+  defp maybe_filter_event(query, event), do: from(d in query, where: d.event == ^event)
+
+  defp maybe_filter_status(query, nil), do: query
+  defp maybe_filter_status(query, status), do: from(d in query, where: d.status == ^status)
+
+  defp parse_limit(nil), do: {:ok, @default_limit}
+
+  defp parse_limit(limit) when is_integer(limit) and limit > 0 and limit <= @max_limit,
+    do: {:ok, limit}
+
+  defp parse_limit(limit) when is_binary(limit) do
+    case Integer.parse(limit) do
+      {value, ""} when value > 0 and value <= @max_limit -> {:ok, value}
+      _ -> {:error, :invalid_limit}
+    end
+  end
+
+  defp parse_limit(_), do: {:error, :invalid_limit}
+
+  defp decode_cursor(nil), do: {:ok, nil}
+  defp decode_cursor(""), do: {:ok, nil}
+
+  defp decode_cursor(cursor) when is_binary(cursor) do
+    with {:ok, decoded} <- Base.url_decode64(cursor, padding: false),
+         {:ok, %{"created_at" => created_at, "delivery_id" => delivery_id}} <-
+           Jason.decode(decoded),
+         true <- is_binary(created_at) and is_binary(delivery_id) do
+      {:ok, %{created_at: created_at, delivery_id: delivery_id}}
+    else
+      _ -> {:error, :invalid_cursor}
+    end
+  end
+
+  defp decode_cursor(_), do: {:error, :invalid_cursor}
+
+  defp maybe_apply_cursor(query, nil), do: query
+
+  defp maybe_apply_cursor(query, %{created_at: created_at, delivery_id: delivery_id}) do
+    from(d in query,
+      where:
+        d.created_at < ^created_at or
+          (d.created_at == ^created_at and d.delivery_id < ^delivery_id)
+    )
+  end
+
+  defp paginate(rows, limit) do
+    {page, rest} = Enum.split(rows, limit)
+
+    next_cursor =
+      case {rest, List.last(page)} do
+        {[], _} -> nil
+        {_, nil} -> nil
+        {_, last} -> encode_cursor(last)
+      end
+
+    {page, next_cursor}
+  end
+
+  defp encode_cursor(row) do
+    %{created_at: row.created_at, delivery_id: row.delivery_id}
+    |> Jason.encode!()
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp persist_update(row, attrs) do
+    row
+    |> WebhookDeliveryLedger.changeset(attrs)
+    |> Repo.update()
+    |> log_result("update webhook delivery #{row.delivery_id}")
+  end
+
+  defp log_result({:ok, _row}, _action), do: :ok
+
+  defp log_result({:error, changeset}, action) do
+    Logger.error("Failed to #{action}: #{inspect(changeset.errors)}")
+    :ok
+  end
+end

--- a/lib/canary/webhook_deliveries.ex
+++ b/lib/canary/webhook_deliveries.ex
@@ -57,21 +57,24 @@ defmodule Canary.WebhookDeliveries do
 
   @spec mark_attempt(String.t(), String.t()) :: :ok
   def mark_attempt(delivery_id, now) do
-    case Repo.get(WebhookDeliveryLedger, delivery_id) do
-      nil ->
-        :ok
+    from(d in WebhookDeliveryLedger,
+      where: d.delivery_id == ^delivery_id,
+      update: [
+        set: [
+          status:
+            fragment(
+              "CASE WHEN status IN ('pending', 'retrying') THEN 'retrying' ELSE status END"
+            ),
+          attempt_count: fragment("attempt_count + 1"),
+          first_attempt_at: fragment("COALESCE(first_attempt_at, ?)", ^now),
+          last_attempt_at: ^now,
+          updated_at: ^now
+        ]
+      ]
+    )
+    |> Repo.update_all([])
 
-      row ->
-        attrs = %{
-          status: if(row.status in ["pending", "retrying"], do: "retrying", else: row.status),
-          attempt_count: row.attempt_count + 1,
-          first_attempt_at: row.first_attempt_at || now,
-          last_attempt_at: now,
-          updated_at: now
-        }
-
-        persist_update(row, attrs)
-    end
+    :ok
   end
 
   @spec mark_delivered(String.t(), String.t()) :: :ok

--- a/lib/canary/workers/webhook_delivery.ex
+++ b/lib/canary/workers/webhook_delivery.ex
@@ -10,7 +10,7 @@ defmodule Canary.Workers.WebhookDelivery do
     priority: 1
 
   alias Canary.Alerter.{CircuitBreaker, Cooldown, Signer}
-  alias Canary.WebhookDeliveries
+  alias Canary.{Repo, WebhookDeliveries}
   alias Canary.Schemas.Webhook
   import Ecto.Query
 
@@ -72,12 +72,19 @@ defmodule Canary.Workers.WebhookDelivery do
       if Cooldown.in_cooldown?(cooldown_key) do
         WebhookDeliveries.create_suppressed(delivery_id, webhook.id, event, "cooldown", now)
       else
-        Cooldown.mark(cooldown_key)
-        WebhookDeliveries.create_pending(delivery_id, webhook.id, event, now)
+        case enqueue_delivery(webhook, payload, event, delivery_id, now) do
+          :ok ->
+            Cooldown.mark(cooldown_key)
 
-        %{webhook_id: webhook.id, payload: payload, event: event, delivery_id: delivery_id}
-        |> __MODULE__.new()
-        |> Oban.insert()
+          {:error, reason} ->
+            Logger.error("Failed to enqueue webhook delivery",
+              webhook_id: webhook.id,
+              event: event,
+              reason: inspect(reason)
+            )
+
+            WebhookDeliveries.mark_discarded(delivery_id, "enqueue_failed", now)
+        end
       end
     end)
 
@@ -160,6 +167,27 @@ defmodule Canary.Workers.WebhookDelivery do
         reason,
         DateTime.utc_now() |> DateTime.to_iso8601()
       )
+    end
+  end
+
+  defp enqueue_delivery(webhook, payload, event, delivery_id, now) do
+    args = %{webhook_id: webhook.id, payload: payload, event: event, delivery_id: delivery_id}
+
+    try do
+      Repo.transaction(fn ->
+        WebhookDeliveries.create_pending(delivery_id, webhook.id, event, now)
+
+        case args |> __MODULE__.new() |> Oban.insert() do
+          {:ok, _job} -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, :ok} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    rescue
+      error -> {:error, {:exception, error}}
     end
   end
 

--- a/lib/canary/workers/webhook_delivery.ex
+++ b/lib/canary/workers/webhook_delivery.ex
@@ -235,21 +235,23 @@ defmodule Canary.Workers.WebhookDelivery do
   defp stable_payload_hash(payload) do
     payload
     |> Map.drop(["timestamp", "sequence"])
-    |> canonicalize()
-    |> :erlang.term_to_binary()
-    |> then(&:crypto.hash(:sha256, &1))
-    |> Base.encode16(case: :lower)
+    |> stable_hash()
     |> then(&"payload:#{&1}")
   end
 
   defp stable_args_hash(args) do
     args
     |> Map.drop(["delivery_id"])
+    |> stable_hash()
+    |> String.slice(0, 24)
+  end
+
+  defp stable_hash(value) do
+    value
     |> canonicalize()
-    |> :erlang.term_to_binary()
+    |> :erlang.term_to_binary(minor_version: 1)
     |> then(&:crypto.hash(:sha256, &1))
     |> Base.encode16(case: :lower)
-    |> String.slice(0, 24)
   end
 
   defp canonicalize(value) when is_map(value) do

--- a/lib/canary/workers/webhook_delivery.ex
+++ b/lib/canary/workers/webhook_delivery.ex
@@ -10,6 +10,7 @@ defmodule Canary.Workers.WebhookDelivery do
     priority: 1
 
   alias Canary.Alerter.{CircuitBreaker, Cooldown, Signer}
+  alias Canary.WebhookDeliveries
   alias Canary.Schemas.Webhook
   import Ecto.Query
 
@@ -18,33 +19,41 @@ defmodule Canary.Workers.WebhookDelivery do
   @delivery_timeout 10_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{
-        args: %{"webhook_id" => webhook_id, "payload" => payload, "event" => event}
-      }) do
+  def perform(%Oban.Job{} = job) do
+    %{"webhook_id" => webhook_id, "payload" => payload, "event" => event} = job.args
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+    delivery_id = delivery_id_from_job(job)
+    WebhookDeliveries.create_pending(delivery_id, webhook_id, event, now)
+
     case Canary.Repos.read_repo().get(Webhook, webhook_id) do
       nil ->
         Logger.warning("Webhook #{webhook_id} not found, discarding")
+        WebhookDeliveries.mark_discarded(delivery_id, "webhook_not_found", now)
         :ok
 
       %Webhook{active: 0} ->
         Logger.info("Webhook #{webhook_id} inactive, skipping")
+        WebhookDeliveries.mark_discarded(delivery_id, "webhook_inactive", now)
         :ok
 
       webhook ->
-        deliver(webhook, payload, event)
+        deliver(webhook, payload, event, delivery_id, job)
     end
   end
 
   def deliver_test(webhook, payload, event) do
-    send_request(webhook, payload, event, false)
+    send_request(webhook, payload, event, Canary.ID.generate("DLV"), false, nil)
   end
 
-  def deliver(webhook, payload, event) do
+  def deliver(webhook, payload, event, delivery_id, job) do
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
     if CircuitBreaker.open?(webhook.id) and not CircuitBreaker.should_probe?(webhook.id) do
       Logger.info("Circuit open for #{webhook.id}, skipping")
+      WebhookDeliveries.create_suppressed(delivery_id, webhook.id, event, "circuit_open", now)
       :ok
     else
-      send_request(webhook, payload, event, true)
+      send_request(webhook, payload, event, delivery_id, true, job)
     end
   end
 
@@ -56,10 +65,17 @@ defmodule Canary.Workers.WebhookDelivery do
       |> Enum.filter(&Webhook.subscribes_to?(&1, event))
 
     Enum.each(webhooks, fn webhook ->
-      unless Cooldown.in_cooldown?("#{webhook.id}:#{event}") do
-        Cooldown.mark("#{webhook.id}:#{event}")
+      now = DateTime.utc_now() |> DateTime.to_iso8601()
+      delivery_id = Canary.ID.generate("DLV")
+      cooldown_key = cooldown_key(webhook.id, event, payload)
 
-        %{webhook_id: webhook.id, payload: payload, event: event}
+      if Cooldown.in_cooldown?(cooldown_key) do
+        WebhookDeliveries.create_suppressed(delivery_id, webhook.id, event, "cooldown", now)
+      else
+        Cooldown.mark(cooldown_key)
+        WebhookDeliveries.create_pending(delivery_id, webhook.id, event, now)
+
+        %{webhook_id: webhook.id, payload: payload, event: event, delivery_id: delivery_id}
         |> __MODULE__.new()
         |> Oban.insert()
       end
@@ -78,9 +94,10 @@ defmodule Canary.Workers.WebhookDelivery do
     end
   end
 
-  defp send_request(webhook, payload, event, track_circuit?) do
+  defp send_request(webhook, payload, event, delivery_id, track_circuit?, job) do
     body = Jason.encode!(payload)
-    delivery_id = Canary.ID.generate()
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+    if track_circuit?, do: WebhookDeliveries.mark_attempt(delivery_id, now)
 
     headers = [
       {"content-type", "application/json"},
@@ -99,19 +116,120 @@ defmodule Canary.Workers.WebhookDelivery do
            finch: Canary.Finch
          ) do
       {:ok, %{status: status}} when status in 200..299 ->
-        if track_circuit?, do: CircuitBreaker.record_success(webhook.id)
+        if track_circuit? do
+          CircuitBreaker.record_success(webhook.id)
+
+          WebhookDeliveries.mark_delivered(
+            delivery_id,
+            DateTime.utc_now() |> DateTime.to_iso8601()
+          )
+        end
+
         Logger.info("Webhook delivered to #{webhook.url}", event: event)
         :ok
 
       {:ok, %{status: status}} ->
-        if track_circuit?, do: CircuitBreaker.record_failure(webhook.id)
+        if track_circuit? do
+          CircuitBreaker.record_failure(webhook.id)
+          maybe_mark_final_discard(job, delivery_id, "http_#{status}")
+        end
+
         Logger.warning("Webhook delivery failed: HTTP #{status}", event: event)
         {:error, "HTTP #{status}"}
 
       {:error, reason} ->
-        if track_circuit?, do: CircuitBreaker.record_failure(webhook.id)
+        if track_circuit? do
+          CircuitBreaker.record_failure(webhook.id)
+          maybe_mark_final_discard(job, delivery_id, "request_error")
+        end
+
         Logger.warning("Webhook delivery error: #{inspect(reason)}", event: event)
         {:error, inspect(reason)}
     end
   end
+
+  defp maybe_mark_final_discard(nil, _delivery_id, _reason), do: :ok
+
+  defp maybe_mark_final_discard(%Oban.Job{} = job, delivery_id, reason) do
+    attempt = job.attempt || 1
+    max_attempts = job.max_attempts || __opts__()[:max_attempts] || 4
+
+    if attempt >= max_attempts do
+      WebhookDeliveries.mark_discarded(
+        delivery_id,
+        reason,
+        DateTime.utc_now() |> DateTime.to_iso8601()
+      )
+    end
+  end
+
+  defp delivery_id_from_job(%Oban.Job{args: %{"delivery_id" => delivery_id}})
+       when is_binary(delivery_id),
+       do: delivery_id
+
+  defp delivery_id_from_job(%Oban.Job{id: job_id}) when is_integer(job_id),
+    do: "DLV-legacy-#{job_id}"
+
+  defp delivery_id_from_job(%Oban.Job{args: args}), do: "DLV-legacy-#{stable_args_hash(args)}"
+
+  defp cooldown_key(webhook_id, event, payload) do
+    identity =
+      case payload_identity(payload) do
+        nil -> "payload"
+        value -> value
+      end
+
+    "#{webhook_id}:#{event}:#{identity}"
+  end
+
+  defp payload_identity(payload) when is_map(payload) do
+    cond do
+      is_binary(get_in(payload, ["error", "group_hash"])) ->
+        "error_group:#{get_in(payload, ["error", "group_hash"])}"
+
+      is_binary(get_in(payload, ["incident", "id"])) ->
+        "incident:#{get_in(payload, ["incident", "id"])}"
+
+      is_map(payload["target"]) ->
+        target = payload["target"]
+        service = target["service"] || ""
+        name = target["name"] || ""
+        url = target["url"] || ""
+        "target:#{service}:#{name}:#{url}"
+
+      true ->
+        stable_payload_hash(payload)
+    end
+  end
+
+  defp payload_identity(_), do: nil
+
+  defp stable_payload_hash(payload) do
+    payload
+    |> Map.drop(["timestamp", "sequence"])
+    |> canonicalize()
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+    |> then(&"payload:#{&1}")
+  end
+
+  defp stable_args_hash(args) do
+    args
+    |> Map.drop(["delivery_id"])
+    |> canonicalize()
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+    |> String.slice(0, 24)
+  end
+
+  defp canonicalize(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, nested} -> {key, canonicalize(nested)} end)
+    |> Enum.sort_by(fn {key, _nested} -> key end)
+  end
+
+  defp canonicalize(value) when is_list(value), do: Enum.map(value, &canonicalize/1)
+  defp canonicalize(value), do: value
 end

--- a/lib/canary_web/controllers/webhook_delivery_controller.ex
+++ b/lib/canary_web/controllers/webhook_delivery_controller.ex
@@ -42,13 +42,13 @@ defmodule CanaryWeb.WebhookDeliveryController do
         )
 
       {:error, {:invalid_param, param}} ->
-        param = to_string(param)
+        param_str = to_string(param)
 
         CanaryWeb.Plugs.ProblemDetails.render_error(
           conn,
           422,
           "validation_error",
-          "Invalid #{param} parameter. Must be a string.",
+          "Invalid #{param_str} parameter. Must be a string.",
           %{errors: %{param => ["must be a string"]}}
         )
 

--- a/lib/canary_web/controllers/webhook_delivery_controller.ex
+++ b/lib/canary_web/controllers/webhook_delivery_controller.ex
@@ -1,0 +1,107 @@
+defmodule CanaryWeb.WebhookDeliveryController do
+  use CanaryWeb, :controller
+
+  alias Canary.WebhookDeliveries
+
+  def index(conn, params) do
+    cursor = Map.get(params, "after") || Map.get(params, "cursor")
+
+    with :ok <- validate_string_param(:webhook_id, Map.get(params, "webhook_id")),
+         :ok <- validate_string_param(:event, Map.get(params, "event")),
+         :ok <- validate_status(Map.get(params, "status")),
+         {:ok, page} <-
+           WebhookDeliveries.page(
+             webhook_id: Map.get(params, "webhook_id"),
+             event: Map.get(params, "event"),
+             status: Map.get(params, "status"),
+             limit: Map.get(params, "limit"),
+             cursor: cursor
+           ) do
+      json(conn, %{
+        returned_count: page.returned_count,
+        cursor: page.cursor,
+        deliveries: Enum.map(page.deliveries, &format_delivery/1)
+      })
+    else
+      {:error, :invalid_limit} ->
+        CanaryWeb.Plugs.ProblemDetails.render_error(
+          conn,
+          422,
+          "validation_error",
+          "Invalid limit. Expected a positive integer up to 200.",
+          %{errors: %{limit: ["must be a positive integer no greater than 200"]}}
+        )
+
+      {:error, :invalid_cursor} ->
+        CanaryWeb.Plugs.ProblemDetails.render_error(
+          conn,
+          422,
+          "validation_error",
+          "Invalid cursor.",
+          %{errors: %{cursor: ["must be a valid pagination cursor"]}}
+        )
+
+      {:error, {:invalid_param, param}} ->
+        param = to_string(param)
+
+        CanaryWeb.Plugs.ProblemDetails.render_error(
+          conn,
+          422,
+          "validation_error",
+          "Invalid #{param} parameter. Must be a string.",
+          %{errors: %{param => ["must be a string"]}}
+        )
+
+      {:error, :invalid_status} ->
+        allowed = WebhookDeliveries.statuses() |> Enum.join(", ")
+
+        CanaryWeb.Plugs.ProblemDetails.render_error(
+          conn,
+          422,
+          "validation_error",
+          "Invalid status. Allowed: #{allowed}",
+          %{errors: %{status: ["must be one of: #{allowed}"]}}
+        )
+    end
+  end
+
+  defp validate_string_param(_name, nil), do: :ok
+  defp validate_string_param(_name, value) when is_binary(value), do: :ok
+  defp validate_string_param(name, _value), do: {:error, {:invalid_param, name}}
+
+  defp validate_status(nil), do: :ok
+
+  defp validate_status(status) when is_binary(status) do
+    if status in WebhookDeliveries.statuses(), do: :ok, else: {:error, :invalid_status}
+  end
+
+  defp validate_status(_status), do: {:error, {:invalid_param, :status}}
+
+  defp format_delivery(delivery) do
+    %{
+      delivery_id: delivery.delivery_id,
+      webhook_id: delivery.webhook_id,
+      event: delivery.event,
+      status: delivery.status,
+      attempt_count: delivery.attempt_count,
+      reason: delivery.reason,
+      first_attempt_at: delivery.first_attempt_at,
+      last_attempt_at: delivery.last_attempt_at,
+      delivered_at: delivery.delivered_at,
+      discarded_at: delivery.discarded_at,
+      completed_at: completed_at(delivery),
+      created_at: delivery.created_at,
+      updated_at: delivery.updated_at
+    }
+  end
+
+  defp completed_at(%{delivered_at: value}) when is_binary(value), do: value
+  defp completed_at(%{discarded_at: value}) when is_binary(value), do: value
+
+  defp completed_at(%{status: status, updated_at: updated_at})
+       when status in ["suppressed", "discarded", "delivered"] do
+    updated_at
+  end
+
+  defp completed_at(_), do: nil
+end

--- a/lib/canary_web/router.ex
+++ b/lib/canary_web/router.ex
@@ -80,6 +80,7 @@ defmodule CanaryWeb.Router do
       get "/errors/:id", QueryController, :show
       get "/report", ReportController, :index
       get "/timeline", TimelineController, :index
+      get "/webhook-deliveries", WebhookDeliveryController, :index
       get "/status", StatusController, :index
       get "/health-status", HealthController, :status
       get "/targets/:id/checks", HealthController, :target_checks

--- a/priv/repo/migrations/20260402230500_create_webhook_deliveries.exs
+++ b/priv/repo/migrations/20260402230500_create_webhook_deliveries.exs
@@ -1,0 +1,24 @@
+defmodule Canary.Repo.Migrations.CreateWebhookDeliveries do
+  use Ecto.Migration
+
+  def change do
+    create table(:webhook_deliveries, primary_key: false) do
+      add :delivery_id, :string, primary_key: true
+      add :webhook_id, :string, null: false
+      add :event, :string, null: false
+      add :status, :string, null: false
+      add :attempt_count, :integer, null: false, default: 0
+      add :reason, :string
+      add :first_attempt_at, :string
+      add :last_attempt_at, :string
+      add :delivered_at, :string
+      add :discarded_at, :string
+      add :created_at, :string, null: false
+      add :updated_at, :string, null: false
+    end
+
+    create index(:webhook_deliveries, [:webhook_id, :created_at])
+    create index(:webhook_deliveries, [:event, :created_at])
+    create index(:webhook_deliveries, [:status, :created_at])
+  end
+end

--- a/priv/repo/migrations/20260402230500_create_webhook_deliveries.exs
+++ b/priv/repo/migrations/20260402230500_create_webhook_deliveries.exs
@@ -17,8 +17,9 @@ defmodule Canary.Repo.Migrations.CreateWebhookDeliveries do
       add :updated_at, :string, null: false
     end
 
-    create index(:webhook_deliveries, [:webhook_id, :created_at])
-    create index(:webhook_deliveries, [:event, :created_at])
-    create index(:webhook_deliveries, [:status, :created_at])
+    create index(:webhook_deliveries, [:created_at, :delivery_id])
+    create index(:webhook_deliveries, [:webhook_id, :created_at, :delivery_id])
+    create index(:webhook_deliveries, [:event, :created_at, :delivery_id])
+    create index(:webhook_deliveries, [:status, :created_at, :delivery_id])
   end
 end

--- a/spec.md
+++ b/spec.md
@@ -560,7 +560,7 @@ Probe history for a specific target. Returns individual check results for debugg
 
 **At-least-once, unordered, lossy on restart.**
 
-Webhooks may be delivered more than once (use `X-Delivery-Id` to deduplicate). Order is not guaranteed across events, but `sequence` numbers within a target/group allow consumers to ignore stale state. In-flight deliveries are lost on process restart (no persistent queue in v1).
+Webhooks may be delivered more than once (use `X-Delivery-Id` to deduplicate). `X-Delivery-Id` is stable across retries for the same logical delivery. Order is not guaranteed across events, but `sequence` numbers within a target/group allow consumers to ignore stale state. In-flight deliveries are lost on process restart (no persistent queue in v1).
 
 ### Signing
 
@@ -571,7 +571,7 @@ All webhooks signed with HMAC-SHA256 using the subscription's secret.
 ```
 X-Signature: sha256=<hex digest of body>
 X-Event: health_check.down
-X-Delivery-Id: <uuid>
+X-Delivery-Id: DLV-<nanoid>
 X-Webhook-Version: 1
 X-Sequence: 42
 Content-Type: application/json
@@ -619,11 +619,13 @@ Content-Type: application/json
 
 ### Delivery
 
-- **Retry:** 3 attempts with exponential backoff (1s, 5s, 30s)
+- **Retry:** 4 attempts with exponential backoff (1s, 5s, 30s, 60s)
 - **Timeout:** 10s per delivery attempt
-- **Idempotency:** `X-Delivery-Id` header for consumer deduplication
+- **Idempotency:** `X-Delivery-Id` header for consumer deduplication; stable across retries for the same delivery
+- **Correctness:** Treat webhooks as wake-up hints. Replay from timeline or query APIs for authoritative state.
 - **Circuit breaker:** After 10 consecutive delivery failures to a webhook URL, mark subscription as `suspended`. Probe periodically (every 5 min) to re-enable.
-- **No dead letter queue** (v1) — failed deliveries are logged (structured), not persisted
+- **Delivery ledger:** `GET /api/v1/webhook-deliveries` exposes final status, attempt count, timestamps, reasons, and cursor-paginated history for operator visibility
+- **No dead letter queue** (v1) — replay/DLQ remains follow-up work
 - **Cooldown:** Per-group cooldown prevents webhook flood from flapping or exception loops (5 min default)
 - **Webhook URL validation:** HTTPS required by default. HTTP allowed only with explicit `--allow-insecure` flag.
 

--- a/test/canary/workers/webhook_delivery_test.exs
+++ b/test/canary/workers/webhook_delivery_test.exs
@@ -1,8 +1,9 @@
 defmodule Canary.Workers.WebhookDeliveryTest do
   use Canary.DataCase
 
+  alias Canary.WebhookDeliveries
   alias Canary.Workers.WebhookDelivery
-  alias Canary.Alerter.{CircuitBreaker, Cooldown, Signer}
+  alias Canary.Alerter.{CircuitBreaker, Signer}
   alias Canary.Schemas.Webhook
 
   setup do
@@ -35,29 +36,124 @@ defmodule Canary.Workers.WebhookDeliveryTest do
   describe "perform/1" do
     test "delivers with HMAC signature", %{bypass: bypass, webhook_id: wid, secret: secret} do
       payload = %{"event" => "error.new_class", "data" => %{"id" => "ERR-test"}}
+      delivery_id = Canary.ID.generate("DLV")
 
       Bypass.expect_once(bypass, "POST", "/hook", fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         [signature] = Plug.Conn.get_req_header(conn, "x-signature")
         [event] = Plug.Conn.get_req_header(conn, "x-event")
+        [header_delivery_id] = Plug.Conn.get_req_header(conn, "x-delivery-id")
 
         assert String.starts_with?(signature, "sha256=")
         assert Signer.verify(body, secret, signature)
         assert event == "error.new_class"
+        assert header_delivery_id == delivery_id
 
         Plug.Conn.resp(conn, 200, "ok")
       end)
 
       job = %Oban.Job{
-        args: %{"webhook_id" => wid, "payload" => payload, "event" => "error.new_class"}
+        args: %{
+          "webhook_id" => wid,
+          "payload" => payload,
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
       }
 
       assert :ok = WebhookDelivery.perform(job)
+
+      [row] = WebhookDeliveries.list(webhook_id: wid, event: "error.new_class")
+      assert row.delivery_id == delivery_id
+      assert row.status == "delivered"
+      assert row.attempt_count == 1
+      assert is_binary(row.first_attempt_at)
+      assert is_binary(row.last_attempt_at)
+      assert is_binary(row.delivered_at)
+      assert is_nil(row.reason)
+    end
+
+    test "uses a stable delivery id across retry attempts", %{bypass: bypass, webhook_id: wid} do
+      payload = %{"event" => "error.new_class", "error" => %{"group_hash" => "grp-stable"}}
+      delivery_id = Canary.ID.generate("DLV")
+      test_pid = self()
+
+      Bypass.stub(bypass, "POST", "/hook", fn conn ->
+        [header_delivery_id] = Plug.Conn.get_req_header(conn, "x-delivery-id")
+        send(test_pid, {:delivery_id, header_delivery_id})
+        Plug.Conn.resp(conn, 500, "Internal Server Error")
+      end)
+
+      first = %Oban.Job{
+        attempt: 1,
+        max_attempts: 4,
+        args: %{
+          "webhook_id" => wid,
+          "payload" => payload,
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
+      }
+
+      second = %Oban.Job{
+        attempt: 2,
+        max_attempts: 4,
+        args: %{
+          "webhook_id" => wid,
+          "payload" => payload,
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
+      }
+
+      assert {:error, "HTTP 500"} = WebhookDelivery.perform(first)
+      assert {:error, "HTTP 500"} = WebhookDelivery.perform(second)
+
+      assert_receive {:delivery_id, ^delivery_id}
+      assert_receive {:delivery_id, ^delivery_id}
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "retrying"
+      assert row.attempt_count == 2
+    end
+
+    test "derives a stable delivery id for legacy jobs without delivery_id", %{
+      bypass: bypass,
+      webhook_id: wid
+    } do
+      payload = %{"event" => "error.new_class", "error" => %{"group_hash" => "grp-legacy"}}
+      test_pid = self()
+
+      Bypass.stub(bypass, "POST", "/hook", fn conn ->
+        [header_delivery_id] = Plug.Conn.get_req_header(conn, "x-delivery-id")
+        send(test_pid, {:legacy_delivery_id, header_delivery_id})
+        Plug.Conn.resp(conn, 500, "Internal Server Error")
+      end)
+
+      first = %Oban.Job{
+        id: 42,
+        attempt: 1,
+        max_attempts: 4,
+        args: %{"webhook_id" => wid, "payload" => payload, "event" => "error.new_class"}
+      }
+
+      second = %{first | attempt: 2}
+
+      assert {:error, "HTTP 500"} = WebhookDelivery.perform(first)
+      assert {:error, "HTTP 500"} = WebhookDelivery.perform(second)
+
+      assert_receive {:legacy_delivery_id, legacy_delivery_id}
+      assert_receive {:legacy_delivery_id, ^legacy_delivery_id}
+
+      [row] = WebhookDeliveries.list(delivery_id: legacy_delivery_id)
+      assert row.attempt_count == 2
+      assert row.status == "retrying"
     end
 
     test "skips when circuit breaker is open", %{bypass: bypass, webhook_id: wid} do
       for _ <- 1..10, do: CircuitBreaker.record_failure(wid)
       assert CircuitBreaker.open?(wid)
+      delivery_id = Canary.ID.generate("DLV")
 
       test_pid = self()
 
@@ -67,41 +163,110 @@ defmodule Canary.Workers.WebhookDeliveryTest do
       end)
 
       job = %Oban.Job{
-        args: %{"webhook_id" => wid, "payload" => %{}, "event" => "error.new_class"}
+        args: %{
+          "webhook_id" => wid,
+          "payload" => %{},
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
       }
 
       assert :ok = WebhookDelivery.perform(job)
       refute_received :webhook_delivered
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "suppressed"
+      assert row.reason == "circuit_open"
+      assert row.attempt_count == 0
     end
 
     test "returns error on non-2xx response", %{bypass: bypass, webhook_id: wid} do
+      delivery_id = Canary.ID.generate("DLV")
+
       Bypass.expect_once(bypass, "POST", "/hook", fn conn ->
         Plug.Conn.resp(conn, 500, "Internal Server Error")
       end)
 
       job = %Oban.Job{
-        args: %{"webhook_id" => wid, "payload" => %{}, "event" => "error.new_class"}
+        args: %{
+          "webhook_id" => wid,
+          "payload" => %{},
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
       }
 
       assert {:error, "HTTP 500"} = WebhookDelivery.perform(job)
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "retrying"
+      assert row.attempt_count == 1
+    end
+
+    test "marks the final retry as discarded", %{bypass: bypass, webhook_id: wid} do
+      delivery_id = Canary.ID.generate("DLV")
+
+      Bypass.expect_once(bypass, "POST", "/hook", fn conn ->
+        Plug.Conn.resp(conn, 500, "Internal Server Error")
+      end)
+
+      job = %Oban.Job{
+        attempt: 4,
+        max_attempts: 4,
+        args: %{
+          "webhook_id" => wid,
+          "payload" => %{},
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
+      }
+
+      assert {:error, "HTTP 500"} = WebhookDelivery.perform(job)
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "discarded"
+      assert row.reason == "http_500"
+      assert row.attempt_count == 1
+      assert is_binary(row.discarded_at)
     end
 
     test "returns error on connection failure", %{bypass: bypass, webhook_id: wid} do
       Bypass.down(bypass)
+      delivery_id = Canary.ID.generate("DLV")
 
       job = %Oban.Job{
-        args: %{"webhook_id" => wid, "payload" => %{}, "event" => "error.new_class"}
+        args: %{
+          "webhook_id" => wid,
+          "payload" => %{},
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
       }
 
       assert {:error, _reason} = WebhookDelivery.perform(job)
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "retrying"
+      assert row.attempt_count == 1
     end
 
     test "discards when webhook not found" do
+      delivery_id = Canary.ID.generate("DLV")
+
       job = %Oban.Job{
-        args: %{"webhook_id" => "WHK-nonexistent", "payload" => %{}, "event" => "x"}
+        args: %{
+          "webhook_id" => "WHK-nonexistent",
+          "payload" => %{},
+          "event" => "x",
+          "delivery_id" => delivery_id
+        }
       }
 
       assert :ok = WebhookDelivery.perform(job)
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "discarded"
+      assert row.reason == "webhook_not_found"
     end
 
     test "skips when webhook inactive", %{bypass: bypass, webhook_id: wid} do
@@ -109,6 +274,8 @@ defmodule Canary.Workers.WebhookDeliveryTest do
       |> Webhook.changeset(%{active: 0})
       |> Repo.update!()
 
+      delivery_id = Canary.ID.generate("DLV")
+
       test_pid = self()
 
       Bypass.stub(bypass, "POST", "/hook", fn conn ->
@@ -117,18 +284,25 @@ defmodule Canary.Workers.WebhookDeliveryTest do
       end)
 
       job = %Oban.Job{
-        args: %{"webhook_id" => wid, "payload" => %{}, "event" => "error.new_class"}
+        args: %{
+          "webhook_id" => wid,
+          "payload" => %{},
+          "event" => "error.new_class",
+          "delivery_id" => delivery_id
+        }
       }
 
       assert :ok = WebhookDelivery.perform(job)
       refute_received :webhook_delivered
+
+      [row] = WebhookDeliveries.list(delivery_id: delivery_id)
+      assert row.status == "discarded"
+      assert row.reason == "webhook_inactive"
     end
   end
 
   describe "enqueue_for_event/2" do
-    test "skips delivery when cooldown active", %{bypass: bypass, webhook_id: wid} do
-      Cooldown.mark("#{wid}:error.new_class")
-
+    test "records cooldown suppression in ledger", %{bypass: bypass} do
       test_pid = self()
 
       Bypass.stub(bypass, "POST", "/hook", fn conn ->
@@ -136,8 +310,19 @@ defmodule Canary.Workers.WebhookDeliveryTest do
         Plug.Conn.resp(conn, 200, "ok")
       end)
 
-      WebhookDelivery.enqueue_for_event("error.new_class", %{"data" => "test"})
+      payload = %{"event" => "error.new_class", "error" => %{"group_hash" => "grp-cooldown"}}
+      WebhookDelivery.enqueue_for_event("error.new_class", payload)
+      WebhookDelivery.enqueue_for_event("error.new_class", payload)
+
+      assert_receive :webhook_delivered
       refute_received :webhook_delivered
+
+      deliveries = WebhookDeliveries.list(event: "error.new_class")
+
+      assert Enum.any?(
+               deliveries,
+               &(&1.status == "suppressed" and &1.reason == "cooldown")
+             )
     end
 
     test "delivers when cooldown not active", %{bypass: bypass} do
@@ -146,6 +331,62 @@ defmodule Canary.Workers.WebhookDeliveryTest do
       end)
 
       WebhookDelivery.enqueue_for_event("error.new_class", %{"data" => "test"})
+    end
+
+    test "uses payload identity in cooldown key so distinct groups are not collapsed", %{
+      bypass: bypass
+    } do
+      test_pid = self()
+
+      Bypass.stub(bypass, "POST", "/hook", fn conn ->
+        send(test_pid, :webhook_delivered)
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      WebhookDelivery.enqueue_for_event("error.new_class", %{
+        "event" => "error.new_class",
+        "error" => %{"group_hash" => "grp-a"}
+      })
+
+      WebhookDelivery.enqueue_for_event("error.new_class", %{
+        "event" => "error.new_class",
+        "error" => %{"group_hash" => "grp-b"}
+      })
+
+      assert_receive :webhook_delivered
+      assert_receive :webhook_delivered
+
+      deliveries = WebhookDeliveries.list(event: "error.new_class")
+      assert Enum.count(deliveries) == 2
+      assert Enum.all?(deliveries, &(&1.status == "delivered"))
+    end
+
+    test "canonicalizes fallback payload identity before hashing", %{bypass: bypass} do
+      test_pid = self()
+
+      Bypass.stub(bypass, "POST", "/hook", fn conn ->
+        send(test_pid, :webhook_delivered)
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      WebhookDelivery.enqueue_for_event("error.new_class", %{
+        "alpha" => 1,
+        "nested" => %{"a" => 1, "b" => 2},
+        "timestamp" => "2026-04-02T12:00:00Z"
+      })
+
+      WebhookDelivery.enqueue_for_event("error.new_class", %{
+        "nested" => %{"b" => 2, "a" => 1},
+        "timestamp" => "2026-04-02T12:05:00Z",
+        "alpha" => 1
+      })
+
+      assert_receive :webhook_delivered
+      refute_received :webhook_delivered
+
+      deliveries = WebhookDeliveries.list(event: "error.new_class")
+
+      assert Enum.any?(deliveries, &(&1.status == "suppressed" and &1.reason == "cooldown"))
     end
 
     test "skips webhooks not subscribed to event", %{bypass: bypass} do

--- a/test/canary_web/controllers/webhook_delivery_controller_test.exs
+++ b/test/canary_web/controllers/webhook_delivery_controller_test.exs
@@ -1,0 +1,188 @@
+defmodule CanaryWeb.WebhookDeliveryControllerTest do
+  use CanaryWeb.ConnCase
+
+  alias Canary.WebhookDeliveries
+
+  setup %{conn: conn} do
+    {raw_key, _key} = create_api_key()
+    conn = authenticate(conn, raw_key)
+    {:ok, conn: conn}
+  end
+
+  describe "GET /api/v1/webhook-deliveries" do
+    test "lists deliveries newest first with filters and bounded fields", %{conn: conn} do
+      assert :ok =
+               WebhookDeliveries.create_pending(
+                 "DLV-old",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "2026-04-02T10:00:00Z"
+               )
+
+      assert :ok = WebhookDeliveries.mark_attempt("DLV-old", "2026-04-02T10:00:01Z")
+      assert :ok = WebhookDeliveries.mark_delivered("DLV-old", "2026-04-02T10:00:02Z")
+
+      assert :ok =
+               WebhookDeliveries.create_suppressed(
+                 "DLV-suppressed",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "cooldown",
+                 "2026-04-02T10:05:00Z"
+               )
+
+      assert :ok =
+               WebhookDeliveries.create_pending(
+                 "DLV-other",
+                 "WHK-beta",
+                 "incident.updated",
+                 "2026-04-02T10:10:00Z"
+               )
+
+      assert :ok = WebhookDeliveries.mark_attempt("DLV-other", "2026-04-02T10:10:01Z")
+
+      assert :ok =
+               WebhookDeliveries.mark_discarded("DLV-other", "http_500", "2026-04-02T10:10:02Z")
+
+      conn =
+        get(conn, "/api/v1/webhook-deliveries", %{
+          "webhook_id" => "WHK-alpha",
+          "limit" => "2"
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["returned_count"] == 2
+      assert Enum.map(body["deliveries"], & &1["delivery_id"]) == ["DLV-suppressed", "DLV-old"]
+      assert is_nil(body["cursor"])
+
+      [suppressed, delivered] = body["deliveries"]
+
+      assert suppressed["status"] == "suppressed"
+      assert suppressed["reason"] == "cooldown"
+      assert suppressed["completed_at"] == "2026-04-02T10:05:00Z"
+      assert suppressed["attempt_count"] == 0
+
+      assert delivered["status"] == "delivered"
+      assert delivered["attempt_count"] == 1
+      assert delivered["first_attempt_at"] == "2026-04-02T10:00:01Z"
+      assert delivered["last_attempt_at"] == "2026-04-02T10:00:01Z"
+      assert delivered["delivered_at"] == "2026-04-02T10:00:02Z"
+      assert delivered["completed_at"] == "2026-04-02T10:00:02Z"
+    end
+
+    test "filters by status", %{conn: conn} do
+      assert :ok =
+               WebhookDeliveries.create_suppressed(
+                 "DLV-cooldown",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "cooldown",
+                 "2026-04-02T11:00:00Z"
+               )
+
+      assert :ok =
+               WebhookDeliveries.create_pending(
+                 "DLV-discarded",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "2026-04-02T11:01:00Z"
+               )
+
+      assert :ok = WebhookDeliveries.mark_attempt("DLV-discarded", "2026-04-02T11:01:01Z")
+
+      assert :ok =
+               WebhookDeliveries.mark_discarded(
+                 "DLV-discarded",
+                 "http_500",
+                 "2026-04-02T11:01:02Z"
+               )
+
+      conn = get(conn, "/api/v1/webhook-deliveries", %{"status" => "suppressed"})
+      body = json_response(conn, 200)
+
+      assert body["returned_count"] == 1
+      assert Enum.map(body["deliveries"], & &1["delivery_id"]) == ["DLV-cooldown"]
+    end
+
+    test "supports cursor pagination", %{conn: conn} do
+      assert :ok =
+               WebhookDeliveries.create_suppressed(
+                 "DLV-3",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "cooldown",
+                 "2026-04-02T12:03:00Z"
+               )
+
+      assert :ok =
+               WebhookDeliveries.create_suppressed(
+                 "DLV-2",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "cooldown",
+                 "2026-04-02T12:02:00Z"
+               )
+
+      assert :ok =
+               WebhookDeliveries.create_suppressed(
+                 "DLV-1",
+                 "WHK-alpha",
+                 "error.new_class",
+                 "cooldown",
+                 "2026-04-02T12:01:00Z"
+               )
+
+      first_conn = get(conn, "/api/v1/webhook-deliveries", %{"limit" => "2"})
+      first_body = json_response(first_conn, 200)
+
+      assert Enum.map(first_body["deliveries"], & &1["delivery_id"]) == ["DLV-3", "DLV-2"]
+      assert is_binary(first_body["cursor"])
+
+      second_conn =
+        get(conn, "/api/v1/webhook-deliveries", %{
+          "limit" => "2",
+          "cursor" => first_body["cursor"]
+        })
+
+      second_body = json_response(second_conn, 200)
+
+      assert Enum.map(second_body["deliveries"], & &1["delivery_id"]) == ["DLV-1"]
+      assert is_nil(second_body["cursor"])
+    end
+
+    test "rejects invalid limits", %{conn: conn} do
+      conn = get(conn, "/api/v1/webhook-deliveries", %{"limit" => "0"})
+      body = json_response(conn, 422)
+
+      assert body["code"] == "validation_error"
+      assert body["detail"] =~ "Invalid limit"
+      assert body["errors"]["limit"] == ["must be a positive integer no greater than 200"]
+    end
+
+    test "rejects invalid status values and filter types", %{conn: conn} do
+      invalid_status_conn = get(conn, "/api/v1/webhook-deliveries", %{"status" => "supressed"})
+      invalid_status_body = json_response(invalid_status_conn, 422)
+
+      assert invalid_status_body["code"] == "validation_error"
+
+      assert invalid_status_body["errors"]["status"] == [
+               "must be one of: pending, retrying, delivered, discarded, suppressed"
+             ]
+
+      invalid_type_conn = get(conn, "/api/v1/webhook-deliveries", %{"status" => ["suppressed"]})
+      invalid_type_body = json_response(invalid_type_conn, 422)
+
+      assert invalid_type_body["code"] == "validation_error"
+      assert invalid_type_body["errors"]["status"] == ["must be a string"]
+    end
+
+    test "rejects invalid cursors", %{conn: conn} do
+      conn = get(conn, "/api/v1/webhook-deliveries", %{"cursor" => "bogus"})
+      body = json_response(conn, 422)
+
+      assert body["code"] == "validation_error"
+      assert body["errors"]["cursor"] == ["must be a valid pagination cursor"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- persist outbound webhook deliveries in a new `webhook_deliveries` ledger with status, attempt counts, timestamps, and reason metadata
- generate stable `DLV-*` delivery IDs per logical delivery, reuse them across retries, and derive deterministic fallback IDs for legacy queued jobs
- record cooldown and circuit-open suppressions in the ledger, tighten cooldown identity to avoid collapsing distinct same-type events, and expose ledger reads via `GET /api/v1/webhook-deliveries`
- document the webhook idempotency and replay contract in the README and spec, and mark backlog item `012` done

## Testing
- `mix test`
- `mix credo --strict`
- `mix format --check-formatted`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `GET /api/v1/webhook-deliveries` endpoint to query webhook delivery history, including status, attempt counts, timestamps, and suppression reasons.
  * Implemented stable delivery identifiers that persist across retry attempts.

* **Documentation**
  * Updated webhook contract specification to clarify delivery semantics, wake-up hint behavior, and delivery ledger API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->