### PR TITLE
feat(cli): add one-command integration agent

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -36,7 +36,7 @@
 | 035 | Deployed app Canary coverage | high | done | XL |
 | 036 | Agent-native inspection surface | high | done | L |
 | 037 | Watch the watchmen | high | done | L |
-| 038 | One-command integration agent | high | ready | XL |
+| 038 | One-command integration agent | high | done | XL |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
 
@@ -83,10 +83,9 @@
 
 ### Active order (2026-06-11)
 
-1. **038** — One-command integration agent (discover, patch, enroll, verify)
-2. **030** — Agent contract safety pass (scope annotations, summary completeness, cold-start guidance, annotation write-back; delivery-id lookup already shipped)
-3. **032** — Live Rust write-path evidence (prove deployed admin/ingest/webhook/monitor/target paths with sanitized packets)
-4. **034** — Worker lifecycle readiness oracle (make Rust background workers visible to readiness and Dagger smoke)
+1. **030** — Agent contract safety pass (scope annotations, summary completeness, cold-start guidance, annotation write-back; delivery-id lookup already shipped)
+2. **032** — Live Rust write-path evidence (prove deployed admin/ingest/webhook/monitor/target paths with sanitized packets)
+3. **034** — Worker lifecycle readiness oracle (make Rust background workers visible to readiness and Dagger smoke)
 
 022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
 2026-04-23 — Ramp
@@ -135,6 +134,11 @@ parity backlog items were retired during the Rust scorched-earth migration.
   `/readyz`, and `service=canary` readback from GitHub Actions, preserves a
   receipt artifact outside Canary, sends `canary-watchman` check-ins when
   healthy, and surfaces witness state in `bin/canary doctor`.
+- 2026-06-12: Delivered 038. `bin/canary integrate` now discovers local
+  project coverage without reading secret values, emits reviewable patch and
+  enrollment plans, safely patches Next.js apps, enrolls deployed health
+  targets through service onboarding, and exposes the loop through the MCP
+  manifest.
 
 ## Status
 

--- a/backlog.d/_done/038-one-command-integration-agent.md
+++ b/backlog.d/_done/038-one-command-integration-agent.md
@@ -1,7 +1,7 @@
 # Build a one-command Canary integration agent
 
 Priority: high
-Status: ready
+Status: done
 Estimate: XL
 
 ## Goal

--- a/clients/typescript/INTEGRATION.md
+++ b/clients/typescript/INTEGRATION.md
@@ -1,5 +1,18 @@
 # Integrating Canary into a Next.js app
 
