### PR TITLE
chore(governance): correct merge doctrine to squash-merge

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -199,9 +199,10 @@ Skip if `scripts/lib/verdicts.sh` is absent (Spellbook-only feature).
 `/code-review` is the penultimate gate before `/settle` lands the branch.
 Expected upstream state: `/settle` has unblocked CI + reviews, `/refactor`
 has already simplified the diff. Expected downstream: a clean verdict ref
-and a green `./bin/validate --strict` so `/settle --land` can merge into
-`master` (linear history, no squash). Commit style is conventional-with-scope:
-`feat(health):`, `fix(ci):`, `refactor(query):`, `docs(ops):`.
+and a green `./bin/validate --strict` so `/settle --land` can squash-merge
+into `master` via `gh pr merge --squash`. The PR title / squash subject
+carries the conventional-with-scope prefix: `feat(health):`, `fix(ci):`,
+`refactor(query):`, `docs(ops):`.
 
 ## Gotchas
 

--- a/.agents/skills/deliver/SKILL.md
+++ b/.agents/skills/deliver/SKILL.md
@@ -18,7 +18,8 @@ argument-hint: "[backlog-item|issue-id] [--resume <ulid>] [--abandon <ulid>] [--
 Inner-loop composer. One backlog item from `backlog.d/NNN-*.md` → merge-ready
 commits on a feature branch. **Delivered ≠ shipped.** The outer loop
 (`/flywheel`) consumes the receipt and decides whether to land and deploy to
-`canary-obs`. Humans merge; master keeps linear history with no squash.
+`canary-obs`. Humans merge; PRs land on master as one squash commit via
+`gh pr merge --squash`.
 
 ## Invariants
 
@@ -165,8 +166,8 @@ Rules:
 - Reference the backlog item ID in the commit body or subject where the
   diff maps one-to-one, e.g. `#021` for `feat(health): add non-http
   check-in monitors` (see `git log`).
-- Linear history; no squash on master. Land commits as they were authored.
-  `/deliver` emits the commits; `/settle` lands them without flattening.
+- Squash-merge on land. Branch keeps the sliced commits for PR review;
+  `/settle` squashes them into one master commit via `gh pr merge --squash`.
 
 ## Archival on Completion
 
@@ -191,8 +192,8 @@ same commit. If it doesn't, `/reflect` will flag the drift.
 
 ## Cross-Cutting Invariants
 
-- **Feature branch only.** Never commit to master. Linear history is
-  preserved by authored commits, not by squashing at merge time.
+- **Feature branch only.** Never commit to master. All changes land
+  via `gh pr merge --squash` as one master commit per PR.
 - **Never push.** `/deliver` stops at merge-ready. `/settle` lands.
 - **Never merge.** Humans merge. CODEOWNERS routes review to `@phrazzld`.
 - **Never deploy.** `flyctl deploy --app canary-obs --remote-only` is fired
