### PR TITLE
feat(lint): add EctoPKViaCast Credo check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -8,9 +8,10 @@
         excluded: [~r"/_build/", ~r"/deps/"]
       },
       plugins: [],
-      requires: [],
+      requires: ["./test/support/credo_checks/ecto_pk_via_cast.ex"],
       checks: %{
         enabled: [
+          {Canary.Checks.EctoPKViaCast, []},
           # Disable AliasUsage — inline qualified calls are clearer in controllers
           # where the alias would be used once or twice.
           {Credo.Check.Design.AliasUsage, false},

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Self-hosted observability for agent-driven infrastructure. Elixir/Phoenix + SQLi
 
 ## Footguns
 
-- **Ecto primary keys.** Custom string PKs (`ERR-nanoid`) must be set on the struct, not cast: `%Error{id: id} |> changeset(attrs)`. Casting silently drops the `id` field because it's not in the `@required`/`@optional` lists. (6 bugs in initial build.)
+- **Ecto primary keys.** Custom string PKs (`ERR-nanoid`) must be set on the struct, not cast: `%Error{id: id} |> changeset(attrs)`. Casting silently drops the `id` field because it's not in the `@required`/`@optional` lists. Enforced by `Canary.Checks.EctoPKViaCast` in `./bin/validate --fast`. (6 bugs in initial build.)
 - **Oban Lite tables.** Oban's SQLite engine does NOT auto-create its tables. `Oban.Migrations.SQLite` exists but `Ecto.Migrator.run` can't invoke it (different migration behaviour). Fixed: dedicated Ecto migration (`20260314230000_create_oban_jobs.exs`) with `execute` for raw SQL. Do NOT put this in a GenServer or Release module — `Repo.query!` races with pool_size:1 during Ecto migration.
 - **Req + Finch.** Cannot pass both `:finch` and `:connect_options` to `Req.request/1`. The `:finch` option implies connection management — use `:receive_timeout` for timeouts.
 - **ReadRepo is not in `ecto_repos`.** Only `Canary.Repo` runs migrations. Adding `ReadRepo` to `ecto_repos` makes `mix ecto.migrate` look for `priv/read_repo/migrations/` which doesn't exist.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -29,7 +29,7 @@
 | 023 | Incident as atomic agent unit (detail API) | high | done | M |
 | 024 | Signal-agnostic annotations | medium | done | M |
 | 025 | Audit test helpers for Ecto PK cast-drop | low | ready | S |
-| 026 | Credo check: EctoPKViaCast | high | ready | S |
+| 026 | Credo check: EctoPKViaCast | high | done | S |
 | 027 | Credo check: PreloadThenTake | high | ready | S |
 | 028 | OpenAPI ↔ Ecto type-parity Dagger lane | medium | ready | M |
 | 029 | Code-review pattern catalog + reviewer wiring | medium | ready | S |
@@ -68,14 +68,14 @@
 **Lane 4 (hardening):** 008, 014, 016, 017, 018, 019 (independent, small, can ship anytime)
 **Lane 5 (future):** 020 (Adminifi HTTP surface verification)
 
-### Active order (2026-04-22)
+### Active order (2026-04-23)
 
-1. **026** — Credo check: EctoPKViaCast (prevent CLAUDE.md footgun #1 structurally)
-2. **027** — Credo check: PreloadThenTake (prevent bounded-payload antipattern)
-3. **029** — Code-review pattern catalog + reviewer wiring (ships independently, pure docs)
-4. **028** — OpenAPI ↔ Ecto type-parity Dagger lane (larger scope; ship after 026/027)
+1. **027** — Credo check: PreloadThenTake (prevent bounded-payload antipattern)
+2. **029** — Code-review pattern catalog + reviewer wiring (ships independently, pure docs)
+3. **028** — OpenAPI ↔ Ecto type-parity Dagger lane (larger scope; ship after 027)
 
-022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22 — Ramp
+022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
+2026-04-23 — Ramp
 substrate now complete; bb/011 unblocks the north star. 026-029
 captured 2026-04-22 from /reflect prevent-coderabbit-patterns — codify
 CodeRabbit's recurring finds at the highest-leverage target in the

--- a/backlog.d/_done/026-credo-check-ecto-pk-via-cast.md
+++ b/backlog.d/_done/026-credo-check-ecto-pk-via-cast.md
@@ -55,16 +55,18 @@ Skill/reference > AGENTS.md > Memory**.
 
 **Where it lives.**
 
-- Check module: `lib/credo_checks/ecto_pk_via_cast.ex` under
+- Check module: `test/support/credo_checks/ecto_pk_via_cast.ex` under
   `Canary.Checks.EctoPKViaCast` (implements `Credo.Check`, category
-  `:warning`, base priority `:high`).
+  `:warning`, base priority `:high`). `.credo.exs` loads it explicitly
+  via `requires` so `mix credo` sees it without shipping Credo-only code
+  in `lib/`.
 - Credo config: append to `.credo.exs` under
   `checks.enabled` — `{Canary.Checks.EctoPKViaCast, []}`.
 - Tests: `test/credo_checks/ecto_pk_via_cast_test.exs`.
-- `lib/credo_checks/` must be compiled for Credo to see it; since the
-  check is a Credo plugin it must load before `mix credo` runs. The
-  existing `elixirc_paths(:test)` behavior in `mix.exs` includes `lib`
-  in all envs — no change needed.
+- `mix credo` must load the check before it runs. `.credo.exs`
+  `requires` the file explicitly, and the existing `elixirc_paths(:test)`
+  behavior in `mix.exs` includes `test/support` so the ExUnit suite can
+  exercise the same module.
 
 **Detection shape (AST walk).**
 

--- a/test/canary/query_test.exs
+++ b/test/canary/query_test.exs
@@ -20,8 +20,11 @@ defmodule Canary.QueryTest do
       status: "active"
     }
 
-    %ErrorGroup{}
-    |> ErrorGroup.changeset(Map.merge(defaults, attrs))
+    merged = Map.merge(defaults, attrs)
+    {group_hash, group_attrs} = Map.pop!(merged, :group_hash)
+
+    %ErrorGroup{group_hash: group_hash}
+    |> ErrorGroup.changeset(group_attrs)
     |> Canary.Repo.insert!()
   end
 

--- a/test/credo_checks/ecto_pk_via_cast_test.exs
+++ b/test/credo_checks/ecto_pk_via_cast_test.exs
@@ -1,0 +1,157 @@
+defmodule Canary.Checks.EctoPKViaCastTest do
+  use Credo.Test.Case, async: false
+
+  alias Canary.Checks.EctoPKViaCast
+
+  setup_all do
+    Application.ensure_all_started(:credo)
+    :ok
+  end
+
+  defmodule AllowsPrimaryKeyCast do
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    @primary_key {:slug, :string, autogenerate: false}
+    schema "allows_primary_key_cast" do
+      field :name, :string
+    end
+
+    def changeset(row, attrs) do
+      cast(row, attrs, [:slug, :name])
+    end
+  end
+
+  test "reports literal custom primary keys passed through changeset attrs" do
+    """
+    defmodule Sample do
+      def insert_group do
+        %Canary.Schemas.ErrorGroup{}
+        |> Canary.Schemas.ErrorGroup.changeset(%{
+          group_hash: "grp",
+          service: "test-svc"
+        })
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoPKViaCast)
+    |> assert_issue(fn issue ->
+      assert issue.message =~ "Custom primary key `:group_hash`"
+      assert issue.message =~ "CLAUDE.md footgun #1"
+      assert issue.trigger == "group_hash"
+    end)
+  end
+
+  test "reports local defaults maps merged into changeset attrs" do
+    """
+    defmodule Sample do
+      alias Canary.Schemas.{ErrorGroup, Target}
+
+      def insert_group(attrs) do
+        defaults = %{
+          group_hash: "grp",
+          service: "test-svc"
+        }
+
+        %ErrorGroup{}
+        |> ErrorGroup.changeset(Map.merge(defaults, attrs))
+      end
+
+      def insert_target(attrs) do
+        defaults = %{url: "https://example.com", name: "api"}
+
+        %Target{}
+        |> Target.changeset(Map.merge(defaults, attrs))
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoPKViaCast)
+    |> assert_issue(%{trigger: "group_hash"})
+  end
+
+  test "accepts the custom primary key set on the struct" do
+    """
+    defmodule Sample do
+      alias Canary.Schemas.ErrorGroup
+
+      def insert_group(attrs) do
+        group_hash = "grp"
+        defaults = %{group_hash: group_hash, service: "test-svc"}
+
+        %ErrorGroup{group_hash: group_hash}
+        |> ErrorGroup.changeset(Map.merge(defaults, attrs))
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoPKViaCast)
+    |> refute_issues()
+  end
+
+  test "accepts schemas whose changeset casts the custom primary key" do
+    """
+    defmodule Sample do
+      alias Canary.Checks.EctoPKViaCastTest.AllowsPrimaryKeyCast
+
+      def insert_row do
+        %AllowsPrimaryKeyCast{}
+        |> AllowsPrimaryKeyCast.changeset(%{slug: "row-1", name: "ok"})
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoPKViaCast)
+    |> refute_issues()
+  end
+
+  test "ignores unrelated code" do
+    """
+    defmodule Sample do
+      def run(attrs) do
+        attrs
+        |> Map.merge(%{group_hash: "grp"})
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoPKViaCast)
+    |> refute_issues()
+  end
+
+  test "reports source-only schemas via static metadata" do
+    [
+      """
+      defmodule Fixture.Schema do
+        use Ecto.Schema
+        import Ecto.Changeset
+
+        @primary_key {:slug, :string, autogenerate: false}
+        schema "fixture_rows" do
+          field :name, :string
+        end
+
+        @required ~w(name)a
+
+        def changeset(row, attrs) do
+          row
+          |> cast(attrs, @required)
+        end
+      end
+      """,
+      """
+      defmodule Fixture.UseSchema do
+        def insert_row do
+          %Fixture.Schema{}
+          |> Fixture.Schema.changeset(%{slug: "row-1", name: "ok"})
+        end
+      end
+      """
+    ]
+    |> to_source_files()
+    |> run_check(EctoPKViaCast)
+    |> assert_issue(%{trigger: "slug"})
+  end
+end

--- a/test/support/credo_checks/ecto_pk_via_cast.ex
+++ b/test/support/credo_checks/ecto_pk_via_cast.ex
@@ -1,0 +1,376 @@
+defmodule Canary.Checks.EctoPKViaCast do
+  use Credo.Check,
+    category: :warning,
+    base_priority: :high,
+    explanations: [
+      check: """
+      Canary schemas use custom string primary keys for externally meaningful IDs.
+      Passing those keys through `changeset/2` is unsafe unless the schema casts
+      the primary key field: Ecto silently drops fields absent from the cast list.
+
+      Set custom primary keys on the struct before calling the changeset.
+      """
+    ]
+
+  alias Credo.{IssueMeta, SourceFile}
+  alias Credo.Execution.ExecutionIssues
+
+  @doc false
+  @impl true
+  def run_on_all_source_files(exec, source_files, params) do
+    schema_index = build_schema_index(source_files)
+
+    Enum.each(source_files, fn source_file ->
+      source_file
+      |> issues_for_source_file(params, schema_index)
+      |> then(&ExecutionIssues.append(exec, &1))
+    end)
+
+    :ok
+  end
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = _source_file, _params), do: []
+
+  defp issues_for_source_file(source_file, params, schema_index) do
+    source_file
+    |> Credo.Code.prewalk(&walk/2, initial_state(source_file, params, schema_index))
+    |> Map.fetch!(:issues)
+    |> Enum.reverse()
+  end
+
+  defp initial_state(source_file, params, schema_index) do
+    %{
+      aliases: %{},
+      issue_meta: IssueMeta.for(source_file, params),
+      issues: [],
+      map_bindings: %{},
+      schema_index: schema_index
+    }
+  end
+
+  defp walk({:alias, _, _} = ast, state) do
+    {ast, update_aliases(state, ast)}
+  end
+
+  defp walk({:=, _, [{name, _, context}, value]} = ast, state)
+       when is_atom(name) and (is_atom(context) or is_nil(context)) do
+    key_names = attr_key_names(value, state.map_bindings)
+
+    state =
+      if key_names == [] do
+        state
+      else
+        put_in(state.map_bindings[name], key_names)
+      end
+
+    {ast, state}
+  end
+
+  defp walk({:|>, _, _} = ast, state) do
+    {ast, maybe_report_pipe(ast, state)}
+  end
+
+  defp walk(ast, state), do: {ast, state}
+
+  defp maybe_report_pipe(ast, state) do
+    with {:ok, struct_module_ast, struct_fields} <- struct_literal(ast),
+         {:ok, changeset_module_ast, attrs_ast, line_no} <- changeset_call(ast),
+         {:ok, schema} <-
+           resolve_same_module(struct_module_ast, changeset_module_ast, state.aliases),
+         {:ok, schema_metadata} <- schema_metadata(schema, state.schema_index),
+         primary_key_name = schema_metadata.primary_key,
+         false <- primary_key_name in key_names(struct_fields),
+         false <- schema_metadata.casts_primary_key?,
+         true <- primary_key_name in attr_key_names(attrs_ast, state.map_bindings) do
+      add_issue(state, issue_for(state.issue_meta, schema, primary_key_name, line_no))
+    else
+      _ -> state
+    end
+  end
+
+  defp build_schema_index(source_files) do
+    Enum.reduce(source_files, %{}, fn source_file, schema_index ->
+      source_file
+      |> module_definitions()
+      |> Enum.reduce(schema_index, fn {module_ast, body}, acc ->
+        case extract_schema_metadata(module_ast, body) do
+          %{module: module} = metadata -> Map.put(acc, module, metadata)
+          nil -> acc
+        end
+      end)
+    end)
+  end
+
+  defp module_definitions(source_file) do
+    source_file
+    |> Credo.Code.prewalk(
+      fn
+        {:defmodule, _, [module_ast, [do: body]]} = ast, modules ->
+          {ast, [{module_ast, body} | modules]}
+
+        ast, modules ->
+          {ast, modules}
+      end,
+      []
+    )
+  end
+
+  defp extract_schema_metadata(module_ast, body) do
+    module = resolve_module(module_ast, %{})
+
+    {_, state} =
+      Macro.prewalk(
+        body,
+        %{attrs: %{}, casts: MapSet.new(), has_schema?: false, primary_key: nil},
+        fn
+          {:schema, _, _} = ast, state ->
+            {ast, %{state | has_schema?: true}}
+
+          {:@, _, [{:primary_key, _, [value_ast]}]} = ast, state ->
+            {ast, %{state | primary_key: primary_key_metadata(value_ast)}}
+
+          {:@, _, [{name, _, [value_ast]}]} = ast, state when is_atom(name) ->
+            value = eval_module_attr(value_ast, state.attrs)
+            attrs = if value == nil, do: state.attrs, else: Map.put(state.attrs, name, value)
+            {ast, %{state | attrs: attrs}}
+
+          {:cast, _, args} = ast, state ->
+            {ast, collect_cast_fields(state, args)}
+
+          ast, state ->
+            {ast, state}
+        end
+      )
+
+    case state do
+      %{has_schema?: true, primary_key: %{type: :string, autogenerate: false, field: field}} ->
+        %{
+          module: module,
+          primary_key: Atom.to_string(field),
+          casts_primary_key?: MapSet.member?(state.casts, Atom.to_string(field))
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp primary_key_metadata({:{}, _, [field, type, opts]})
+       when is_atom(field) and is_atom(type) and is_list(opts) do
+    %{autogenerate: Keyword.get(opts, :autogenerate, true), field: field, type: type}
+  end
+
+  defp primary_key_metadata(_), do: nil
+
+  defp collect_cast_fields(state, [_attrs_ast, fields_ast]) do
+    update_in(
+      state.casts,
+      &MapSet.union(&1, MapSet.new(eval_field_names(fields_ast, state.attrs)))
+    )
+  end
+
+  defp collect_cast_fields(state, [_data_ast, _attrs_ast, fields_ast]) do
+    update_in(
+      state.casts,
+      &MapSet.union(&1, MapSet.new(eval_field_names(fields_ast, state.attrs)))
+    )
+  end
+
+  defp collect_cast_fields(state, _args), do: state
+
+  defp eval_module_attr({:sigil_w, _, [{:<<>>, _, [words]}, ~c"a"]}, _attrs)
+       when is_binary(words) do
+    words
+    |> String.split()
+    |> Enum.map(&String.to_atom/1)
+  end
+
+  defp eval_module_attr(fields, _attrs) when is_list(fields) do
+    if Enum.all?(fields, &(is_atom(&1) or is_binary(&1))) do
+      fields
+    else
+      nil
+    end
+  end
+
+  defp eval_module_attr(_value_ast, _attrs), do: nil
+
+  defp eval_field_names({:@, _, [{name, _, nil}]}, attrs),
+    do: List.wrap(attrs[name]) |> Enum.map(&to_string/1)
+
+  defp eval_field_names({:++, _, [left, right]}, attrs) do
+    (eval_field_names(left, attrs) ++ eval_field_names(right, attrs))
+    |> Enum.uniq()
+  end
+
+  defp eval_field_names(fields, _attrs) when is_list(fields) do
+    Enum.map(fields, &to_string/1)
+  end
+
+  defp eval_field_names(_fields_ast, _attrs), do: []
+
+  defp schema_metadata(schema, schema_index) do
+    case Map.get(schema_index, schema) do
+      nil -> compiled_schema_metadata(schema)
+      metadata -> {:ok, metadata}
+    end
+  end
+
+  defp compiled_schema_metadata(schema) when is_atom(schema) do
+    if Code.ensure_loaded?(schema) and function_exported?(schema, :__schema__, 1) do
+      case schema.__schema__(:primary_key) do
+        [primary_key] ->
+          if schema.__schema__(:autogenerate_id) == nil and
+               schema.__schema__(:type, primary_key) == :string do
+            {:ok,
+             %{
+               casts_primary_key?: changeset_casts_primary_key?(schema, primary_key),
+               module: schema,
+               primary_key: Atom.to_string(primary_key)
+             }}
+          else
+            :error
+          end
+
+        _ ->
+          :error
+      end
+    else
+      :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp compiled_schema_metadata(_), do: :error
+
+  defp changeset_casts_primary_key?(schema, primary_key) do
+    changeset =
+      apply(schema, :changeset, [struct(schema), %{primary_key => "canary-credo-probe"}])
+
+    Map.has_key?(changeset.changes, primary_key)
+  rescue
+    _ -> false
+  end
+
+  defp struct_literal({:|>, _, [struct_ast, _]}), do: struct_literal(struct_ast)
+
+  defp struct_literal({:%, _, [module_ast, {:%{}, _, fields}]}) do
+    {:ok, module_ast, fields}
+  end
+
+  defp struct_literal(_), do: :error
+
+  defp changeset_call({:|>, meta, [_, {{:., _, [module_ast, :changeset]}, _, [attrs_ast]}]}) do
+    {:ok, module_ast, attrs_ast, meta[:line]}
+  end
+
+  defp changeset_call(_), do: :error
+
+  defp resolve_same_module(left_ast, right_ast, aliases) do
+    left = resolve_module(left_ast, aliases)
+    right = resolve_module(right_ast, aliases)
+
+    if left == right and is_atom(left) do
+      {:ok, left}
+    else
+      :error
+    end
+  end
+
+  defp resolve_module({:__aliases__, _, [name]}, aliases) do
+    Map.get(aliases, name, Module.concat([name]))
+  end
+
+  defp resolve_module({:__aliases__, _, parts}, _aliases) do
+    Module.concat(parts)
+  end
+
+  defp resolve_module(_, _aliases), do: nil
+
+  defp update_aliases(state, {:alias, _, [{{:., _, [base_ast, :{}]}, _, children}]}) do
+    base_parts = module_parts(base_ast)
+
+    aliases =
+      Enum.reduce(children, state.aliases, fn child, aliases ->
+        parts = module_parts(child)
+        Map.put(aliases, List.last(parts), Module.concat(base_parts ++ parts))
+      end)
+
+    %{state | aliases: aliases}
+  end
+
+  defp update_aliases(state, {:alias, _, [module_ast, [as: {:__aliases__, _, [as_name]}]]}) do
+    put_in(state.aliases[as_name], module_ast |> module_parts() |> Module.concat())
+  end
+
+  defp update_aliases(state, {:alias, _, [module_ast]}) do
+    parts = module_parts(module_ast)
+    put_in(state.aliases[List.last(parts)], Module.concat(parts))
+  end
+
+  defp update_aliases(state, _), do: state
+
+  defp module_parts({:__aliases__, _, parts}), do: parts
+
+  defp attr_key_names({:%{}, _, pairs}, _bindings), do: key_names(pairs)
+
+  defp attr_key_names({name, _, context}, bindings)
+       when is_atom(name) and (is_atom(context) or is_nil(context)) do
+    Map.get(bindings, name, [])
+  end
+
+  defp attr_key_names({{:., _, [map_module, :merge]}, _, [left, right]}, bindings) do
+    if map_module?(map_module) do
+      (attr_key_names(left, bindings) ++ attr_key_names(right, bindings))
+      |> Enum.uniq()
+    else
+      []
+    end
+  end
+
+  defp attr_key_names({{:., _, [map_module, :put]}, _, [map_ast, key_ast, _value]}, bindings) do
+    if map_module?(map_module) do
+      (attr_key_names(map_ast, bindings) ++ key_names([{key_ast, nil}]))
+      |> Enum.uniq()
+    else
+      []
+    end
+  end
+
+  defp attr_key_names(_, _bindings), do: []
+
+  defp map_module?({:__aliases__, _, [:Map]}), do: true
+  defp map_module?(_), do: false
+
+  defp key_names(pairs) when is_list(pairs) do
+    pairs
+    |> Enum.flat_map(&key_name/1)
+    |> Enum.uniq()
+  end
+
+  defp key_name({key, _value}) when is_atom(key), do: [Atom.to_string(key)]
+  defp key_name({key, _value}) when is_binary(key), do: [key]
+  defp key_name(_), do: []
+
+  defp issue_for(issue_meta, schema, primary_key_name, line_no) do
+    schema_name = inspect(schema)
+
+    format_issue(
+      issue_meta,
+      message:
+        "Custom primary key `:#{primary_key_name}` is being passed through #{schema_name}.changeset/2. " <>
+          "The schema does not cast `:#{primary_key_name}`, so Ecto will silently drop it " <>
+          "(CLAUDE.md footgun #1). Set it on the struct instead: " <>
+          "%#{schema_name}{#{primary_key_name}: #{primary_key_name}} |> #{schema_name}.changeset(attrs_without_#{primary_key_name}).",
+      trigger: primary_key_name,
+      line_no: line_no
+    )
+  end
+
+  defp add_issue(state, issue) do
+    %{state | issues: [issue | state.issues]}
+  end
+end


### PR DESCRIPTION
## Summary
- add `Canary.Checks.EctoPKViaCast` as a project-local Credo check loaded from `test/support`
- cover the check with Credo-focused ExUnit cases, including source-only schema metadata
- fix the existing `ErrorGroup` helper to set the custom PK on the struct, document enforcement in `CLAUDE.md`, and archive backlog item `026`

## Verification
- `mix test test/credo_checks/ecto_pk_via_cast_test.exs --trace --max-failures 3`
- `mix credo --strict`
- `mix dialyzer`
- `./bin/validate --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new code validation check that detects when custom Ecto primary keys are provided through changeset operations instead of being set directly on the struct before calling the changeset.

* **Chores**
  * Updated validation configuration and documentation to reflect the newly enforced check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->