+Agents should prefer the reviewable setup loop before hand-editing snippets:
+
+```bash
+bin/canary integrate discover /path/to/app --production-url https://app.example.com --json
+bin/canary integrate plan /path/to/app --service my-app --production-url https://app.example.com --json
+bin/canary integrate patch /path/to/app --service my-app --json
+bin/canary integrate enroll --service my-app --url https://app.example.com/api/health --json
+```
+
+The `discover` and `plan` phases report env var names only. `enroll` redacts the
+one-time ingest key by default; use `--show-secret` only for a secure secret
+handoff.
+
 ## Step 1: Install
 
 ```bash

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -1,6 +1,7 @@
 //! Agent-native inspection helpers for the `canary` CLI.
 
 use std::{
+    collections::{BTreeSet, VecDeque},
     env, fs,
     path::{Path, PathBuf},
     process::Command,
@@ -17,6 +18,10 @@ pub const DEFAULT_ENDPOINT: &str = "https://canary-obs.fly.dev";
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const WITNESS_MONITOR_NAME: &str = "canary-watchman";
+const DEFAULT_INTEGRATION_ENDPOINT_ENV: &str = "CANARY_ENDPOINT";
+const DEFAULT_INTEGRATION_SERVER_KEY_ENV: &str = "CANARY_API_KEY";
+const DEFAULT_INTEGRATION_PUBLIC_ENDPOINT_ENV: &str = "NEXT_PUBLIC_CANARY_ENDPOINT";
+const DEFAULT_INTEGRATION_PUBLIC_KEY_ENV: &str = "NEXT_PUBLIC_CANARY_API_KEY";
 
 /// Error returned by the CLI library.
 #[derive(Debug, Error)]
@@ -187,6 +192,26 @@ impl ApiClient {
         self.get_json(path, true)
     }
 
+    /// POST an authenticated JSON request and parse the JSON response.
+    pub fn post_auth_json(&self, path: &str, body: &Value) -> Result<Value> {
+        let url = format!("{}{}", self.config.endpoint, path);
+        let response = self
+            .client
+            .post(url)
+            .bearer_auth(self.config.api_key()?)
+            .json(body)
+            .send()?;
+        let status = response.status();
+        let body = response.text()?;
+        if !status.is_success() {
+            return Err(CliError::Message(format!(
+                "POST {path} returned {status}: {}",
+                redact_text(&body)
+            )));
+        }
+        serde_json::from_str(&body).map_err(CliError::from)
+    }
+
     fn get_json(&self, path: &str, auth: bool) -> Result<Value> {
         let url = format!("{}{}", self.config.endpoint, path);
         let mut request = self.client.get(url);
@@ -255,6 +280,36 @@ pub enum RenderMode {
     Json,
     /// Concise text for agent transcripts.
     Text,
+}
+
+/// Input shared by integration discovery, planning, and patching.
+#[derive(Debug, Clone)]
+pub struct IntegrationInput {
+    /// Local project path or remote platform project name.
+    pub target: PathBuf,
+    /// Optional service override.
+    pub service: Option<String>,
+    /// Optional production URL override.
+    pub production_url: Option<String>,
+    /// Optional platform project override.
+    pub platform_project: Option<String>,
+    /// Canary endpoint used in generated snippets.
+    pub endpoint: String,
+}
+
+/// Request for enrolling one service through Canary.
+#[derive(Debug, Clone)]
+pub struct IntegrationEnrollRequest {
+    /// Service name.
+    pub service: String,
+    /// Health URL to enroll as an HTTP target.
+    pub url: String,
+    /// Runtime environment label.
+    pub environment: String,
+    /// Target probe interval in milliseconds.
+    pub interval_ms: Option<i64>,
+    /// Redact returned secret material.
+    pub redact: bool,
 }
 
 /// Render a stable JSON command envelope.
@@ -372,6 +427,721 @@ pub fn run_dogfood_inventory(repo_root: &Path, strict: bool) -> Result<Value> {
         });
     }
     serde_json::from_slice(&output.stdout).map_err(CliError::from)
+}
+
+/// Discover local project integration state without reading secret values.
+pub fn integration_discover(input: &IntegrationInput) -> Result<Value> {
+    let target = &input.target;
+    let path_exists = target.exists();
+    let project_root = if path_exists {
+        target.canonicalize().map_err(|source| CliError::Io {
+            path: target.clone(),
+            source,
+        })?
+    } else {
+        target.clone()
+    };
+    let project_name = input
+        .platform_project
+        .clone()
+        .or_else(|| vercel_project_name(&project_root))
+        .or_else(|| file_name_string(target))
+        .unwrap_or_else(|| target.display().to_string());
+    let service = input
+        .service
+        .clone()
+        .unwrap_or_else(|| service_name_from_project(&project_name));
+    let package_json = path_exists
+        .then(|| project_root.join("package.json"))
+        .filter(|path| path.is_file());
+    let package = package_json
+        .as_ref()
+        .and_then(|path| read_json_file(path).ok());
+    let package_manager = detect_package_manager(&project_root);
+    let framework = detect_framework(&project_root, package.as_ref());
+    let platform = detect_platform(&project_root);
+    let env_names = discover_env_names(&project_root)?;
+    let code_paths = discover_code_paths(&project_root)?;
+    let health_routes = discover_health_routes(&project_root);
+    let canary_present = code_paths
+        .iter()
+        .any(|path| path.get("kind").and_then(Value::as_str) == Some("canary"));
+    let sentry_present = code_paths
+        .iter()
+        .any(|path| path.get("kind").and_then(Value::as_str) == Some("sentry"));
+    let canary_env_names = env_names
+        .iter()
+        .filter(|name| name.contains("CANARY"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let sentry_env_names = env_names
+        .iter()
+        .filter(|name| name.contains("SENTRY"))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "schema_version": 1,
+        "target": target.display().to_string(),
+        "path_exists": path_exists,
+        "project_root": if path_exists { project_root.display().to_string() } else { "unresolved".to_owned() },
+        "service": service,
+        "platform_project": project_name,
+        "framework": framework,
+        "platform": platform,
+        "package_manager": package_manager,
+        "production_url": input.production_url,
+        "health_route": health_routes.first().cloned(),
+        "health_routes": health_routes,
+        "signals": {
+            "package_json": package_json.map(|path| path.display().to_string()),
+            "canary_sdk_dependency": package_has_dependency(package.as_ref(), "@canary-obs/sdk"),
+            "sentry_dependency": package_has_dependency(package.as_ref(), "@sentry/nextjs")
+                || package_has_dependency(package.as_ref(), "@sentry/browser")
+                || package_has_dependency(package.as_ref(), "@sentry/react"),
+            "canary_code_paths": code_paths.iter().filter(|path| path.get("kind").and_then(Value::as_str) == Some("canary")).cloned().collect::<Vec<_>>(),
+            "sentry_code_paths": code_paths.iter().filter(|path| path.get("kind").and_then(Value::as_str) == Some("sentry")).cloned().collect::<Vec<_>>(),
+            "canary_present": canary_present,
+            "sentry_present": sentry_present,
+            "env_names": env_names,
+            "canary_env_names": canary_env_names,
+            "sentry_env_names": sentry_env_names,
+            "csp_mentions_connect_src": file_contains(&project_root.join("next.config.js"), "connect-src")
+                || file_contains(&project_root.join("next.config.mjs"), "connect-src")
+                || file_contains(&project_root.join("next.config.ts"), "connect-src")
+        }
+    }))
+}
+
+/// Build a reviewable integration plan from discovery.
+pub fn integration_plan(input: &IntegrationInput) -> Result<Value> {
+    let discovery = integration_discover(input)?;
+    let target = &input.target;
+    let path_exists = discovery
+        .get("path_exists")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let framework = discovery
+        .get("framework")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let service = discovery
+        .get("service")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let production_url = input.production_url.as_deref();
+    let health_url = production_url.map(|url| format!("{}/api/health", url.trim_end_matches('/')));
+    let canary_dep = discovery
+        .pointer("/signals/canary_sdk_dependency")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let canary_code_paths = discovery
+        .pointer("/signals/canary_code_paths")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let server_instrumentation_present = canary_code_paths.iter().any(|path| {
+        path.get("path")
+            .and_then(Value::as_str)
+            .is_some_and(|path| path == "instrumentation.ts")
+    });
+    let global_error_capture_present = canary_code_paths.iter().any(|path| {
+        path.get("path")
+            .and_then(Value::as_str)
+            .is_some_and(is_next_error_boundary_path)
+    });
+    let has_health = discovery
+        .get("health_routes")
+        .and_then(Value::as_array)
+        .is_some_and(|items| !items.is_empty());
+    let env_names = discovery
+        .pointer("/signals/env_names")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let env_set = env_names
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut actions = Vec::new();
+
+    actions.push(plan_action(
+        "sdk_dependency",
+        if canary_dep { "present" } else { "needed" },
+        "@canary-obs/sdk dependency",
+        "patch",
+    ));
+    actions.push(plan_action(
+        "server_instrumentation",
+        if server_instrumentation_present {
+            "present"
+        } else {
+            "needed"
+        },
+        "Next.js instrumentation.ts initializes Canary and exports onRequestError",
+        "patch",
+    ));
+    actions.push(plan_action(
+        "health_route",
+        if has_health { "present" } else { "needed" },
+        "GET /api/health returns a stable JSON health response",
+        "patch",
+    ));
+    actions.push(plan_action(
+        "global_error_capture",
+        if global_error_capture_present {
+            "present"
+        } else {
+            "needed"
+        },
+        "Next.js global error capture sends browser-visible errors to Canary",
+        "patch",
+    ));
+    actions.push(json!({
+        "kind": "env_names",
+        "status": required_env_names_present(&env_set),
+        "description": "Deployment should define Canary endpoint/key env names without exposing values.",
+        "executor": "platform",
+        "names": [
+            DEFAULT_INTEGRATION_ENDPOINT_ENV,
+            DEFAULT_INTEGRATION_SERVER_KEY_ENV,
+            DEFAULT_INTEGRATION_PUBLIC_ENDPOINT_ENV,
+            DEFAULT_INTEGRATION_PUBLIC_KEY_ENV
+        ]
+    }));
+    actions.push(json!({
+        "kind": "target_enrollment",
+        "status": if health_url.is_some() { "needed" } else { "blocked" },
+        "description": "Create a Canary HTTP target and ingest key through service onboarding.",
+        "executor": "enroll",
+        "service": service,
+        "health_url": health_url,
+        "blocked_reason": if health_url.is_some() { Value::Null } else { json!("pass --production-url to compute the health URL") }
+    }));
+    actions.push(json!({
+        "kind": "webhook_subscription",
+        "status": "manual",
+        "description": "Optional responder webhook; keep repo mutation outside Canary.",
+        "executor": "admin-api",
+        "events": ["error.new_class", "incident.opened", "health_check.failed"]
+    }));
+
+    Ok(json!({
+        "schema_version": 1,
+        "target": target.display().to_string(),
+        "service": service,
+        "framework": framework,
+        "can_patch": path_exists && framework == "nextjs",
+        "discovery": discovery,
+        "actions": actions,
+        "commands": {
+            "patch": format!("bin/canary integrate patch {} --service {} --endpoint {}", shell_arg(&target.display().to_string()), shell_arg(service), shell_arg(&input.endpoint)),
+            "enroll": health_url.map(|url| format!("bin/canary integrate enroll --service {} --url {}", shell_arg(service), shell_arg(&url))),
+            "verify": format!("bin/canary errors {} --window 1h", shell_arg(service))
+        }
+    }))
+}
+
+/// Apply safe Next.js integration patches and report every file touched or skipped.
+pub fn integration_patch(input: &IntegrationInput) -> Result<Value> {
+    let plan = integration_plan(input)?;
+    if !plan
+        .get("can_patch")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(CliError::Message(
+            "patch currently supports existing Next.js project paths only".to_owned(),
+        ));
+    }
+
+    let root = input.target.canonicalize().map_err(|source| CliError::Io {
+        path: input.target.clone(),
+        source,
+    })?;
+    let service = plan
+        .get("service")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let mut changes = Vec::new();
+
+    changes.push(update_package_dependency(&root)?);
+    changes.push(write_if_absent_or_canary(
+        &instrumentation_path(&root),
+        &instrumentation_source(service, &input.endpoint),
+    )?);
+    changes.push(write_if_absent_or_canary(
+        &health_route_path(&root),
+        health_route_source(),
+    )?);
+    changes.push(write_if_absent_or_canary(
+        &global_error_path(&root),
+        &global_error_source(service),
+    )?);
+
+    Ok(json!({
+        "schema_version": 1,
+        "project_root": root.display().to_string(),
+        "service": service,
+        "changes": changes,
+        "next_steps": [
+            "Review the patch before deploying.",
+            "Set Canary env names in the deployment platform without committing secret values.",
+            "Deploy, then run canary integrate enroll and canary errors <service> --window 1h."
+        ]
+    }))
+}
+
+/// Enroll a service through the hosted Canary admin API and redact secret output by default.
+pub fn integration_enroll(client: &ApiClient, request: &IntegrationEnrollRequest) -> Result<Value> {
+    let mut body = json!({
+        "service": request.service,
+        "url": request.url,
+        "environment": request.environment
+    });
+    if let Some(interval_ms) = request.interval_ms
+        && let Some(object) = body.as_object_mut()
+    {
+        object.insert("interval_ms".to_owned(), json!(interval_ms));
+    }
+    let response = client.post_auth_json("/api/v1/service-onboarding", &body)?;
+    if request.redact {
+        Ok(redact_secret_value(response))
+    } else {
+        Ok(response)
+    }
+}
+
+/// Summarize an integration discovery/plan/patch/enroll response.
+pub fn summarize_integration(value: &Value) -> Vec<String> {
+    let mut lines = vec![
+        format!("service: {}", string_field(value, "service")),
+        format!("framework: {}", string_field(value, "framework")),
+    ];
+    if let Some(actions) = value.get("actions").and_then(Value::as_array) {
+        lines.push(format!("actions: {}", actions.len()));
+        lines.extend(actions.iter().map(|action| {
+            format!(
+                "- {}: {}",
+                string_field(action, "kind"),
+                string_field(action, "status")
+            )
+        }));
+    } else if let Some(changes) = value.get("changes").and_then(Value::as_array) {
+        lines.push(format!("changes: {}", changes.len()));
+        lines.extend(changes.iter().map(|change| {
+            format!(
+                "- {}: {}",
+                string_field(change, "path"),
+                string_field(change, "status")
+            )
+        }));
+    } else if value.get("target").is_some() && value.get("api_key").is_some() {
+        lines.push(format!(
+            "target: {}",
+            value
+                .get("target")
+                .map(|target| string_field(target, "id"))
+                .unwrap_or_else(|| "unknown".to_owned())
+        ));
+        lines.push(format!(
+            "api_key: {}",
+            value
+                .get("api_key")
+                .map(|key| string_field(key, "key"))
+                .unwrap_or_else(|| "redacted".to_owned())
+        ));
+    }
+    lines
+}
+
+fn read_json_file(path: &Path) -> Result<Value> {
+    let body = fs::read_to_string(path).map_err(|source| CliError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&body).map_err(CliError::from)
+}
+
+fn file_name_string(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn vercel_project_name(root: &Path) -> Option<String> {
+    let path = root.join(".vercel/project.json");
+    read_json_file(&path)
+        .ok()
+        .and_then(|value| string_value(&value, "projectName"))
+}
+
+fn service_name_from_project(project: &str) -> String {
+    project
+        .trim()
+        .trim_start_matches("www.")
+        .replace("_", "-")
+        .to_ascii_lowercase()
+}
+
+fn detect_package_manager(root: &Path) -> &'static str {
+    if root.join("pnpm-lock.yaml").is_file() {
+        "pnpm"
+    } else if root.join("yarn.lock").is_file() {
+        "yarn"
+    } else if root.join("package-lock.json").is_file() {
+        "npm"
+    } else {
+        "unknown"
+    }
+}
+
+fn detect_framework(root: &Path, package: Option<&Value>) -> &'static str {
+    if package_has_dependency(package, "next")
+        || root.join("next.config.js").is_file()
+        || root.join("next.config.mjs").is_file()
+        || root.join("next.config.ts").is_file()
+    {
+        "nextjs"
+    } else if package.is_some() {
+        "node"
+    } else {
+        "unknown"
+    }
+}
+
+fn detect_platform(root: &Path) -> &'static str {
+    if root.join(".vercel/project.json").is_file() {
+        "vercel"
+    } else if root.join("fly.toml").is_file() {
+        "fly"
+    } else {
+        "unknown"
+    }
+}
+
+fn package_has_dependency(package: Option<&Value>, name: &str) -> bool {
+    package.is_some_and(|package| {
+        [
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies",
+        ]
+        .into_iter()
+        .any(|key| package.get(key).and_then(|deps| deps.get(name)).is_some())
+    })
+}
+
+fn discover_env_names(root: &Path) -> Result<Vec<String>> {
+    let mut names = BTreeSet::new();
+    for filename in [
+        ".env",
+        ".env.local",
+        ".env.production",
+        ".env.production.local",
+        ".env.example",
+    ] {
+        let path = root.join(filename);
+        if !path.is_file() {
+            continue;
+        }
+        let body = fs::read_to_string(&path).map_err(|source| CliError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        for line in body.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('#') || trimmed.is_empty() {
+                continue;
+            }
+            if let Some((name, _value)) = trimmed.split_once('=') {
+                let name = name.trim();
+                if valid_env_name(name) {
+                    names.insert(name.to_owned());
+                }
+            }
+        }
+    }
+    Ok(names.into_iter().collect())
+}
+
+fn valid_env_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_uppercase() || ch.is_ascii_digit())
+}
+
+fn discover_code_paths(root: &Path) -> Result<Vec<Value>> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut paths = Vec::new();
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    let mut scanned = 0usize;
+    while let Some(dir) = queue.pop_front() {
+        if scanned > 500 {
+            break;
+        }
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(source) => {
+                return Err(CliError::Io { path: dir, source });
+            }
+        };
+        for entry in entries {
+            let entry = entry.map_err(|source| CliError::Io {
+                path: dir.clone(),
+                source,
+            })?;
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with(".git")
+                || matches!(
+                    name.as_ref(),
+                    "node_modules" | ".next" | "dist" | "build" | "coverage" | "target"
+                )
+            {
+                continue;
+            }
+            if path.is_dir() {
+                queue.push_back(path);
+                continue;
+            }
+            scanned += 1;
+            if !is_source_like(&path) {
+                continue;
+            }
+            let body = fs::read_to_string(&path).unwrap_or_default();
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(path.as_path())
+                .display()
+                .to_string();
+            if body.contains("@canary-obs/sdk") || body.contains("initCanary") {
+                paths.push(json!({"kind": "canary", "path": rel}));
+            } else if body.contains("@sentry/")
+                || body.contains("Sentry.")
+                || body.contains("withSentryConfig")
+            {
+                paths.push(json!({"kind": "sentry", "path": rel}));
+            }
+        }
+    }
+    Ok(paths)
+}
+
+fn is_source_like(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs"))
+}
+
+fn discover_health_routes(root: &Path) -> Vec<Value> {
+    let mut routes = Vec::new();
+    for (path, route) in [
+        ("app/api/health/route.ts", "/api/health"),
+        ("app/api/health/route.tsx", "/api/health"),
+        ("pages/api/health.ts", "/api/health"),
+        ("pages/api/health.js", "/api/health"),
+        ("app/health/route.ts", "/health"),
+        ("app/health/route.tsx", "/health"),
+    ] {
+        if root.join(path).is_file() {
+            routes.push(json!({"path": path, "route": route}));
+        }
+    }
+    routes
+}
+
+fn file_contains(path: &Path, needle: &str) -> bool {
+    fs::read_to_string(path).is_ok_and(|body| body.contains(needle))
+}
+
+fn is_next_error_boundary_path(path: &str) -> bool {
+    path == "app/global-error.tsx"
+        || path == "app/global-error.jsx"
+        || path.ends_with("/global-error.tsx")
+        || path.ends_with("/global-error.jsx")
+        || path.ends_with("/error.tsx")
+        || path.ends_with("/error.jsx")
+}
+
+fn plan_action(kind: &str, status: &str, description: &str, executor: &str) -> Value {
+    json!({
+        "kind": kind,
+        "status": status,
+        "description": description,
+        "executor": executor
+    })
+}
+
+fn required_env_names_present(env_set: &BTreeSet<&str>) -> &'static str {
+    let required = [
+        DEFAULT_INTEGRATION_ENDPOINT_ENV,
+        DEFAULT_INTEGRATION_SERVER_KEY_ENV,
+        DEFAULT_INTEGRATION_PUBLIC_ENDPOINT_ENV,
+        DEFAULT_INTEGRATION_PUBLIC_KEY_ENV,
+    ];
+    if required.into_iter().all(|name| env_set.contains(name)) {
+        "present"
+    } else {
+        "needed"
+    }
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '-' | '_' | ':' | '='))
+    {
+        value.to_owned()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn instrumentation_path(root: &Path) -> PathBuf {
+    root.join("instrumentation.ts")
+}
+
+fn health_route_path(root: &Path) -> PathBuf {
+    root.join("app/api/health/route.ts")
+}
+
+fn global_error_path(root: &Path) -> PathBuf {
+    root.join("app/global-error.tsx")
+}
+
+fn instrumentation_source(service: &str, endpoint: &str) -> String {
+    let endpoint = ts_string_literal(endpoint);
+    let service = ts_string_literal(service);
+    format!(
+        "import {{ initCanary }} from \"@canary-obs/sdk\";\nexport {{ onRequestError }} from \"@canary-obs/sdk/nextjs\";\n\nexport function register() {{\n  initCanary({{\n    endpoint: process.env.{DEFAULT_INTEGRATION_ENDPOINT_ENV} ?? {endpoint},\n    apiKey: process.env.{DEFAULT_INTEGRATION_SERVER_KEY_ENV} ?? \"\",\n    service: {service},\n    environment: process.env.NODE_ENV ?? \"production\",\n    scrubPii: true,\n  }});\n}}\n"
+    )
+}
+
+fn health_route_source() -> &'static str {
+    "// Canary health route generated by canary integrate patch.\nexport function GET() {\n  return Response.json({ status: \"ok\" });\n}\n"
+}
+
+fn global_error_source(service: &str) -> String {
+    let service = ts_string_literal(service);
+    format!(
+        "\"use client\";\n\nimport {{ useEffect }} from \"react\";\nimport {{ captureException, initCanary }} from \"@canary-obs/sdk\";\n\nexport default function GlobalError({{ error }}: {{ error: Error }}) {{\n  useEffect(() => {{\n    initCanary({{\n      endpoint: process.env.{DEFAULT_INTEGRATION_PUBLIC_ENDPOINT_ENV} ?? \"\",\n      apiKey: process.env.{DEFAULT_INTEGRATION_PUBLIC_KEY_ENV} ?? \"\",\n      service: process.env.NEXT_PUBLIC_CANARY_SERVICE ?? {service},\n      environment: process.env.NODE_ENV ?? \"production\",\n      scrubPii: true,\n    }});\n    void captureException(error);\n  }}, [error]);\n\n  return (\n    <html>\n      <body>Something went wrong.</body>\n    </html>\n  );\n}}\n"
+    )
+}
+
+fn ts_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_owned())
+}
+
+fn update_package_dependency(root: &Path) -> Result<Value> {
+    let path = root.join("package.json");
+    let mut package = read_json_file(&path)?;
+    if package_has_dependency(Some(&package), "@canary-obs/sdk") {
+        return Ok(json!({"path": path.display().to_string(), "status": "unchanged"}));
+    }
+    let Some(object) = package.as_object_mut() else {
+        return Err(CliError::Message(
+            "package.json must be a JSON object".to_owned(),
+        ));
+    };
+    let deps = object.entry("dependencies").or_insert_with(|| json!({}));
+    let Some(deps) = deps.as_object_mut() else {
+        return Err(CliError::Message(
+            "package.json dependencies must be a JSON object".to_owned(),
+        ));
+    };
+    deps.insert("@canary-obs/sdk".to_owned(), json!("^0.1.0"));
+    write_json_file(&path, &package)?;
+    Ok(json!({"path": path.display().to_string(), "status": "updated"}))
+}
+
+fn write_json_file(path: &Path, value: &Value) -> Result<()> {
+    let body = format!("{}\n", serde_json::to_string_pretty(value)?);
+    fs::write(path, body).map_err(|source| CliError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn write_if_absent_or_canary(path: &Path, body: &str) -> Result<Value> {
+    if path.exists() {
+        let existing = fs::read_to_string(path).map_err(|source| CliError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        if !existing.contains("@canary-obs/sdk")
+            && !existing.to_ascii_lowercase().contains("canary")
+        {
+            return Ok(json!({
+                "path": path.display().to_string(),
+                "status": "skipped",
+                "reason": "existing file is not Canary-owned"
+            }));
+        }
+        if existing == body {
+            return Ok(json!({"path": path.display().to_string(), "status": "unchanged"}));
+        }
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| CliError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    fs::write(path, body).map_err(|source| CliError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(json!({"path": path.display().to_string(), "status": "updated"}))
+}
+
+fn redact_secret_value(mut value: Value) -> Value {
+    if let Some(key) = value.get_mut("api_key").and_then(Value::as_object_mut) {
+        if key.contains_key("key") {
+            key.insert("key".to_owned(), json!("redacted"));
+        }
+        if key.contains_key("warning") {
+            key.insert(
+                "warning".to_owned(),
+                json!("Key redacted by CLI. Re-run with --show-secret only in a secure handoff."),
+            );
+        }
+    }
+    redact_secret_strings(&mut value);
+    value
+}
+
+fn redact_secret_strings(value: &mut Value) {
+    match value {
+        Value::String(text) => {
+            *text = redact_text(text);
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_secret_strings(item);
+            }
+        }
+        Value::Object(object) => {
+            for item in object.values_mut() {
+                redact_secret_strings(item);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn string_value(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
 }
 
 /// Find the repository root by walking upward until the dogfood command exists.
@@ -505,17 +1275,26 @@ fn normalize_endpoint(endpoint: &str) -> String {
 }
 
 fn redact_text(input: &str) -> String {
-    input
-        .split_whitespace()
-        .map(|part| {
-            if part.starts_with("sk_") {
-                "sk_...".to_owned()
-            } else {
-                part.to_owned()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+    let mut output = String::with_capacity(input.len());
+    let mut remaining = input;
+    while let Some(index) = remaining.find("sk_") {
+        output.push_str(&remaining[..index]);
+        output.push_str("sk_...");
+        let secret = &remaining[index..];
+        let end = secret
+            .char_indices()
+            .find_map(|(offset, ch)| {
+                if offset > 0 && !matches!(ch, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '-') {
+                    Some(offset)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(secret.len());
+        remaining = &secret[end..];
+    }
+    output.push_str(remaining);
+    output
 }
 
 fn string_field(value: &Value, key: &str) -> String {
@@ -823,12 +1602,33 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
             description: "Run the agent-oriented Canary doctor check.",
             input_schema: json!({"type":"object","properties":{}}),
         },
+        ToolSpec {
+            name: "canary_integrate_discover",
+            description: "Discover local project integration state without reading secret values.",
+            input_schema: json!({"type":"object","required":["path_or_project"],"properties":{"path_or_project":{"type":"string"},"service":{"type":"string"},"production_url":{"type":"string"},"platform_project":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_integrate_plan",
+            description: "Emit a reviewable Canary integration patch and enrollment plan.",
+            input_schema: json!({"type":"object","required":["path_or_project"],"properties":{"path_or_project":{"type":"string"},"service":{"type":"string"},"production_url":{"type":"string"},"platform_project":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_integrate_patch",
+            description: "Apply safe Next.js Canary integration patches after reviewing the plan.",
+            input_schema: json!({"type":"object","required":["path_or_project"],"properties":{"path_or_project":{"type":"string"},"service":{"type":"string"},"production_url":{"type":"string"},"platform_project":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_integrate_enroll",
+            description: "Create a Canary health target and scoped ingest key for a deployed service; redacts the one-time key by default.",
+            input_schema: json!({"type":"object","required":["service","url"],"properties":{"service":{"type":"string"},"url":{"type":"string"},"environment":{"type":"string"},"interval_ms":{"type":"integer"},"show_secret":{"type":"boolean","default":false}}}),
+        },
     ]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn witness_monitor_report_keeps_never_checked_in_monitor_configured() {
@@ -861,5 +1661,280 @@ mod tests {
         assert_eq!(report["status"], "configured");
         assert_eq!(report["monitor"], "canary-watchman");
         assert_eq!(report["mode"], "ttl");
+    }
+
+    #[test]
+    fn integration_discovery_reports_secret_names_without_values()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let root = temp_project("discover")?;
+        fs::create_dir_all(root.join(".vercel"))?;
+        fs::write(
+            root.join(".vercel/project.json"),
+            r#"{"projectName":"Misty Step"}"#,
+        )?;
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"next":"15.0.0","@sentry/nextjs":"8.0.0"}}"#,
+        )?;
+        fs::write(
+            root.join(".env.local"),
+            "CANARY_API_KEY=sk_live_should_not_leak\nSENTRY_DSN=https://secret@example.com\n",
+        )?;
+        fs::write(
+            root.join("instrumentation.ts"),
+            "import * as Sentry from '@sentry/nextjs';\n",
+        )?;
+
+        let discovery = integration_discover(&IntegrationInput {
+            target: root.clone(),
+            service: None,
+            production_url: Some("https://www.mistystep.io".to_owned()),
+            platform_project: None,
+            endpoint: DEFAULT_ENDPOINT.to_owned(),
+        })?;
+        let rendered = serde_json::to_string(&discovery)?;
+
+        assert_eq!(discovery["framework"], "nextjs");
+        assert_eq!(discovery["platform"], "vercel");
+        assert_eq!(discovery["service"], "misty step");
+        assert_eq!(
+            discovery["signals"]["canary_env_names"],
+            json!(["CANARY_API_KEY"])
+        );
+        assert_eq!(
+            discovery["signals"]["sentry_env_names"],
+            json!(["SENTRY_DSN"])
+        );
+        assert!(
+            discovery["signals"]["sentry_present"]
+                .as_bool()
+                .unwrap_or(false)
+        );
+        assert!(
+            !discovery["signals"]["canary_present"]
+                .as_bool()
+                .unwrap_or(true)
+        );
+        assert_eq!(discovery["signals"]["canary_code_paths"], json!([]));
+        assert!(!rendered.contains("sk_live_should_not_leak"));
+        assert!(!rendered.contains("secret@example.com"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn integration_plan_distinguishes_patch_platform_and_enrollment_actions()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let root = temp_project("plan")?;
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"next":"15.0.0"}}"#,
+        )?;
+
+        let plan = integration_plan(&IntegrationInput {
+            target: root.clone(),
+            service: Some("timeismoney-splash".to_owned()),
+            production_url: Some("https://www.timeismoney.works".to_owned()),
+            platform_project: None,
+            endpoint: DEFAULT_ENDPOINT.to_owned(),
+        })?;
+        let actions = plan["actions"].as_array().ok_or("missing actions")?;
+
+        assert_eq!(plan["can_patch"], true);
+        assert!(has_action(actions, "sdk_dependency", "needed"));
+        assert!(has_action(actions, "server_instrumentation", "needed"));
+        assert!(has_action(actions, "health_route", "needed"));
+        assert!(has_action(actions, "global_error_capture", "needed"));
+        assert!(has_action(actions, "env_names", "needed"));
+        assert!(has_action(actions, "target_enrollment", "needed"));
+        assert_eq!(
+            action(actions, "target_enrollment")?["health_url"],
+            "https://www.timeismoney.works/api/health"
+        );
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn integration_plan_distinguishes_server_and_browser_canary_capture()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let root = temp_project("roles")?;
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"next":"15.0.0","@canary-obs/sdk":"0.1.0"}}"#,
+        )?;
+        fs::create_dir_all(root.join("app"))?;
+        fs::write(
+            root.join("app/global-error.tsx"),
+            "import { captureException } from '@canary-obs/sdk';\n",
+        )?;
+
+        let plan = integration_plan(&IntegrationInput {
+            target: root.clone(),
+            service: Some("browser-only".to_owned()),
+            production_url: Some("https://example.com".to_owned()),
+            platform_project: None,
+            endpoint: DEFAULT_ENDPOINT.to_owned(),
+        })?;
+        let actions = plan["actions"].as_array().ok_or("missing actions")?;
+
+        assert!(has_action(actions, "server_instrumentation", "needed"));
+        assert!(has_action(actions, "global_error_capture", "present"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn integration_patch_adds_nextjs_files_and_refuses_foreign_overwrites()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let root = temp_project("patch")?;
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"next":"15.0.0"}}"#,
+        )?;
+        fs::write(
+            root.join("instrumentation.ts"),
+            "export function register() {}\n",
+        )?;
+
+        let patched = integration_patch(&IntegrationInput {
+            target: root.clone(),
+            service: Some("vanity".to_owned()),
+            production_url: Some("https://www.phaedrus.io".to_owned()),
+            platform_project: None,
+            endpoint: DEFAULT_ENDPOINT.to_owned(),
+        })?;
+        let changes = patched["changes"].as_array().ok_or("missing changes")?;
+        let package = fs::read_to_string(root.join("package.json"))?;
+        let instrumentation = fs::read_to_string(root.join("instrumentation.ts"))?;
+        let health = fs::read_to_string(root.join("app/api/health/route.ts"))?;
+        let global_error = fs::read_to_string(root.join("app/global-error.tsx"))?;
+
+        assert!(package.contains("@canary-obs/sdk"));
+        assert_eq!(instrumentation, "export function register() {}\n");
+        assert!(health.contains("status: \"ok\""));
+        assert!(
+            global_error.contains("service: process.env.NEXT_PUBLIC_CANARY_SERVICE ?? \"vanity\"")
+        );
+        assert!(changes.iter().any(|change| {
+            change["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("instrumentation.ts"))
+                && change["status"] == "skipped"
+        }));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn integration_patch_skips_foreign_health_routes_and_escapes_literals()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let root = temp_project("patch-safe")?;
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"next":"15.0.0"}}"#,
+        )?;
+        fs::create_dir_all(root.join("app/api/health"))?;
+        fs::write(
+            root.join("app/api/health/route.ts"),
+            "export function GET() {\n  return Response.json({ status: \"ok\", database: \"checked\" });\n}\n",
+        )?;
+
+        let patched = integration_patch(&IntegrationInput {
+            target: root.clone(),
+            service: Some("bad\"; throw new Error(\"boom\") //".to_owned()),
+            production_url: Some("https://example.com".to_owned()),
+            platform_project: None,
+            endpoint: "https://canary.example/\"quoted\"".to_owned(),
+        })?;
+        let changes = patched["changes"].as_array().ok_or("missing changes")?;
+        let health = fs::read_to_string(root.join("app/api/health/route.ts"))?;
+        let instrumentation = fs::read_to_string(root.join("instrumentation.ts"))?;
+
+        assert!(health.contains("database: \"checked\""));
+        assert!(changes.iter().any(|change| {
+            change["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("app/api/health/route.ts"))
+                && change["status"] == "skipped"
+        }));
+        assert!(instrumentation.contains(r#"service: "bad\"; throw new Error(\"boom\") //""#));
+        assert!(instrumentation.contains(
+            r#"endpoint: process.env.CANARY_ENDPOINT ?? "https://canary.example/\"quoted\"""#
+        ));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn integration_enroll_receipt_redaction_removes_one_time_keys() {
+        let response = json!({
+            "service": "vanity",
+            "api_key": {
+                "key": "sk_live_secret",
+                "warning": "Store this key securely. It will not be shown again."
+            },
+            "target": {"id": "TGT-1"},
+            "nested": {"future": "prefix sk_live_secret suffix"},
+            "snippets": {
+                "typescript_init": "initCanary({ apiKey: \"sk_live_secret\" })",
+                "error_ingest_curl": "Authorization: Bearer sk_live_secret"
+            }
+        });
+
+        let redacted = redact_secret_value(response);
+        let rendered = serde_json::to_string(&redacted).unwrap_or_default();
+
+        assert_eq!(redacted["api_key"]["key"], "redacted");
+        assert!(
+            redacted["api_key"]["warning"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("redacted")
+        );
+        assert_eq!(redacted["nested"]["future"], "prefix sk_... suffix");
+        assert!(!rendered.contains("sk_live_secret"));
+        assert!(rendered.contains("sk_..."));
+    }
+
+    #[test]
+    fn mcp_manifest_exposes_integration_tools() {
+        let names = tool_manifest()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<BTreeSet<_>>();
+
+        assert!(names.contains("canary_integrate_discover"));
+        assert!(names.contains("canary_integrate_plan"));
+        assert!(names.contains("canary_integrate_patch"));
+        assert!(names.contains("canary_integrate_enroll"));
+    }
+
+    fn temp_project(name: &str) -> std::result::Result<PathBuf, Box<dyn std::error::Error>> {
+        let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let root = env::temp_dir().join(format!("canary-cli-{name}-{nonce}"));
+        fs::create_dir_all(&root)?;
+        Ok(root)
+    }
+
+    fn has_action(actions: &[Value], kind: &str, status: &str) -> bool {
+        actions
+            .iter()
+            .any(|item| item["kind"] == kind && item["status"] == status)
+    }
+
+    fn action<'a>(
+        actions: &'a [Value],
+        kind: &str,
+    ) -> std::result::Result<&'a Value, Box<dyn std::error::Error>> {
+        actions
+            .iter()
+            .find(|item| item["kind"] == kind)
+            .ok_or_else(|| format!("missing action {kind}").into())
     }
 }

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -3,11 +3,13 @@
 use std::{env, path::PathBuf, process::ExitCode};
 
 use canary_cli::{
-    ApiClient, CliError, Config, RenderMode, Result, Window, doctor_report,
-    dogfood_strict_failure_count, encode, find_repo_root, json_envelope, print_json, print_lines,
-    resolve_endpoint_without_config, run_dogfood_inventory, summarize_doctor, summarize_dogfood,
-    summarize_incidents, summarize_monitors, summarize_query, summarize_report, summarize_services,
-    summarize_targets, summarize_timeline, tool_manifest,
+    ApiClient, CliError, Config, IntegrationEnrollRequest, IntegrationInput, RenderMode, Result,
+    Window, doctor_report, dogfood_strict_failure_count, encode, find_repo_root,
+    integration_discover, integration_enroll, integration_patch, integration_plan, json_envelope,
+    print_json, print_lines, resolve_endpoint_without_config, run_dogfood_inventory,
+    summarize_doctor, summarize_dogfood, summarize_incidents, summarize_integration,
+    summarize_monitors, summarize_query, summarize_report, summarize_services, summarize_targets,
+    summarize_timeline, tool_manifest,
 };
 use clap::{Args, Parser, Subcommand};
 use serde_json::json;
@@ -46,6 +48,8 @@ enum Commands {
     Monitors,
     /// Inspect dogfood coverage.
     Dogfood(DogfoodArgs),
+    /// Discover, plan, patch, and enroll application integrations.
+    Integrate(IntegrateArgs),
     /// Run an agent-oriented health and coverage diagnostic.
     Doctor,
     /// Emit the CLI-backed MCP tool manifest.
@@ -107,6 +111,49 @@ struct DogfoodAuditArgs {
     strict: bool,
 }
 
+#[derive(Debug, Args)]
+struct IntegrateArgs {
+    #[command(subcommand)]
+    command: IntegrateCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum IntegrateCommand {
+    /// Discover local integration state without reading secret values.
+    Discover(IntegrateProjectArgs),
+    /// Emit a reviewable patch/enrollment plan.
+    Plan(IntegrateProjectArgs),
+    /// Apply safe Next.js integration patches.
+    Patch(IntegrateProjectArgs),
+    /// Enroll a deployed service in Canary.
+    Enroll(IntegrateEnrollArgs),
+}
+
+#[derive(Debug, Args)]
+struct IntegrateProjectArgs {
+    path_or_project: PathBuf,
+    #[arg(long)]
+    service: Option<String>,
+    #[arg(long)]
+    production_url: Option<String>,
+    #[arg(long)]
+    platform_project: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct IntegrateEnrollArgs {
+    #[arg(long)]
+    service: String,
+    #[arg(long)]
+    url: String,
+    #[arg(long, default_value = "production")]
+    environment: String,
+    #[arg(long)]
+    interval_ms: Option<i64>,
+    #[arg(long)]
+    show_secret: bool,
+}
+
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
@@ -157,11 +204,88 @@ fn run() -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Integrate(args) => run_integrate_command(args, endpoint, api_key, config, mode),
         Commands::McpManifest => print_json(&json!({
             "schema_version": 1,
             "tools": tool_manifest()
         })),
         command => run_http_command(command, endpoint, api_key, config, mode),
+    }
+}
+
+fn run_integrate_command(
+    args: IntegrateArgs,
+    endpoint: Option<String>,
+    api_key: Option<String>,
+    config_path: Option<PathBuf>,
+    mode: RenderMode,
+) -> Result<()> {
+    match args.command {
+        IntegrateCommand::Discover(args) => {
+            let endpoint = resolve_endpoint_without_config(endpoint.as_deref());
+            let input = integration_input(args, endpoint.clone());
+            let response = integration_discover(&input)?;
+            render(
+                "integrate discover",
+                &endpoint,
+                response,
+                mode,
+                summarize_integration,
+            )
+        }
+        IntegrateCommand::Plan(args) => {
+            let endpoint = resolve_endpoint_without_config(endpoint.as_deref());
+            let input = integration_input(args, endpoint.clone());
+            let response = integration_plan(&input)?;
+            render(
+                "integrate plan",
+                &endpoint,
+                response,
+                mode,
+                summarize_integration,
+            )
+        }
+        IntegrateCommand::Patch(args) => {
+            let endpoint = resolve_endpoint_without_config(endpoint.as_deref());
+            let input = integration_input(args, endpoint.clone());
+            let response = integration_patch(&input)?;
+            render(
+                "integrate patch",
+                &endpoint,
+                response,
+                mode,
+                summarize_integration,
+            )
+        }
+        IntegrateCommand::Enroll(args) => {
+            let config = Config::resolve(endpoint, api_key, config_path)?;
+            let client = ApiClient::new(config)?;
+            let request = IntegrationEnrollRequest {
+                service: args.service,
+                url: args.url,
+                environment: args.environment,
+                interval_ms: args.interval_ms,
+                redact: !args.show_secret,
+            };
+            let response = integration_enroll(&client, &request)?;
+            render(
+                "integrate enroll",
+                client.endpoint(),
+                response,
+                mode,
+                summarize_integration,
+            )
+        }
+    }
+}
+
+fn integration_input(args: IntegrateProjectArgs, endpoint: String) -> IntegrationInput {
+    IntegrationInput {
+        target: args.path_or_project,
+        service: args.service,
+        production_url: args.production_url,
+        platform_project: args.platform_project,
+        endpoint,
     }
 }
 
@@ -272,7 +396,9 @@ fn run_http_command(
                 summarize_doctor,
             )
         }
-        Commands::Dogfood(_) | Commands::McpManifest => unreachable!("handled before HTTP setup"),
+        Commands::Dogfood(_) | Commands::Integrate(_) | Commands::McpManifest => {
+            unreachable!("handled before HTTP setup")
+        }
     }
 }
 

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -42,6 +42,10 @@ bin/canary timeline --service chrondle --window 7d --limit 20
 bin/canary targets
 bin/canary monitors
 bin/canary dogfood audit --strict
+bin/canary integrate discover /path/to/app --production-url https://app.example.com --json
+bin/canary integrate plan /path/to/app --service app --production-url https://app.example.com --json
+bin/canary integrate patch /path/to/app --service app --json
+bin/canary integrate enroll --service app --url https://app.example.com/api/health --json
 bin/canary doctor --json
 bin/canary mcp-manifest
 ```