@@ -329,5 +330,5 @@ backlog.d/_done/` when appropriate). Do not collapse it into the brief.
 ## Related
 
 - Consumer: `/flywheel` — outer loop passes `--state-dir` under its cycle tree and reads `receipt.json`.
-- Lander: `/settle` — takes a `merge_ready` receipt, runs `./bin/validate --strict` one more time if stale, and lands the branch with linear history. `/deliver` never calls `/settle`.
+- Lander: `/settle` — takes a `merge_ready` receipt, runs `./bin/validate --strict` one more time if stale, and lands the branch via `gh pr merge --squash`. `/deliver` never calls `/settle`.
 - Phases: `/shape`, `/implement`, `/code-review`, `/ci`, `/refactor`, `/qa`.

--- a/.agents/skills/deps/SKILL.md
+++ b/.agents/skills/deps/SKILL.md
@@ -324,7 +324,8 @@ Evidence sections.
 
 **Merge gate.** `./bin/validate --strict` locally + hosted CI's
 `dagger call strict --source=../candidate` via the immutable control
-plane (`.github/workflows/ci.yml`). Linear history, no squash on master.
+plane (`.github/workflows/ci.yml`). Squash-merge on land via
+`gh pr merge --squash`.
 
 ## Gotchas
 

--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -267,8 +267,8 @@ Never skip justification. "Just try X" is a red flag.
    at `.ci/trusted/` (see `docs/ci-control-plane.md`); a green local strict
    run is the contract for a green CI run.
 6. **Commit with scoped prefix** — `fix(health):`, `fix(ingest):`,
-   `fix(webhooks):`, `fix(ci):`, `fix(query):` etc. Linear history; do
-   not squash on master.
+   `fix(webhooks):`, `fix(ci):`, `fix(query):` etc. The PR title carries
+   the same prefix — that's what becomes the squash commit on master.
 7. **If 3+ fixes failed** — STOP. Question the architecture. See
    `references/systematic-debugging.md`.
 

--- a/.agents/skills/flywheel/SKILL.md
+++ b/.agents/skills/flywheel/SKILL.md
@@ -36,11 +36,11 @@ the canary-specific invariants that aren't inferable from the leaf names.
 3. **Land.** `/settle` is the canary-ratified merge step. It runs
    `./bin/validate --strict` (full `dagger call strict` gate: 81% core
    coverage, 90% `canary_sdk`, format/credo/sobelow/dialyzer, live
-   advisories, `.codex/agents/*.toml` role validation), then lands with
-   `git merge --ff-only` onto `master` (linear history, no squash), then
-   archives: `git mv backlog.d/NNN-item.md backlog.d/_done/`. Commit
-   scope follows conventional-with-scope (e.g. `feat(health):`,
-   `fix(ci):`, `refactor(query):`).
+   advisories, `.codex/agents/*.toml` role validation), then lands via
+   `gh pr merge --squash --delete-branch` with a pre-composed subject
+   carrying the conventional-with-scope prefix (e.g. `feat(health):`,
+   `fix(ci):`, `refactor(query):`), then archives:
+   `git mv backlog.d/NNN-item.md backlog.d/_done/`.
 4. **Deploy.** Hosted CI auto-deploys via `.github/workflows/deploy.yml`
    after `ci.yml` green — that workflow fires `flyctl deploy --app
    canary-obs --remote-only`. If the dispatch didn't fire (workflow

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -73,8 +73,8 @@ Do not try to fill in the gaps. Shape is a different skill's judgment.
 `git checkout -b <type>/<slug>` from the current branch. Use the commit-scope
 vocabulary for `<type>`: `feat`, `fix`, `refactor`, `chore`, `docs`, `build`.
 Builders never commit to `master`. If you forget, create the branch after
-and cherry-pick before handing off. Master is linear — do not squash,
-do not merge commits on top.
+and cherry-pick before handing off. All changes go through a PR and land
+as one squash commit via `gh pr merge --squash`.
 
 ### 3. Dispatch the builder
 
@@ -300,7 +300,7 @@ by widening tests — that's the job).
   `lib/canary_web/router.ex` or `lib/canary/query.ex` at once will merge-conflict
   and lose work. Partition by file ownership first.
 - **Branch drift.** Forgetting to `git checkout -b feat/<slug>` and
-  committing to `master`. Master is linear — always branch first.
+  committing to `master`. All changes go through a PR — always branch first.
 - **Scope creep from builders.** Builder adds "while I'm here" cleanups
   to `lib/canary/errors/ingest.ex`. The spec is the constraint — raise a
   blocker, don't silently expand the diff.

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -238,9 +238,10 @@ If `--apply` is explicitly set:
 - Commit scope matches the hot module: `refactor(query):`, `refactor(health):`,
   `refactor(webhooks):`, `refactor(alerter):`, `refactor(incidents):`,
   `refactor(ingest):`, `refactor(timeline):`, `refactor(correlation):`.
-- Linear history. No squash on `master`. If the refactor is a sequence of
-  extractions (as in PR #125: three commits, one per extracted read model),
-  preserve each as a standalone commit.
+- Squash-merge on land. If the refactor is a sequence of extractions
+  (as in PR #125: three branch commits, one per extracted read model),
+  keep the slices for PR review — they squash into one master commit at
+  merge time, but reviewers still read each extraction separately.
 - Gate: `./bin/validate --strict` before push. Hosted CI re-runs the same
   Dagger entrypoint; local and CI share the control plane by design.
 

--- a/.agents/skills/settle/SKILL.md
+++ b/.agents/skills/settle/SKILL.md
@@ -17,9 +17,9 @@ argument-hint: "[PR-number|branch-name]"
 # /settle
 
 Take a canary branch from blocked to clean and (as `/land`) onto `master`
-with linear history. Plain `/settle` stops at merge-ready. `/land` is the
-landing mode of this same skill and continues through a fast-forward merge
-per canary's linear-history-no-squash policy.
+with one squash commit per PR. Plain `/settle` stops at merge-ready. `/land` is the
+landing mode of this same skill and continues through `gh pr merge --squash`
+per canary's squash-merge policy.
 
 Canary ships on the `/settle → /refactor → /code-review → merge` outer loop.
 `/settle` is the unblock + polish + land step. The gate it answers to is
@@ -63,10 +63,11 @@ Detection sequence:
 There is no separate `/land` skill. When invoked as `/land <branch>`, always use
 git-native mode regardless of whether a PR exists. `/land` validates the verdict
 ref (must exist and point at HEAD), rejects `dont-ship` verdicts, re-runs
-`./bin/validate --strict` when available, and lands the branch directly per
-canary policy: **linear history on master, no squash** — use `git merge --ff-only`
-to fast-forward a ticket branch into `master`. `SPELLBOOK_NO_REVIEW=1` bypasses
-the verdict gate for emergencies.
+`./bin/validate --strict` when available, and lands the branch per canary
+policy: **squash-merge**. In GitHub mode use `gh pr merge --squash` with a
+pre-composed `--subject`/`--body`; in git-native mode use
+`git merge --squash <branch> && git commit` on `master` then `git push`.
+`SPELLBOOK_NO_REVIEW=1` bypasses the verdict gate for emergencies.
 
 ## Objective
 
@@ -107,9 +108,10 @@ Read `references/pr-fix.md` and follow it completely.
 
 **Goal:** Get from blocked to green on `./bin/validate --strict`.
 
-1. **Conflicts** — rebase (preferred, keeps linear history) or merge, resolve
-   all conflicts. Prefer `git rebase origin/master` so the eventual
-   `git merge --ff-only` is a no-brainer.
+1. **Conflicts** — rebase or merge, resolve all conflicts. Either works under
+   squash-merge (the branch commits don't land on `master`; only the squash
+   commit does). `git rebase origin/master` is still convenient for review
+   readability.
 2. **Gate** — invoke `/ci` for gate ownership, which runs `./bin/validate`
    (default) or `./bin/validate --strict` before landing. In GitHub mode, also
    wait on the `dagger` check in `.github/workflows/ci.yml` — it runs
@@ -140,11 +142,10 @@ Read `references/pr-fix.md` and follow it completely.
 Dispatch fixes to smaller worker subagents when scope is clear and bounded —
 one Dagger lane failure per subagent, one review comment thread per subagent.
 
-6. **Per-commit gate (multi-commit branches)** — canary uses linear history, so
-   each commit on the branch will appear verbatim in `master` history. If the
-   branch has more than one commit, verify each commit *independently* passes
-   `./bin/validate --strict` (rebase with `git rebase -x './bin/validate --strict'
-   origin/master`). Bisect-cleanliness is a real requirement here, not a vanity.
+6. **Branch-head gate** — canary squash-merges, so only the squash-commit
+   state lands on `master`. Run `./bin/validate --strict` once against the
+   branch HEAD before merge. No per-commit gate; no bisect-cleanliness
+   requirement on the branch commits.
 7. **Merge-readiness verification** —
    - **GitHub mode:** `gh pr view --json reviews,statusCheckRollup` — at least
      one approving review, the `dagger` check passing
@@ -260,15 +261,17 @@ produces no changes. The outer loop above this skill is
 
 When invoked as `/land`, after all three phases are green:
 
-1. Re-confirm `./bin/validate --strict` on the tip commit.
-2. Fetch and rebase onto `origin/master` so the merge is a fast-forward.
-3. Land per canary policy — **linear history on master, no squash**:
-   - Local: `git checkout master && git merge --ff-only <branch> && git push origin master`
-   - GitHub: `gh pr merge <PR> --merge --delete-branch`
-     (**never** `--squash`, **never** `--rebase` unless explicitly requested —
-     canary preserves every commit from the branch)
-4. Verify linear history after push: `git log --oneline --graph origin/master | head` —
-   there should be no merge commits from feature branches.
+1. Re-confirm `./bin/validate --strict` on the branch HEAD.
+2. Fetch and rebase onto `origin/master` (optional — conflicts resolved
+   pre-squash make the PR diff clean for reviewers).
+3. Land per canary policy — **squash-merge**:
+   - GitHub: `gh pr merge <PR> --squash --subject "<conventional-with-scope subject>" --body "<summary>" --delete-branch`
+   - Git-native: `git checkout master && git merge --squash <branch> && git commit -m "<conventional-with-scope subject>" && git push origin master`
+4. The PR title / squash subject carries the conventional-with-scope prefix
+   (`feat(health):`, `fix(ci):`, etc.); branch commits stay for review
+   readability but don't land on `master`.
+5. Verify `git log --oneline -3 origin/master` shows the squash commit as
+   a single entry.
 
 ## Reviewer Artifact Policy
 
@@ -311,13 +314,17 @@ When settlement needs screenshots, videos, logs, or walkthrough proof:
   The control plane is immutable by design (`docs/ci-control-plane.md`): the
   workflow runs from the base snapshot in `.ci/trusted/`, so the edit in your
   PR does nothing for the required check. Fix the Dagger module or the code.
-- **Squashing on merge.** Canary is linear-history-no-squash. `--squash`
-  destroys bisectable history and drops conventional-commit scopes.
-- **Non-ff merge commits into `master`.** Rebase the branch first; then
-  `git merge --ff-only` (or `gh pr merge --merge` after a green fast-forward state).
-- **Landing a multi-commit branch without per-commit gate.** Every commit
-  that reaches `master` must independently pass `./bin/validate --strict`;
-  otherwise `git bisect` is broken for everyone.
+- **Using `--merge` or `--rebase`.** Canary lands one squash commit per PR.
+  `gh pr merge --merge` fills `master` with branch commits; `--rebase`
+  replays them. Neither matches policy.
+- **Squash subject without conventional-with-scope prefix.** The squash
+  commit IS the master history; it must carry `feat(health):` /
+  `fix(ci):` / etc. for `git log` readability and downstream tooling.
+- **Forgetting `--delete-branch` on the squash merge.** Branches left
+  dangling on the remote after a squash land are clutter.
+- **Relying on bisect-cleanliness of branch commits.** Branch commits
+  don't reach `master` under squash-merge; only the squash commit does.
+  Run `./bin/validate --strict` once on branch HEAD, not per commit.
 - Polish without re-running `./bin/validate --strict` afterward.
 - Refactoring without verifying invariants are preserved (pure
   `StateMachine.transition/4`, deterministic summaries, RFC 9457 shape,

--- a/.agents/skills/settle/references/pr-fix.md
+++ b/.agents/skills/settle/references/pr-fix.md
@@ -19,11 +19,12 @@ before responding to comments.
 ```text
 fetch origin
   │
-  ├─ Few commits, linear history matters, no downstream consumers → rebase
-  │    git rebase origin/main
+  ├─ Few commits, branch readable, no downstream consumers → rebase
+  │    git rebase origin/master
   │
   └─ Many commits, shared branch, complex conflicts → merge
-       git merge origin/main
+       git merge origin/master
+(Either works — branch gets squashed into one commit on master at merge.)
 ```
 
 **Always:**

--- a/.agents/skills/yeet/SKILL.md
+++ b/.agents/skills/yeet/SKILL.md
@@ -30,9 +30,9 @@ skill's scope is: worktree → commits → remote.
    `git status --short` still shows modified, staged, or untracked paths.
    Resolve every path by commit, ignore, move out of the repo, or delete.
 3. **Reviewability is the product.** A stack of three focused commits beats
-   one 2,000-line "wip" commit. Canary runs linear history with **no squash
-   on master** — every commit lands on `master` as written and must stand
-   alone. Slice accordingly.
+   one 2,000-line "wip" commit. Canary squash-merges PRs, so branch commits
+   don't land on `master` — but reviewers read them, and one squash commit
+   per PR means the PR title carries the master history. Slice accordingly.
 4. **Never lose work.** Untracked scratch that might be the user's in-flight
    thinking gets moved (`~/vault/canary/scratch/…`), not deleted, unless it's
    unambiguous debris.
@@ -50,8 +50,8 @@ skill's scope is: worktree → commits → remote.
 - `--dry-run`: report the plan (commit boundaries, messages, skips), do not
   execute. Skips hooks entirely.
 - `--single-commit`: skip the split pass; one commit for everything that
-  belongs. Use sparingly — multi-concern single commits violate the
-  linear-no-squash-on-master contract.
+  belongs. Use sparingly — multi-concern single commits are harder to review
+  even though they'll squash into one master commit at merge time.
 - `--no-push`: commit locally but don't push. `./bin/validate --fast` still
   runs (pre-commit); `--strict` does not (no push).
 
@@ -136,8 +136,9 @@ For each changed / untracked path, assign one of:
 
 ### 3. Group signals into semantic commits
 
-**One concern per commit.** Canary's linear-no-squash policy means every
-commit lands on `master` as written. Each commit must pass
+**One concern per commit.** Canary squash-merges PRs, so branch commits
+don't appear on `master` — but reviewers read them individually. Each
+commit should still pass
 `./bin/validate --strict` standalone. For multi-commit branches, verify
 per-commit before push:
 
@@ -275,9 +276,9 @@ convention has changed, match the new convention.
      non-trivially.
   3. Retry push once.
   4. On second rejection, stop and surface — something stranger is going on.
-- **Never force-push.** Linear history is load-bearing. If the user's
-  branch needs force-push semantics, that's a `/settle` rewrite concern,
-  not `/yeet`.
+- **Never force-push.** Branch history integrity is load-bearing for
+  review even though the branch commits don't reach `master`. Force-push
+  semantics are a `/settle` rewrite concern, not `/yeet`.
 - After push: `git status --short --untracked-files=all`. Any visible path
   means `/yeet` isn't done — continue classifying.
 
@@ -319,7 +320,7 @@ Stop and surface to the user instead of committing:
 
 ## Safety rails (never)
 
-- Never force-push. Linear history on `master` is load-bearing.
+- Never force-push. Branch-commit integrity matters for PR review.
 - Never `--no-verify` to bypass `.githooks/pre-commit` or `.githooks/pre-push`.
   The gates ARE the product contract.
 - Never `--amend` a commit that was rejected by a hook — create a new
@@ -385,7 +386,7 @@ Ignored: design-catalog.html (regenerated QA artifact, already in .gitignore)
 Commits:
   abc1234 refactor(query): extract incident read model into Canary.Query.Incidents
   def5678 feat(query): add cursor pagination to incident read model (#010)
-  9012345 chore(governance): document linear-no-squash policy in AGENTS.md
+  9012345 chore(governance): document squash-merge policy in AGENTS.md
 
 Per-commit strict: green (git rebase -x './bin/validate --strict').
 Pushed feat/010-ramp-pattern-query-split → origin (3 new commits).

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -60,7 +60,7 @@ allow = [
   "npm ci",
   "npm run",
 
-  # Git (read + the linear-no-squash write set)
+  # Git (read + the squash-merge write set)
   "git status",
   "git diff",
   "git log",
@@ -122,7 +122,7 @@ commit-scopes = [
 ]
 # Canary-specific area suffixes seen on real commits: (health), (ci), (query),
 # (auth), (ops), (governance), (backlog), (dr), (onboarding).
-merge-strategy = "linear-no-squash"
+merge-strategy = "squash"
 
 [gate]
 # /ci skill and every gate-adjacent skill cites this verbatim.

--- a/.spellbook/repo-brief.md
+++ b/.spellbook/repo-brief.md
@@ -84,8 +84,10 @@ history + memory):
   a prose codex.
 - Single gate citation of `./bin/validate` (never "run CI" / "run the
   tests"); coverage names `81% core / 90% canary_sdk`;
-  conventional-commit scopes taken from `git log`; linear-no-squash on
-  master; responder boundary enforced in acceptance criteria.
+  conventional-commit scopes taken from `git log` (they land on the
+  PR-title / squash-subject, not necessarily every branch commit);
+  squash-merge via `gh pr merge --squash`; responder boundary enforced
+  in acceptance criteria.
 - Load-bearing footgun list stays in `CLAUDE.md`. Never duplicate into
   `AGENTS.md` or skill bodies — cite it.
 - Shared-root skill layout: `.agents/skills/<name>/` canonical;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,10 @@ pick it up.
 | `/implement` | TDD on narrow tests: `mix test test/canary/<area>/<area>_test.exs --trace --max-failures 3`. Custom PKs on struct not cast. RFC 9457, deterministic summaries, single-writer. Stops at green. |
 | `/monitor` | **Harness-side** post-deploy signal watch — not `Canary.Monitors` (product concept). Polls `/healthz`, `/readyz`, `flyctl status`, Canary's own `/api/v1/query?service=canary`, health targets, circuit-breaker state. Grace window default 5m. |
 | `/qa` | API-first (curl against `canary-obs.fly.dev` or local `mix phx.server`). Endpoint matrix with `$CANARY_*_KEY` scope enforcement. `bin/dogfood-audit --strict` for owned services. Dashboard is secondary. |
-| `/refactor` | Branch mode: simplify the diff against `origin/master`. Master mode: whole-repo hunt. Cites PR #125 query split as exemplar. `refactor(<scope>):` linear-history commits. |
-| `/settle` | Merges with **linear-history, no-squash**. `git merge --ff-only` or `gh pr merge --merge` (never `--squash`). Multi-commit branches must pass gate per-commit via `git rebase -x './bin/validate --strict'`. |
+| `/refactor` | Branch mode: simplify the diff against `origin/master`. Master mode: whole-repo hunt. Cites PR #125 query split as exemplar. Branch commits use `refactor(<scope>):`; squash-merge collapses them into one master commit. |
+| `/settle` | Lands a PR via `gh pr merge --squash` with PR title/body → single master commit. No `--merge`, no `--rebase`. Runs `./bin/validate --strict` once on branch head before merging; no per-commit gate needed. |
 | `/shape` | Produces `backlog.d/NNN-<slug>.md` context packets. Lanes 1–5. `#NNN` dependency IDs. Enforces responder boundary + OpenAPI-router-scope-pipeline contract in acceptance criteria. |
-| `/yeet` | Worktree → semantically-split conventional commits → `git push`. Classifies paths (signal/debris/drift/evidence/secret-risk). Refuses on `gentle-working-tundra/` / `polished-marching-river/` / `sunlit-moving-walnut/` leakage, `*.db*`, `erl_crash.dump`, Fly/Tigris tokens, Dagger pin drift, OpenAPI↔router desync. Hooks run: `./bin/validate --fast` (commit), `--strict` (push). Linear-no-squash. Distinct from `/settle` (branch landing). |
+| `/yeet` | Worktree → semantically-split conventional commits → `git push`. Classifies paths (signal/debris/drift/evidence/secret-risk). Refuses on `gentle-working-tundra/` / `polished-marching-river/` / `sunlit-moving-walnut/` leakage, `*.db*`, `erl_crash.dump`, Fly/Tigris tokens, Dagger pin drift, OpenAPI↔router desync. Hooks run: `./bin/validate --fast` (commit), `--strict` (push). Branch commits stay clean for PR review; master keeps one squash commit per PR via `/settle`. Distinct from `/settle` (branch landing). |
 
 **Universal skills (verbatim from spellbook):** `/research`, `/model-research`, `/office-hours`, `/ceo-review`, `/reflect`, `/groom`.
 
@@ -123,7 +123,7 @@ pick it up.
 
 ## Outer loop
 
-User-ratified composition: **`/settle → /refactor → /code-review → merge`.** Linear history on master, conventional commits with scope (`feat(health):`, `fix(ci):`, `refactor(query):`, `chore(governance):`, `docs(ops):`, `build:`). Narrow test idiom: `mix test test/canary/<area>/<area>_test.exs --trace --max-failures 3`.
+User-ratified composition: **`/settle → /refactor → /code-review → merge`.** Master keeps one squash commit per PR via `gh pr merge --squash`; PR title + body become that commit. Conventional-with-scope prefix on the PR title / squash subject (`feat(health):`, `fix(ci):`, `refactor(query):`, `chore(governance):`, `docs(ops):`, `build:`). Narrow test idiom: `mix test test/canary/<area>/<area>_test.exs --trace --max-failures 3`.
 
 ## Self-monitoring
 


### PR DESCRIPTION
## Summary

- User correction after PR #130 landed: canary is **squash-merge**, not linear-no-squash. Prior tailor had encoded the wrong policy.
- Updates AGENTS.md, `.spellbook/repo-brief.md`, `.codex/config.toml`, and 10 workflow SKILL.md bodies (`settle`, `yeet`, `deliver`, `flywheel`, `code-review`, `refactor`, `deps`, `diagnose`, `implement`, plus `settle/references/pr-fix.md`).
- `gh pr merge --squash` is the landing command; PR title + body become the squash commit.

## Verification

- [x] `./bin/validate --fast` green
- [x] Zero remaining `linear-no-squash` / `--ff-only.*master` / `no squash` citations (grep clean)
- [x] Memory saved (`feedback_merge_strategy.md`) so future sessions don't relearn

## Deferred

Spellbook upstream (`/Users/phaedrus/Development/spellbook/skills/*/SKILL.md`) still carries the old doctrine and will re-propagate on fresh `/tailor`. Next `/harness` pass should fix upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge strategy configuration and workflow documentation: PRs now land on master as single squash commits via `gh pr merge --squash`.
  * Individual branch commits are combined into one master commit, with the PR title/body becoming the commit message.
  * Updated skill guides and process documentation throughout to reflect the new squash-merge approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->