### PR TITLE
build(ci): bridge Elixir and Rust candidate gates

### DIFF
--- a/dagger/scripts/ci_contract_validation.py
+++ b/dagger/scripts/ci_contract_validation.py
@@ -722,12 +722,17 @@ require(
     "dagger/src/index.ts must scope cache volumes by dag.defaultPlatform()",
 )
 require(
-    dagger_source.count("const platformKey = await cachePlatformKey()") == 2,
+    dagger_source.count("const platformKey = await cachePlatformKey()") == 3,
     "Each Dagger dependency container must compute a platform cache key once",
 )
 require(
-    dagger_source.count("platformKey, imageKey, digest") == 5,
+    dagger_source.count("platformKey, imageKey, digest") == 8,
     "Every Dagger cache volume must scope its key by platform, image, and lockfile digest",
+)
+require(
+    "async function repoUsesRust(source: Directory)" in dagger_source
+    and 'expected Cargo.lock or mix.lock' in dagger_source,
+    "Dagger strict must support both Rust and legacy Elixir candidate source shapes",
 )
 
 sync_result = subprocess.run(

--- a/dagger/scripts/sync_source_arguments.py
+++ b/dagger/scripts/sync_source_arguments.py
@@ -20,6 +20,7 @@ COMMON_IGNORE = [
     "clients/typescript/dist",
     "clients/typescript/coverage",
     "dagger/node_modules",
+    "target",
 ]
 
 SOURCE_POLICIES = {
@@ -40,6 +41,9 @@ FUNCTION_POLICIES = {
     "rootDialyzer": "without_git",
     "sdkQuality": "without_git",
     "typescriptQuality": "without_git",
+    "rustQuality": "without_git",
+    "productionImageSmoke": "without_git",
+    "rustAdvisories": "without_git",
     "secrets": "with_git",
     "secretsHistory": "with_git",
 }

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -20,6 +20,8 @@ const NODE_IMAGE =
   "node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94"
 const PYTHON_IMAGE =
   "python:3.13-slim-bookworm@sha256:f13a6b7565175da40695e8109f64cbc4d2e65f4c9ef2e3b321c3a44fa3c06fe7"
+const RUST_IMAGE =
+  "rust:1.94.0-bookworm@sha256:365468470075493dc4583f47387001854321c5a8583ea9604b297e67f01c5a4f"
 const GITLEAKS_IMAGE =
   "zricethezav/gitleaks:latest@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f"
 const DIGEST_PREFIX = "sha256:"
@@ -91,6 +93,27 @@ async function lockfileDigest(
   path: string,
 ): Promise<string> {
   return source.file(path).digest({ excludeMetadata: true })
+}
+
+async function sourceHasFile(source: Directory, path: string): Promise<boolean> {
+  try {
+    await source.file(path).digest({ excludeMetadata: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function repoUsesRust(source: Directory): Promise<boolean> {
+  if (await sourceHasFile(source, "Cargo.lock")) {
+    return true
+  }
+
+  if (await sourceHasFile(source, "mix.lock")) {
+    return false
+  }
+
+  throw new Error("unsupported Canary source shape: expected Cargo.lock or mix.lock")
 }
 
 /** Elixir container with system deps, Hex/Rebar caches, and mix deps fetched. */
@@ -166,6 +189,31 @@ async function nodeContainer(
     .withExec(["npm", "ci", "--ignore-scripts"])
 }
 
+async function rustContainer(source: Directory): Promise<Container> {
+  const digest = await lockfileDigest(source, "Cargo.lock")
+  const platformKey = await cachePlatformKey()
+  const imageKey = imageIdentity(RUST_IMAGE)
+  const registryCache = dag.cacheVolume(
+    cacheVolumeName("canary-rust-registry", platformKey, imageKey, digest),
+  )
+  const gitCache = dag.cacheVolume(
+    cacheVolumeName("canary-rust-git", platformKey, imageKey, digest),
+  )
+  const targetCache = dag.cacheVolume(
+    cacheVolumeName("canary-rust-target", platformKey, imageKey, digest),
+  )
+
+  return dag
+    .container()
+    .from(RUST_IMAGE)
+    .withExec(["rustup", "component", "add", "rustfmt", "clippy"])
+    .withMountedDirectory("/work", source)
+    .withMountedCache("/usr/local/cargo/registry", registryCache)
+    .withMountedCache("/usr/local/cargo/git", gitCache)
+    .withMountedCache("/work/target", targetCache)
+    .withWorkdir("/work")
+}
+
 function codexAgentRolesContainer(source: Directory): Container {
   return dag
     .container()
@@ -200,6 +248,19 @@ function secretsContainer(source: Directory, mode: "dir" | "git"): Container {
 
 @object()
 export class Ci {
+  private scriptsQualityContainer(source: Directory): Container {
+    return dag
+      .container()
+      .from(PYTHON_IMAGE)
+      .withExec(["apt-get", "update"])
+      .withExec(["apt-get", "install", "-y", "--no-install-recommends", "jq"])
+      .withMountedDirectory("/work", source)
+      .withWorkdir("/work")
+      .withExec(["bash", "test/bin/entrypoint_test.sh"])
+      .withExec(["bash", "test/bin/dr_test.sh"])
+      .withExec(["bash", "test/bin/dogfood_audit_test.sh"])
+  }
+
   private async rootQualityContainer(source: Directory): Promise<Container> {
     return (await elixirContainer(source, ".", "test", "canary-root-test", "mix.lock"))
       .withExec(["mix", "compile", "--warnings-as-errors"])
@@ -281,6 +342,27 @@ export class Ci {
     ).withExec(["npm", "run", "typecheck"])
   }
 
+  private async rustFastContainer(source: Directory): Promise<Container> {
+    return (await rustContainer(source))
+      .withExec(["cargo", "fmt", "--all", "--check"])
+      .withExec(["cargo", "check", "--workspace", "--all-targets", "--locked"])
+  }
+
+  private async rustQualityContainer(source: Directory): Promise<Container> {
+    return (await this.rustFastContainer(source))
+      .withExec([
+        "cargo",
+        "clippy",
+        "--workspace",
+        "--all-targets",
+        "--locked",
+        "--",
+        "-D",
+        "warnings",
+      ])
+      .withExec(["cargo", "test", "--workspace", "--locked"])
+  }
+
   private async rootAdvisoryContainer(source: Directory): Promise<Container> {
     return (await elixirContainer(source, ".", "test", "canary-root-test", "mix.lock")).withExec(
       ["mix", "deps.audit", "--ignore-file", ".mix_audit.ignore"],
@@ -297,6 +379,12 @@ export class Ci {
         "canary_sdk/mix.lock",
       )
     ).withExec(["mix", "deps.audit", "--ignore-file", ".mix_audit.ignore"])
+  }
+
+  private async rustAdvisoryContainer(source: Directory): Promise<Container> {
+    return (await rustContainer(source))
+      .withExec(["cargo", "install", "cargo-audit", "--version", "0.22.1", "--locked"])
+      .withExec(["cargo", "audit"])
   }
 
   private async typescriptAdvisoryContainer(source: Directory): Promise<Container> {
@@ -326,6 +414,43 @@ export class Ci {
     )
   }
 
+  private productionImageContainer(source: Directory): Container {
+    return source.dockerBuild()
+  }
+
+  private productionImageSmokeContainer(source: Directory): Container {
+    const service = this.productionImageContainer(source)
+      .withEnvVariable("CANARY_DB_PATH", "/tmp/canary-smoke.db")
+      .withEnvVariable("PORT", "4000")
+      .withEnvVariable("CANARY_DISCLOSE_BOOTSTRAP_KEY", "false")
+      .withExposedPort(4000)
+      .asService()
+
+    return dag
+      .container()
+      .from(RUST_IMAGE)
+      .withExec(["apt-get", "update", "-q"])
+      .withExec(["apt-get", "install", "-yq", "--no-install-recommends", "curl"])
+      .withServiceBinding("canary", service)
+      .withExec([
+        "bash",
+        "-ceu",
+        [
+          "for _ in {1..60}; do",
+          "  if curl --fail --silent --show-error http://canary:4000/healthz >/tmp/healthz.json &&",
+          "     curl --fail --silent --show-error http://canary:4000/readyz >/tmp/readyz.json; then",
+          "    grep -F '\"status\":\"ok\"' /tmp/healthz.json",
+          "    grep -F '\"status\":\"ready\"' /tmp/readyz.json",
+          "    exit 0",
+          "  fi",
+          "  sleep 1",
+          "done",
+          "cat /tmp/healthz.json /tmp/readyz.json 2>/dev/null || true",
+          "exit 1",
+        ].join("\n"),
+      ])
+  }
+
   @func()
   async fast(
     @argument({
@@ -342,6 +467,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -349,8 +475,13 @@ export class Ci {
     const repo = source!
 
     await codexAgentRolesContainer(repo).sync()
-    await (await this.rootFastContainer(repo)).sync()
-    await (await this.sdkFastContainer(repo)).sync()
+    if (await repoUsesRust(repo)) {
+      await this.scriptsQualityContainer(repo).sync()
+      await (await this.rustFastContainer(repo)).sync()
+    } else {
+      await (await this.rootFastContainer(repo)).sync()
+      await (await this.sdkFastContainer(repo)).sync()
+    }
     await (await this.typescriptFastContainer(repo)).sync()
   }
 
@@ -370,14 +501,19 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
   ): Promise<void> {
     const repo = source!.withoutDirectory(".git")
 
-    await (await this.rootAdvisoryContainer(repo)).sync()
-    await (await this.sdkAdvisoryContainer(repo)).sync()
+    if (await repoUsesRust(repo)) {
+      await (await this.rustAdvisoryContainer(repo)).sync()
+    } else {
+      await (await this.rootAdvisoryContainer(repo)).sync()
+      await (await this.sdkAdvisoryContainer(repo)).sync()
+    }
     await (await this.typescriptAdvisoryContainer(repo)).sync()
   }
 
@@ -396,6 +532,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -424,6 +561,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -450,6 +588,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -458,6 +597,15 @@ export class Ci {
 
     await this.ciContract(repo)
     await this.openapiContract(repo)
+    if (await repoUsesRust(repo)) {
+      await this.scriptsQualityContainer(repo).sync()
+      await this.typescriptQuality(repo)
+      await this.rustQuality(repo)
+      await this.productionImageSmoke(repo)
+      await this.secrets(repo)
+      return
+    }
+
     await this.apiContracts(repo)
     await this.rootQuality(repo)
     await this.rootDialyzer(repo)
@@ -482,6 +630,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -505,6 +654,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -528,6 +678,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -551,6 +702,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -574,6 +726,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -597,6 +750,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -620,11 +774,84 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
   ): Promise<void> {
     await (await this.typescriptQualityContainer(source!)).sync()
+  }
+
+  @func()
+  async rustQuality(
+    @argument({
+      defaultPath: "/",
+      ignore: [
+        ".git",
+        "_build",
+        "deps",
+        "cover",
+        "canary_sdk/_build",
+        "canary_sdk/deps",
+        "canary_sdk/cover",
+        "clients/typescript/node_modules",
+        "clients/typescript/dist",
+        "clients/typescript/coverage",
+        "dagger/node_modules",
+        "target",
+      ],
+    })
+    source?: Directory,
+  ): Promise<void> {
+    await (await this.rustQualityContainer(source!)).sync()
+  }
+
+  @func()
+  async productionImageSmoke(
+    @argument({
+      defaultPath: "/",
+      ignore: [
+        ".git",
+        "_build",
+        "deps",
+        "cover",
+        "canary_sdk/_build",
+        "canary_sdk/deps",
+        "canary_sdk/cover",
+        "clients/typescript/node_modules",
+        "clients/typescript/dist",
+        "clients/typescript/coverage",
+        "dagger/node_modules",
+        "target",
+      ],
+    })
+    source?: Directory,
+  ): Promise<void> {
+    await this.productionImageSmokeContainer(source!).sync()
+  }
+
+  @func()
+  async rustAdvisories(
+    @argument({
+      defaultPath: "/",
+      ignore: [
+        ".git",
+        "_build",
+        "deps",
+        "cover",
+        "canary_sdk/_build",
+        "canary_sdk/deps",
+        "canary_sdk/cover",
+        "clients/typescript/node_modules",
+        "clients/typescript/dist",
+        "clients/typescript/coverage",
+        "dagger/node_modules",
+        "target",
+      ],
+    })
+    source?: Directory,
+  ): Promise<void> {
+    await (await this.rustAdvisoryContainer(source!)).sync()
   }
 
   @func()
@@ -642,6 +869,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,
@@ -665,6 +893,7 @@ export class Ci {
         "clients/typescript/dist",
         "clients/typescript/coverage",
         "dagger/node_modules",
+        "target",
       ],
     })
     source?: Directory,


### PR DESCRIPTION
## Summary
- teach the trusted Dagger control plane to detect Rust candidates via Cargo.lock while preserving the current Elixir master path via mix.lock
- add Rust quality, advisory, and production image smoke targets for Rust-shaped candidate sources
- update source argument sync and CI contract validation so the bridge remains enforced

## Verification
- ./bin/validate --fast on legacy master-shaped bridge worktree
- ./bin/dagger call strict --source=/Users/phaedrus/.codex/worktrees/3cff/canary from the bridge worktree against the Rust candidate
- git push -u origin fix/ci-dual-shape-control-plane, including ./bin/validate --strict pre-push on the legacy master-shaped bridge worktree

## Notes
- This PR is a prerequisite for PR #139 because pull_request_target runs trusted Dagger from master before it can validate the Rust-only candidate.