@@ -77,6 +81,38 @@ created by `bin/canary-witness`. The witness line is:
 
 The witness runbook and GitHub Actions receipt contract live in
 `docs/canary-witness.md`.
+
+## Integration Agent
+
+`integrate` is the agent-native setup loop for deployed applications. It is
+deliberately split into reviewable phases:
+
+- `discover <path-or-project> --json` reads local project structure, framework hints,
+  Vercel/Fly markers, package dependencies, existing Sentry/Canary code paths,
+  health routes, and environment variable names. It does not read or print env
+  values.
+- `plan <path-or-project> --json` emits an action list for SDK instrumentation, health
+  routes, platform env names, Canary target enrollment, monitor/webhook followup,
+  and the commands the agent should run next.
+- `patch <path-or-project> --json` applies the safe Next.js code path: adds
+  `@canary-obs/sdk`, `instrumentation.ts`, `app/api/health/route.ts`, and
+  `app/global-error.tsx` only when files are absent or already Canary-owned.
+- `enroll --service <name> --url <health-url> --json` calls the admin API to
+  create the health target and scoped ingest key. The one-time key and snippets
+  are redacted unless `--show-secret` is explicitly passed for a secure handoff.
+
+Use SDK instrumentation when the application code can ship a patch: it provides
+service names, environments, scrubbed context, and typed request/browser error
+capture. Use platform-level drains only as a supplement for logs/errors the app
+cannot reach directly; drains do not replace typed SDK context and still need
+Canary target/query readback before coverage is claimed.
+
+For Vercel projects, pair `integrate discover/plan` with `vercel env ls
+production --cwd <repo> --format=json` and `vercel env ls preview --cwd <repo>
+--format=json` to audit env-name presence without exposing values. For Fly apps,
+pair it with `flyctl status` and the app's public health URL. Agents should not
+write platform secrets unless the value arrives through stdin or an approved
+secret-manager handoff.
 
 ## MCP Shape
 

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -52,6 +52,107 @@
         "type": "object"
       },
       "name": "canary_doctor"
