### PR TITLE
feat(server): add mint-key operator subcommand for key recovery

### DIFF
--- a/crates/canary-server/src/keygen.rs
+++ b/crates/canary-server/src/keygen.rs
@@ -1,0 +1,131 @@
+//! Operator key minting.
+//!
+//! `canary-server mint-key` is the no-data-loss recovery path for issuing a new
+//! scoped API key directly against the production SQLite store when the
+//! one-time bootstrap key has been lost. It reuses the exact wire shape of the
+//! `POST /api/v1/keys` admin route (raw `sk_<env>_<nanoid>`, 12-char prefix,
+//! bcrypt hash) so minted keys are indistinguishable from API-issued ones.
+
+use std::path::Path;
+
+use canary_store::{API_KEY_PREFIX_LEN, ApiKeyInsert, Store};
+
+use crate::server_time::current_rfc3339;
+
+/// Scopes accepted by the minting path, mirroring the router's permission model.
+const VALID_SCOPES: [&str; 3] = ["admin", "read-only", "ingest-only"];
+
+/// Failure modes when minting an operator API key.
+#[derive(Debug)]
+pub enum MintKeyError {
+    /// The requested scope is not one of `admin`, `read-only`, `ingest-only`.
+    InvalidScope(String),
+    /// Opening, migrating, or writing to the store failed.
+    Store(canary_store::StoreError),
+    /// Bcrypt hashing of the raw key failed.
+    Hash(bcrypt::BcryptError),
+}
+
+impl std::fmt::Display for MintKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MintKeyError::InvalidScope(scope) => write!(
+                f,
+                "invalid scope {scope:?}; expected one of admin, read-only, ingest-only"
+            ),
+            MintKeyError::Store(error) => write!(f, "store error: {error}"),
+            MintKeyError::Hash(error) => write!(f, "hash error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for MintKeyError {}
+
+/// Mint a scoped API key against the store at `db_path` and return the raw key.
+///
+/// The raw key is shown only here; the store persists the bcrypt hash. Opening
+/// a second connection while the server runs is safe for this one-shot insert:
+/// SQLite WAL serializes the brief write transaction behind the live writer.
+pub fn mint_key(db_path: &Path, scope: &str, name: &str) -> Result<String, MintKeyError> {
+    if !VALID_SCOPES.contains(&scope) {
+        return Err(MintKeyError::InvalidScope(scope.to_owned()));
+    }
+
+    let mut store = Store::open(db_path).map_err(MintKeyError::Store)?;
+    store.migrate().map_err(MintKeyError::Store)?;
+
+    let raw_key = canary_core::secrets::api_key("live");
+    let key_hash = bcrypt::hash(&raw_key, bcrypt::DEFAULT_COST).map_err(MintKeyError::Hash)?;
+
+    store
+        .insert_api_key(ApiKeyInsert {
+            id: canary_core::ids::ApiKeyId::generate().into_string(),
+            name: name.to_owned(),
+            key_prefix: raw_key.chars().take(API_KEY_PREFIX_LEN).collect(),
+            key_hash,
+            created_at: current_rfc3339(),
+            revoked_at: None,
+            scope: scope.to_owned(),
+        })
+        .map_err(MintKeyError::Store)?;
+
+    Ok(raw_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Unique temp DB path per test without pulling in a temp-file dependency.
+    fn unique_db_path(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "canary-keygen-test-{tag}-{}-{nanos}-{seq}.db",
+            std::process::id()
+        ))
+    }
+
+    struct DbGuard(PathBuf);
+    impl Drop for DbGuard {
+        fn drop(&mut self) {
+            for suffix in ["", "-wal", "-shm"] {
+                let _ = std::fs::remove_file(format!("{}{suffix}", self.0.display()));
+            }
+        }
+    }
+
+    #[test]
+    fn mint_key_round_trips_through_verification() -> Result<(), Box<dyn std::error::Error>> {
+        let db_path = unique_db_path("roundtrip");
+        let _guard = DbGuard(db_path.clone());
+
+        let raw_key = mint_key(&db_path, "admin", "recovery")?;
+
+        let store = Store::open(&db_path)?;
+        let verified = store
+            .verify_api_key(&raw_key)?
+            .ok_or("minted key should verify as active")?;
+        assert_eq!(verified.scope, "admin");
+        Ok(())
+    }
+
+    #[test]
+    fn mint_key_rejects_unknown_scope() {
+        let db_path = unique_db_path("badscope");
+        let _guard = DbGuard(db_path.clone());
+
+        let result = mint_key(&db_path, "superuser", "x");
+        assert!(
+            matches!(&result, Err(MintKeyError::InvalidScope(scope)) if scope == "superuser"),
+            "expected InvalidScope(\"superuser\"), got {result:?}"
+        );
+    }
+}

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -24,6 +24,7 @@ mod health_fanout;
 mod health_routes;
 mod http_contract;
 mod ingest_routes;