+    },
+    {
+      "description": "Discover local project integration state without reading secret values.",
+      "input_schema": {
+        "properties": {
+          "path_or_project": {
+            "type": "string"
+          },
+          "platform_project": {
+            "type": "string"
+          },
+          "production_url": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path_or_project"
+        ],
+        "type": "object"
+      },
+      "name": "canary_integrate_discover"
+    },
+    {
+      "description": "Emit a reviewable Canary integration patch and enrollment plan.",
+      "input_schema": {
+        "properties": {
+          "path_or_project": {
+            "type": "string"
+          },
+          "platform_project": {
+            "type": "string"
+          },
+          "production_url": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path_or_project"
+        ],
+        "type": "object"
+      },
+      "name": "canary_integrate_plan"
+    },
+    {
+      "description": "Apply safe Next.js Canary integration patches after reviewing the plan.",
+      "input_schema": {
+        "properties": {
+          "path_or_project": {
+            "type": "string"
+          },
+          "platform_project": {
+            "type": "string"
+          },
+          "production_url": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path_or_project"
+        ],
+        "type": "object"
+      },
+      "name": "canary_integrate_patch"
+    },
+    {
+      "description": "Create a Canary health target and scoped ingest key for a deployed service; redacts the one-time key by default.",
+      "input_schema": {
+        "properties": {
+          "environment": {
+            "type": "string"
+          },
+          "interval_ms": {
+            "type": "integer"
+          },
+          "service": {
+            "type": "string"
+          },
+          "show_secret": {
+            "default": false,
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service",
+          "url"
+        ],
+        "type": "object"
+      },
+      "name": "canary_integrate_enroll"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `bin/canary integrate discover|plan|patch|enroll` for agent-led project integration
- expose integration actions in the CLI-backed MCP manifest and integration docs
- archive backlog item 038 after live `misty-step` enrollment proof

## Verification
- `cargo fmt --all --check && cargo test -p canary-cli --locked && cargo check -p canary-cli --all-targets --locked`
- `cargo clippy -p canary-cli --all-targets --locked -- -D warnings && cargo test -p canary-cli --locked`
- `cargo run -q -p canary-cli -- mcp-manifest > /tmp/canary-mcp-manifest.json && diff -u priv/mcp/canary-cli-tools.json /tmp/canary-mcp-manifest.json`
- `./bin/validate --fast`
- `./bin/validate --strict`
- pre-push `./bin/validate --strict`

## Live QA
- `bin/canary integrate discover /Users/phaedrus/Development/misty-step --service misty-step --production-url https://www.mistystep.io --json`
- `bin/canary integrate plan /Users/phaedrus/Development/misty-step --service misty-step --production-url https://www.mistystep.io --json`
- `bin/canary integrate discover /Users/phaedrus/Development/vanity --service vanity --production-url https://www.phaedrus.io --json`
- `bin/canary integrate enroll --service misty-step --url https://www.mistystep.io/api/health --json`
- `bin/canary targets --json` confirmed `misty-step` target `TGT-ifbre1aplmka`
- `bin/canary services --state up --window 1h --json` showed `misty-step` up
- `bin/canary errors misty-step --window 1h --json` showed zero errors
- `bin/canary-witness --json --receipt .codex/receipts/canary-witness-038-20260612T021803Z.json`
- `bin/canary doctor --json` showed all 6 health surfaces healthy and zero canary errors in the last hour

## Review
- QA lane exercised discover/plan/targets read-only flows and confirmed no secret values were printed.
- Adversarial review initially found blockers around MCP patch exposure, generic health overwrite safety, TS literal escaping, server/browser coverage conflation, and enroll redaction. All blockers were fixed and the reviewer rechecked with no remaining blockers.

## Residual Risk
- `patch` currently handles safe Next.js scaffolding only; non-Next/static projects are intentionally planned rather than auto-mutated.
- External consumer repos with dirty or unlinked state were not patched in this PR; only Canary enrollment for the already-live `misty-step` health endpoint was performed.
- Existing advisory warnings remain visible in the gate output, but the configured strict gate passes.