+pub mod keygen;
 mod metrics_routes;
 mod monitor_overdue;
 mod public_routes;

--- a/crates/canary-server/src/main.rs
+++ b/crates/canary-server/src/main.rs
@@ -1,8 +1,10 @@
 //! Production process entrypoint for the Rust Canary server.
 
-use std::{error::Error, process};
+use std::{error::Error, path::PathBuf, process};
 
-use canary_server::{CanaryServer, ServerProcessConfig};
+use canary_server::{CanaryServer, ServerProcessConfig, keygen};
+
+const DEFAULT_DB_PATH: &str = "/data/canary.db";
 
 #[tokio::main]
 async fn main() {
@@ -13,6 +15,14 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn Error>> {
+    // Operator subcommand: `canary-server mint-key [--scope S] [--name N]`.
+    // Recovery path for issuing a scoped API key directly against the SQLite
+    // store when the one-time bootstrap key has been lost. Defaults to admin.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.first().map(String::as_str) == Some("mint-key") {
+        return run_mint_key(&args[1..]);
+    }
+
     let config = ServerProcessConfig::from_env(std::env::vars())?;
     let listener = tokio::net::TcpListener::bind(config.listen_addr).await?;
     let local_addr = listener.local_addr()?;
@@ -20,6 +30,38 @@ async fn run() -> Result<(), Box<dyn Error>> {
 
     eprintln!("canary-server listening on {local_addr}");
     server.serve(listener, shutdown_signal()).await?;
+    Ok(())
+}
+
+fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
+    let mut scope = "admin".to_owned();
+    let mut name = "operator-minted".to_owned();
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--scope" => {
+                scope = iter.next().ok_or("--scope requires a value")?.clone();
+            }
+            "--name" => {
+                name = iter.next().ok_or("--name requires a value")?.clone();
+            }
+            other => return Err(format!("unknown mint-key argument: {other}").into()),
+        }
+    }
+
+    let db_path = std::env::var("CANARY_DB_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_DB_PATH));
+
+    let raw_key = keygen::mint_key(&db_path, &scope, &name)?;
+    // The raw key prints to stdout; everything else goes to stderr so the key
+    // can be captured cleanly (e.g. `... mint-key | tail -1`).
+    eprintln!(
+        "Minted {scope} API key {name:?} against {}",
+        db_path.display()
+    );
+    eprintln!("Store this key securely - it will not be shown again.");
+    println!("{raw_key}");
     Ok(())
 }
 


### PR DESCRIPTION
Adds `canary-server mint-key [--scope S] [--name N]` — a no-data-loss recovery path for issuing a scoped API key directly against the SQLite store when the one-time bootstrap key is lost (e.g. after a fresh-DB cutover, which orphaned all consumer ingest keys).

Reuses the exact wire shape of `POST /api/v1/keys` (sk_<env>_<nanoid>, 12-char prefix, bcrypt hash) so minted keys are indistinguishable from API-issued ones. Raw key prints to stdout; diagnostics to stderr. Complements the human-gated nuclear DB reset documented in CLAUDE.md.

Tested: round-trip (mint → verify_api_key active) and invalid-scope rejection. Passes clippy -D warnings and the pre-commit dagger fast gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `mint-key` operator command for generating scoped API keys
  * Added scope validation to prevent invalid key creation
  * Keys are cryptographically secured and stored with metadata (name, scope, timestamps)

* **Tests**
  * Added unit tests for key minting and scope validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->