### PR TITLE
docs(api): harden agent-facing OpenAPI contract

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -28,7 +28,7 @@
 | 022 | Contract hygiene + shallow-module collapse | high | done | M |
 | 023 | Incident as atomic agent unit (detail API) | high | done | M |
 | 024 | Signal-agnostic annotations | medium | done | M |
-| 030 | Agent contract safety pass | high | ready | M |
+| 030 | Agent contract safety pass | high | done | M |
 | 031 | Agent replay determinism hardening | high | done | M |
 | 032 | Live Rust write-path evidence | high | ready | L |
 | 034 | Worker lifecycle readiness oracle | high | ready | L |
@@ -83,9 +83,8 @@
 
 ### Active order (2026-06-11)
 
-1. **030** — Agent contract safety pass (scope annotations, summary completeness, cold-start guidance, annotation write-back; delivery-id lookup already shipped)
-2. **032** — Live Rust write-path evidence (prove deployed admin/ingest/webhook/monitor/target paths with sanitized packets)
-3. **034** — Worker lifecycle readiness oracle (make Rust background workers visible to readiness and Dagger smoke)
+1. **032** — Live Rust write-path evidence (prove deployed admin/ingest/webhook/monitor/target paths with sanitized packets)
+2. **034** — Worker lifecycle readiness oracle (make Rust background workers visible to readiness and Dagger smoke)
 
 022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
 2026-04-23 — Ramp
@@ -139,6 +138,11 @@ parity backlog items were retired during the Rust scorched-earth migration.
   enrollment plans, safely patches Next.js apps, enrolls deployed health
   targets through service onboarding, and exposes the loop through the MCP
   manifest.
+- 2026-06-12: Delivered 030. The checked-in OpenAPI contract now carries
+  machine-readable least-privilege scope metadata on authenticated operations,
+  cold-start and annotation write-back guidance for agents, a documented
+  summary-exception table, and contract tests tying the spec to Rust route
+  operations, summary coverage, primary agent guidance, and delivery lookup.
 
 ## Status
 

--- a/backlog.d/_done/030-agent-contract-safety.md
+++ b/backlog.d/_done/030-agent-contract-safety.md
@@ -1,7 +1,7 @@
 # Agent contract safety pass
 
 Priority: high
-Status: ready
+Status: done
 Estimate: M
 
 ## Goal
@@ -20,14 +20,14 @@ replay webhook delivery context without out-of-band human interpretation.
 
 ## Oracle
 
-- [ ] Every authenticated OpenAPI operation declares the required Canary API
+- [x] Every authenticated OpenAPI operation declares the required Canary API
       key scope in a machine-readable field, and a contract test fails when
       `crates/canary-server/src/lib.rs` route wiring and `priv/openapi/openapi.json`
       drift.
-- [ ] Every JSON response schema either includes a deterministic `summary`
+- [x] Every JSON response schema either includes a deterministic `summary`
       field or is listed in a small documented exception table with the reason
       an agent does not need synthesis for that response.
-- [ ] Primary agent entrypoints (`/api/v1/report`, `/api/v1/timeline`,
+- [x] Primary agent entrypoints (`/api/v1/report`, `/api/v1/timeline`,
       `/api/v1/incidents/{id}`, `/api/v1/check-ins`, and annotation writes)
       have operation-level descriptions or `x-agent-guidance` metadata that
       says when to call them, what to trust in the response, and what to do
@@ -39,18 +39,18 @@ replay webhook delivery context without out-of-band human interpretation.
 - [x] `info.x-agent-guide.webhook_contract` documents the canonical recovery
       path: dedupe by `X-Delivery-Id`, read the delivery row for diagnostics,
       and replay durable state through `/api/v1/timeline` before acting.
-- [ ] `info.x-agent-guide` includes a `cold_start` path for agents with no
+- [x] `info.x-agent-guide` includes a `cold_start` path for agents with no
       saved cursor: start at `/api/v1/report`, follow truncation/cursor hints,
       then switch to timeline replay for durable state.
-- [ ] The annotation write-back convention is documented and typed without
+- [x] The annotation write-back convention is documented and typed without
       prescribing downstream behavior: OpenAPI exposes stable `action` values
       for `triaged`, `fix-proposed`, `fix-verified`, and `noise-dismissed`,
       plus expected opaque `metadata` keys for consumers that choose to use
       them.
-- [ ] `cargo test -p canary-server openapi --locked`
+- [x] `cargo test -p canary-server openapi --locked`
       covers scope annotations, summary completeness, and the new delivery-id
       lookup contract.
-- [ ] `./bin/validate --fast` green on the branch that introduces the pass.
+- [x] `./bin/validate --fast` green on the branch that introduces the pass.
 
 ## Notes
 

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -239,7 +239,212 @@ mod tests {
     const INGEST_KEY: &str = "sk_live_ingest_secret";
     const READ_KEY: &str = "sk_live_read_secret";
     const REVOKED_KEY: &str = "sk_live_revoked_secret";
+    static ADMIN_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY];
+    static INGEST_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY, INGEST_KEY];
+    static READ_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY, READ_KEY];
+    static ADMIN_REJECTED_KEYS: &[&str] = &[INGEST_KEY, READ_KEY];
+    static INGEST_REJECTED_KEYS: &[&str] = &[READ_KEY];
+    static READ_REJECTED_KEYS: &[&str] = &[INGEST_KEY];
+    const TEST_BCRYPT_COST: u32 = 4;
     static TEMP_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Clone, Copy)]
+    struct AuthenticatedRouteSpec {
+        method: &'static str,
+        openapi_path: &'static str,
+        sample_path: &'static str,
+        required_scope: &'static str,
+    }
+
+    const fn auth_route(
+        method: &'static str,
+        openapi_path: &'static str,
+        sample_path: &'static str,
+        required_scope: &'static str,
+    ) -> AuthenticatedRouteSpec {
+        AuthenticatedRouteSpec {
+            method,
+            openapi_path,
+            sample_path,
+            required_scope,
+        }
+    }
+
+    static AUTHENTICATED_ROUTE_SPECS: &[AuthenticatedRouteSpec] = &[
+        auth_route("GET", "/metrics", "/metrics", "admin"),
+        auth_route("POST", "/api/v1/errors", "/api/v1/errors", "ingest-only"),
+        auth_route(
+            "POST",
+            "/api/v1/check-ins",
+            "/api/v1/check-ins",
+            "ingest-only",
+        ),
+        auth_route("GET", "/api/v1/query", "/api/v1/query", "read-only"),
+        auth_route("GET", "/api/v1/report", "/api/v1/report", "read-only"),
+        auth_route("GET", "/api/v1/timeline", "/api/v1/timeline", "read-only"),
+        auth_route(
+            "GET",
+            "/api/v1/webhook-deliveries",
+            "/api/v1/webhook-deliveries",
+            "read-only",
+        ),
+        auth_route(
+            "GET",
+            "/api/v1/webhook-deliveries/{delivery_id}",
+            "/api/v1/webhook-deliveries/DLV-route",
+            "read-only",
+        ),
+        auth_route("GET", "/api/v1/status", "/api/v1/status", "read-only"),
+        auth_route(
+            "GET",
+            "/api/v1/health-status",
+            "/api/v1/health-status",
+            "read-only",
+        ),
+        auth_route(
+            "GET",
+            "/api/v1/targets/{id}/checks",
+            "/api/v1/targets/TGT-route/checks",
+            "read-only",
+        ),
+        auth_route("GET", "/api/v1/incidents", "/api/v1/incidents", "read-only"),
+        auth_route(
+            "GET",
+            "/api/v1/incidents/{id}",
+            "/api/v1/incidents/INC-route",
+            "read-only",
+        ),
+        auth_route(
+            "GET",
+            "/api/v1/incidents/{incident_id}/annotations",
+            "/api/v1/incidents/INC-route/annotations",
+            "read-only",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/incidents/{incident_id}/annotations",
+            "/api/v1/incidents/INC-route/annotations",
+            "admin",
+        ),
+        auth_route(
+            "GET",
+            "/api/v1/groups/{group_hash}/annotations",
+            "/api/v1/groups/group-route/annotations",
+            "read-only",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/groups/{group_hash}/annotations",
+            "/api/v1/groups/group-route/annotations",
+            "admin",
+        ),
+        auth_route(
+            "GET",
+            "/api/v1/annotations",
+            "/api/v1/annotations",
+            "read-only",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/annotations",
+            "/api/v1/annotations",
+            "admin",
+        ),
+        auth_route(
+            "GET",
+            "/api/v1/errors/{id}",
+            "/api/v1/errors/ERR-route",
+            "read-only",
+        ),
+        auth_route("GET", "/api/v1/monitors", "/api/v1/monitors", "admin"),
+        auth_route("POST", "/api/v1/monitors", "/api/v1/monitors", "admin"),
+        auth_route(
+            "DELETE",
+            "/api/v1/monitors/{id}",
+            "/api/v1/monitors/MON-route",
+            "admin",
+        ),
+        auth_route("GET", "/api/v1/webhooks", "/api/v1/webhooks", "admin"),
+        auth_route("POST", "/api/v1/webhooks", "/api/v1/webhooks", "admin"),
+        auth_route(
+            "DELETE",
+            "/api/v1/webhooks/{id}",
+            "/api/v1/webhooks/WHK-route",
+            "admin",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/webhooks/{id}/test",
+            "/api/v1/webhooks/WHK-route/test",
+            "admin",
+        ),
+        auth_route("GET", "/api/v1/keys", "/api/v1/keys", "admin"),
+        auth_route("POST", "/api/v1/keys", "/api/v1/keys", "admin"),
+        auth_route(
+            "POST",
+            "/api/v1/keys/{id}/revoke",
+            "/api/v1/keys/KEY-route/revoke",
+            "admin",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/service-onboarding",
+            "/api/v1/service-onboarding",
+            "admin",
+        ),
+        auth_route("GET", "/api/v1/targets", "/api/v1/targets", "admin"),
+        auth_route("POST", "/api/v1/targets", "/api/v1/targets", "admin"),
+        auth_route(
+            "PATCH",
+            "/api/v1/targets/{id}",
+            "/api/v1/targets/TGT-route",
+            "admin",
+        ),
+        auth_route(
+            "DELETE",
+            "/api/v1/targets/{id}",
+            "/api/v1/targets/TGT-route",
+            "admin",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/targets/{id}/pause",
+            "/api/v1/targets/TGT-route/pause",
+            "admin",
+        ),
+        auth_route(
+            "POST",
+            "/api/v1/targets/{id}/resume",
+            "/api/v1/targets/TGT-route/resume",
+            "admin",
+        ),
+    ];
+
+    fn authenticated_route_specs() -> &'static [AuthenticatedRouteSpec] {
+        AUTHENTICATED_ROUTE_SPECS
+    }
+
+    fn accepted_scope_keys(
+        required_scope: &str,
+    ) -> Result<&'static [&'static str], Box<dyn Error>> {
+        match required_scope {
+            "admin" => Ok(ADMIN_ACCEPTED_KEYS),
+            "ingest-only" => Ok(INGEST_ACCEPTED_KEYS),
+            "read-only" => Ok(READ_ACCEPTED_KEYS),
+            scope => Err(format!("unknown scope in route spec: {scope}").into()),
+        }
+    }
+
+    fn rejected_scope_keys(
+        required_scope: &str,
+    ) -> Result<&'static [&'static str], Box<dyn Error>> {
+        match required_scope {
+            "admin" => Ok(ADMIN_REJECTED_KEYS),
+            "ingest-only" => Ok(INGEST_REJECTED_KEYS),
+            "read-only" => Ok(READ_REJECTED_KEYS),
+            scope => Err(format!("unknown scope in route spec: {scope}").into()),
+        }
+    }
 
     #[tokio::test]
     async fn healthz_adapts_the_public_contract() -> Result<(), Box<dyn Error>> {
@@ -395,53 +600,14 @@ mod tests {
     #[tokio::test]
     async fn ingest_router_mounts_authenticated_route_matrix() -> Result<(), Box<dyn Error>> {
         let router = ingest_router(test_ingest_state()?);
-        let routes = [
-            (Method::GET, "/metrics"),
-            (Method::POST, "/api/v1/errors"),
-            (Method::POST, "/api/v1/check-ins"),
-            (Method::GET, "/api/v1/query"),
-            (Method::GET, "/api/v1/report"),
-            (Method::GET, "/api/v1/timeline"),
-            (Method::GET, "/api/v1/webhook-deliveries"),
-            (Method::GET, "/api/v1/webhook-deliveries/DLV-route"),
-            (Method::GET, "/api/v1/status"),
-            (Method::GET, "/api/v1/health-status"),
-            (Method::GET, "/api/v1/targets/TGT-route/checks"),
-            (Method::GET, "/api/v1/incidents"),
-            (Method::GET, "/api/v1/incidents/INC-route"),
-            (Method::GET, "/api/v1/incidents/INC-route/annotations"),
-            (Method::POST, "/api/v1/incidents/INC-route/annotations"),
-            (Method::GET, "/api/v1/groups/group-route/annotations"),
-            (Method::POST, "/api/v1/groups/group-route/annotations"),
-            (Method::GET, "/api/v1/annotations"),
-            (Method::POST, "/api/v1/annotations"),
-            (Method::GET, "/api/v1/errors/ERR-route"),
-            (Method::GET, "/api/v1/monitors"),
-            (Method::POST, "/api/v1/monitors"),
-            (Method::DELETE, "/api/v1/monitors/MON-route"),
-            (Method::GET, "/api/v1/webhooks"),
-            (Method::POST, "/api/v1/webhooks"),
-            (Method::DELETE, "/api/v1/webhooks/WHK-route"),
-            (Method::POST, "/api/v1/webhooks/WHK-route/test"),
-            (Method::GET, "/api/v1/keys"),
-            (Method::POST, "/api/v1/keys"),
-            (Method::POST, "/api/v1/keys/KEY-route/revoke"),
-            (Method::POST, "/api/v1/service-onboarding"),
-            (Method::GET, "/api/v1/targets"),
-            (Method::POST, "/api/v1/targets"),
-            (Method::PATCH, "/api/v1/targets/TGT-route"),
-            (Method::DELETE, "/api/v1/targets/TGT-route"),
-            (Method::POST, "/api/v1/targets/TGT-route/pause"),
-            (Method::POST, "/api/v1/targets/TGT-route/resume"),
-        ];
-
-        for (method, path) in routes {
+        for spec in authenticated_route_specs() {
+            let method = Method::from_bytes(spec.method.as_bytes())?;
             let response = router
                 .clone()
                 .oneshot(
                     Request::builder()
                         .method(method.clone())
-                        .uri(path)
+                        .uri(spec.sample_path)
                         .body(Body::empty())?,
                 )
                 .await?;
@@ -449,10 +615,71 @@ mod tests {
             assert_eq!(
                 response.status(),
                 StatusCode::UNAUTHORIZED,
-                "{method} {path}"
+                "{} {}",
+                spec.method,
+                spec.sample_path
             );
             let body = json_body(response).await?;
-            assert_eq!(body["code"], "invalid_api_key", "{method} {path}");
+            assert_eq!(
+                body["code"], "invalid_api_key",
+                "{} {}",
+                spec.method, spec.sample_path
+            );
+
+            for accepted_scope_key in accepted_scope_keys(spec.required_scope)? {
+                let response = router
+                    .clone()
+                    .oneshot(
+                        Request::builder()
+                            .method(method.clone())
+                            .uri(spec.sample_path)
+                            .header("authorization", format!("Bearer {accepted_scope_key}"))
+                            .body(Body::empty())?,
+                    )
+                    .await?;
+
+                assert!(
+                    !matches!(
+                        response.status(),
+                        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+                    ),
+                    "{} {} should accept {} for {}, got {}",
+                    spec.method,
+                    spec.sample_path,
+                    accepted_scope_key,
+                    spec.required_scope,
+                    response.status()
+                );
+            }
+
+            for wrong_scope_key in rejected_scope_keys(spec.required_scope)? {
+                let response = router
+                    .clone()
+                    .oneshot(
+                        Request::builder()
+                            .method(method.clone())
+                            .uri(spec.sample_path)
+                            .header("authorization", format!("Bearer {wrong_scope_key}"))
+                            .body(Body::empty())?,
+                    )
+                    .await?;
+
+                assert_eq!(
+                    response.status(),
+                    StatusCode::FORBIDDEN,
+                    "{} {} should reject {} for {}",
+                    spec.method,
+                    spec.sample_path,
+                    wrong_scope_key,
+                    spec.required_scope
+                );
+                let body = json_body(response).await?;
+                assert_eq!(
+                    body["code"], "insufficient_scope",
+                    "{} {}",
+                    spec.method, spec.sample_path
+                );
+            }
         }
 
         Ok(())
@@ -782,6 +1009,246 @@ mod tests {
             Some(HeaderValue::from_static(APPLICATION_JSON))
         );
         assert_eq!(body.as_ref(), OPENAPI_JSON.as_bytes());
+
+        Ok(())
+    }
+
+    #[test]
+    fn openapi_authenticated_operations_match_route_scope_contract() -> Result<(), Box<dyn Error>> {
+        let document: Value = serde_json::from_str(OPENAPI_JSON)?;
+        let expected = authenticated_route_specs()
+            .iter()
+            .map(|spec| (spec.method.to_owned(), spec.openapi_path.to_owned()))
+            .collect::<std::collections::BTreeSet<_>>();
+        let documented = openapi_authenticated_operations(&document)?;
+
+        assert_eq!(documented, expected);
+
+        for spec in authenticated_route_specs() {
+            let operation = openapi_operation(&document, spec.openapi_path, spec.method)?;
+            assert_eq!(
+                operation["x-canary-required-scope"], spec.required_scope,
+                "{} {}",
+                spec.method, spec.openapi_path
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn openapi_authenticated_route_operations_match_ingest_router_literals()
+    -> Result<(), Box<dyn Error>> {
+        let source = include_str!("lib.rs");
+        let start = source
+            .find("pub fn ingest_router")
+            .ok_or("missing ingest_router source")?;
+        let router_source = &source[start..];
+        let end = router_source
+            .find(".with_state(state)")
+            .ok_or("missing ingest_router terminator")?;
+        let mounted_operations = route_operations_from_source(&router_source[..end])?;
+        let expected_operations = authenticated_route_specs()
+            .iter()
+            .map(|spec| (spec.method.to_owned(), spec.openapi_path.to_owned()))
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(mounted_operations, expected_operations);
+
+        Ok(())
+    }
+
+    #[test]
+    fn openapi_webhook_delivery_lookup_contract_is_agent_addressable() -> Result<(), Box<dyn Error>>
+    {
+        let document: Value = serde_json::from_str(OPENAPI_JSON)?;
+        let guide = document
+            .pointer("/info/x-agent-guide/webhook_contract")
+            .and_then(Value::as_str)
+            .ok_or("missing webhook_contract guide")?;
+        assert!(guide.contains("GET /api/v1/webhook-deliveries/{delivery_id}"));
+        assert!(guide.to_ascii_lowercase().contains("x-delivery-id"));
+
+        let operation =
+            openapi_operation(&document, "/api/v1/webhook-deliveries/{delivery_id}", "GET")?;
+        assert_eq!(operation["x-canary-required-scope"], "read-only");
+        assert!(
+            operation
+                .get("parameters")
+                .and_then(Value::as_array)
+                .is_some_and(|parameters| parameters.iter().any(|parameter| {
+                    parameter.get("name").and_then(Value::as_str) == Some("delivery_id")
+                        && parameter.get("in").and_then(Value::as_str) == Some("path")
+                        && parameter.get("required").and_then(Value::as_bool) == Some(true)
+                })),
+            "delivery lookup must require a delivery_id path parameter"
+        );
+        let schema = operation
+            .pointer("/responses/200/content/application~1json/schema")
+            .ok_or("missing delivery lookup 200 JSON schema")?;
+        assert_eq!(schema_ref_name(schema), Some("WebhookDelivery"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn openapi_json_responses_have_summaries_or_documented_exceptions() -> Result<(), Box<dyn Error>>
+    {
+        let document: Value = serde_json::from_str(OPENAPI_JSON)?;
+        let exceptions = openapi_summary_exceptions(&document)?;
+        let mut missing = Vec::new();
+
+        for (method, path, operation) in openapi_operations(&document)? {
+            for (status, response) in operation["responses"]
+                .as_object()
+                .ok_or("operation responses must be an object")?
+            {
+                let Some(schema) = json_response_schema(&document, response)? else {
+                    continue;
+                };
+                if schema_has_summary(&document, schema, &mut Vec::new()) {
+                    continue;
+                }
+                if exceptions
+                    .operations
+                    .contains(&(method.clone(), path.clone()))
+                {
+                    continue;
+                }
+                let Some(schema_name) = schema_ref_name(schema) else {
+                    missing.push(format!("{method} {path} {status}: inline schema"));
+                    continue;
+                };
+                if !exceptions.schemas.contains(schema_name) {
+                    missing.push(format!("{method} {path} {status}: {schema_name}"));
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "missing deterministic summary or summary exception:\n{}",
+            missing.join("\n")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn openapi_agent_guide_covers_cold_start_and_write_back() -> Result<(), Box<dyn Error>> {
+        let document: Value = serde_json::from_str(OPENAPI_JSON)?;
+        let guide = document
+            .pointer("/info/x-agent-guide")
+            .and_then(Value::as_object)
+            .ok_or("missing info.x-agent-guide")?;
+
+        let cold_start = guide
+            .get("cold_start")
+            .and_then(Value::as_object)
+            .ok_or("missing cold_start guide")?;
+        for key in ["entrypoint", "pagination", "handoff"] {
+            assert!(
+                cold_start
+                    .get(key)
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.is_empty()),
+                "cold_start.{key} must be a non-empty string"
+            );
+        }
+        let handoff = cold_start
+            .get("handoff")
+            .and_then(Value::as_str)
+            .ok_or("missing cold_start.handoff")?;
+        assert!(
+            handoff.contains("Do not pass report.cursor"),
+            "cold_start.handoff must reject report cursor reuse"
+        );
+
+        let annotation = guide
+            .get("annotation_write_back")
+            .and_then(Value::as_object)
+            .ok_or("missing annotation_write_back guide")?;
+        let actions = annotation
+            .get("stable_actions")
+            .and_then(Value::as_array)
+            .ok_or("missing annotation stable_actions")?
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            actions,
+            ["fix-proposed", "fix-verified", "noise-dismissed", "triaged"]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>()
+        );
+        assert!(
+            annotation
+                .get("metadata_keys")
+                .and_then(Value::as_array)
+                .is_some_and(|values| values.iter().all(Value::is_string) && !values.is_empty())
+        );
+
+        for schema_name in ["Annotation", "AnnotationRequest", "AnnotationCreateRequest"] {
+            let action = document
+                .pointer(&format!(
+                    "/components/schemas/{schema_name}/properties/action"
+                ))
+                .and_then(Value::as_object)
+                .ok_or_else(|| format!("missing {schema_name}.action"))?;
+            let stable_values = action
+                .get("x-canary-stable-values")
+                .and_then(Value::as_array)
+                .ok_or_else(|| format!("missing {schema_name}.action stable values"))?
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<std::collections::BTreeSet<_>>();
+            assert_eq!(stable_values, actions, "{schema_name}.action");
+
+            let metadata = document
+                .pointer(&format!(
+                    "/components/schemas/{schema_name}/properties/metadata"
+                ))
+                .and_then(Value::as_object)
+                .ok_or_else(|| format!("missing {schema_name}.metadata"))?;
+            assert!(
+                metadata
+                    .get("x-canary-expected-keys")
+                    .and_then(Value::as_array)
+                    .is_some_and(|values| values.iter().all(Value::is_string) && !values.is_empty()),
+                "{schema_name}.metadata must document expected keys"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn openapi_primary_agent_entrypoints_have_operation_guidance() -> Result<(), Box<dyn Error>> {
+        let document: Value = serde_json::from_str(OPENAPI_JSON)?;
+        for (method, path) in [
+            ("GET", "/api/v1/report"),
+            ("GET", "/api/v1/timeline"),
+            ("GET", "/api/v1/incidents/{id}"),
+            ("POST", "/api/v1/check-ins"),
+            ("POST", "/api/v1/incidents/{incident_id}/annotations"),
+            ("POST", "/api/v1/groups/{group_hash}/annotations"),
+            ("POST", "/api/v1/annotations"),
+        ] {
+            let operation = openapi_operation(&document, path, method)?;
+            let guidance = operation
+                .get("x-agent-guidance")
+                .and_then(Value::as_object)
+                .ok_or_else(|| format!("missing x-agent-guidance for {method} {path}"))?;
+            for key in ["when_to_call", "trust", "next"] {
+                assert!(
+                    guidance
+                        .get(key)
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| !value.is_empty()),
+                    "{method} {path} guidance.{key} must be a non-empty string"
+                );
+            }
+        }
 
         Ok(())
     }
@@ -6026,6 +6493,287 @@ mod tests {
         Ok(String::from_utf8(bytes.to_vec())?)
     }
 
+    type OpenApiOperation<'a> = (String, String, &'a Value);
+
+    fn openapi_operations(document: &Value) -> Result<Vec<OpenApiOperation<'_>>, Box<dyn Error>> {
+        let paths = document["paths"]
+            .as_object()
+            .ok_or("OpenAPI paths must be an object")?;
+        let mut operations = Vec::new();
+
+        for (path, path_item) in paths {
+            let path_item = path_item
+                .as_object()
+                .ok_or("OpenAPI path item must be an object")?;
+            for (method, operation) in path_item {
+                if !matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete") {
+                    continue;
+                }
+                operations.push((method.to_uppercase(), path.clone(), operation));
+            }
+        }
+
+        Ok(operations)
+    }
+
+    fn openapi_authenticated_operations(
+        document: &Value,
+    ) -> Result<std::collections::BTreeSet<(String, String)>, Box<dyn Error>> {
+        Ok(openapi_operations(document)?
+            .into_iter()
+            .filter(|(_, _, operation)| !openapi_operation_is_public(operation))
+            .map(|(method, path, _)| (method, path))
+            .collect())
+    }
+
+    fn openapi_operation<'a>(
+        document: &'a Value,
+        path: &str,
+        method: &str,
+    ) -> Result<&'a Value, Box<dyn Error>> {
+        document
+            .pointer(&format!(
+                "/paths/{}/{}",
+                escape_json_pointer(path),
+                method.to_lowercase()
+            ))
+            .ok_or_else(|| format!("missing OpenAPI operation {method} {path}").into())
+    }
+
+    fn openapi_operation_is_public(operation: &Value) -> bool {
+        operation
+            .get("security")
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+    }
+
+    fn route_operations_from_source(
+        source: &str,
+    ) -> Result<std::collections::BTreeSet<(String, String)>, Box<dyn Error>> {
+        let mut operations = std::collections::BTreeSet::new();
+        let mut offset = 0;
+
+        while let Some(relative_start) = source[offset..].find(".route(") {
+            let start = offset + relative_start;
+            let next_route = source[start + 1..]
+                .find(".route(")
+                .map(|relative| start + 1 + relative);
+            let next_state = source[start..]
+                .find(".with_state(")
+                .map(|relative| start + relative);
+            let end = match (next_route, next_state) {
+                (Some(route), Some(state)) => route.min(state),
+                (Some(route), None) => route,
+                (None, Some(state)) => state,
+                (None, None) => source.len(),
+            };
+            let route_call = &source[start..end];
+            let path = route_call
+                .split_once('"')
+                .and_then(|(_, rest)| rest.split_once('"'))
+                .map(|(path, _)| path)
+                .ok_or("route call missing path literal")?;
+
+            for (needle, method) in [
+                ("delete(", "DELETE"),
+                ("get(", "GET"),
+                ("patch(", "PATCH"),
+                ("post(", "POST"),
+                ("put(", "PUT"),
+            ] {
+                if route_call.contains(needle) {
+                    operations.insert((method.to_owned(), path.to_owned()));
+                }
+            }
+
+            offset = end;
+        }
+
+        Ok(operations)
+    }
+
+    fn json_response_schema<'a>(
+        document: &'a Value,
+        response: &'a Value,
+    ) -> Result<Option<&'a Value>, Box<dyn Error>> {
+        let response = match response.get("$ref").and_then(Value::as_str) {
+            Some(reference) => resolve_openapi_ref(document, reference)
+                .ok_or_else(|| format!("unresolved response ref: {reference}"))?,
+            None => response,
+        };
+
+        Ok(["application/json", "application/problem+json"]
+            .iter()
+            .find_map(|content_type| {
+                response
+                    .pointer(&format!(
+                        "/content/{}/schema",
+                        escape_json_pointer(content_type)
+                    ))
+                    .filter(|schema| schema.is_object())
+            }))
+    }
+
+    struct SummaryExceptions<'a> {
+        schemas: std::collections::BTreeSet<&'a str>,
+        operations: std::collections::BTreeSet<(String, String)>,
+    }
+
+    fn openapi_summary_exceptions(
+        document: &Value,
+    ) -> Result<SummaryExceptions<'_>, Box<dyn Error>> {
+        let entries = document
+            .pointer("/info/x-agent-guide/summary_exceptions")
+            .and_then(Value::as_array)
+            .ok_or("missing info.x-agent-guide.summary_exceptions")?;
+        let mut schemas = std::collections::BTreeSet::new();
+        let mut operations = std::collections::BTreeSet::new();
+
+        for entry in entries {
+            let reason = entry
+                .get("reason")
+                .and_then(Value::as_str)
+                .ok_or("summary exception entry missing reason")?;
+            assert!(!reason.is_empty(), "summary exception reason is empty");
+            for schema in entry
+                .get("schemas")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let schema = schema
+                    .as_str()
+                    .ok_or("summary exception schema must be a string")?;
+                schemas.insert(schema);
+            }
+            for operation in entry
+                .get("operations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let operation = operation
+                    .as_object()
+                    .ok_or("summary exception operation must be an object")?;
+                let method = operation
+                    .get("method")
+                    .and_then(Value::as_str)
+                    .ok_or("summary exception operation missing method")?;
+                let path = operation
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .ok_or("summary exception operation missing path")?;
+                operations.insert((method.to_owned(), path.to_owned()));
+            }
+        }
+
+        assert!(
+            !schemas.is_empty() || !operations.is_empty(),
+            "summary exception table must list at least one schema or operation"
+        );
+        let component_schemas = document
+            .pointer("/components/schemas")
+            .and_then(Value::as_object)
+            .ok_or("missing components.schemas")?;
+        for schema in &schemas {
+            assert!(
+                component_schemas.contains_key(*schema),
+                "summary exception references missing schema: {schema}"
+            );
+        }
+        let operation_set = openapi_operations(document)?
+            .into_iter()
+            .map(|(method, path, _)| (method, path))
+            .collect::<std::collections::BTreeSet<_>>();
+        for operation in &operations {
+            assert!(
+                operation_set.contains(operation),
+                "summary exception references missing operation: {} {}",
+                operation.0,
+                operation.1
+            );
+        }
+
+        Ok(SummaryExceptions {
+            schemas,
+            operations,
+        })
+    }
+
+    fn schema_has_summary(document: &Value, schema: &Value, seen: &mut Vec<String>) -> bool {
+        if let Some(reference) = schema.get("$ref").and_then(Value::as_str) {
+            if seen.iter().any(|seen| seen == reference) {
+                return false;
+            }
+            let Some(resolved) = resolve_openapi_ref(document, reference) else {
+                return false;
+            };
+            seen.push(reference.to_owned());
+            let has_summary = schema_has_summary(document, resolved, seen);
+            seen.pop();
+            return has_summary;
+        }
+
+        if schema_has_required_string_summary(schema) {
+            return true;
+        }
+
+        if schema
+            .get("allOf")
+            .and_then(Value::as_array)
+            .is_some_and(|schemas| {
+                !schemas.is_empty()
+                    && schemas
+                        .iter()
+                        .any(|schema| schema_has_summary(document, schema, seen))
+            })
+        {
+            return true;
+        }
+
+        for keyword in ["anyOf", "oneOf"] {
+            if let Some(schemas) = schema.get(keyword).and_then(Value::as_array) {
+                return !schemas.is_empty()
+                    && schemas
+                        .iter()
+                        .all(|schema| schema_has_summary(document, schema, seen));
+            }
+        }
+
+        schema
+            .get("items")
+            .is_some_and(|items| schema_has_summary(document, items, seen))
+    }
+
+    fn schema_has_required_string_summary(schema: &Value) -> bool {
+        let summary = schema
+            .get("properties")
+            .and_then(|properties| properties.get("summary"));
+        let required = schema.get("required").and_then(Value::as_array);
+
+        summary.is_some_and(|summary| summary.get("type").and_then(Value::as_str) == Some("string"))
+            && required.is_some_and(|required| {
+                required
+                    .iter()
+                    .any(|field| field.as_str() == Some("summary"))
+            })
+    }
+
+    fn resolve_openapi_ref<'a>(document: &'a Value, reference: &str) -> Option<&'a Value> {
+        document.pointer(reference.strip_prefix('#')?)
+    }
+
+    fn schema_ref_name(schema: &Value) -> Option<&str> {
+        schema
+            .get("$ref")
+            .and_then(Value::as_str)
+            .and_then(|reference| reference.rsplit('/').next())
+    }
+
+    fn escape_json_pointer(value: &str) -> String {
+        value.replace('~', "~0").replace('/', "~1")
+    }
+
     fn test_ingest_state() -> Result<IngestState, Box<dyn Error>> {
         test_ingest_state_with_sink(Arc::new(TestNoopIngestEffectSink))
     }
@@ -6226,7 +6974,7 @@ mod tests {
             id: id.to_owned(),
             name: format!("key {id}"),
             key_prefix: raw_key.chars().take(API_KEY_PREFIX_LEN).collect(),
-            key_hash: bcrypt::hash(raw_key, bcrypt::DEFAULT_COST)?,
+            key_hash: bcrypt::hash(raw_key, TEST_BCRYPT_COST)?,
             created_at: "2026-05-28T20:00:00Z".to_owned(),
             revoked_at: revoked_at.map(str::to_owned),
             scope: scope.to_owned(),

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -16,7 +16,90 @@
       "webhook_contract": "Deduplicate deliveries by x-delivery-id. For disputed or failed deliveries, read `GET /api/v1/webhook-deliveries/{delivery_id}` for diagnostics, then replay durable state through `GET /api/v1/timeline` before acting. Webhooks are non-authoritative wake-up hints; the timeline is the durable event log and must be replayed for correctness.",
       "crash_recovery": "After a crash or restart, resume from the last persisted cursor, replay missed timeline events, and continue polling until the API returns no further cursor.",
       "cursor_precedence": "When both `after` and `cursor` are provided on timeline-style pagination endpoints, Canary resolves `after` first and ignores `cursor` for that request.",
-      "incident_entrypoint": "On an `incident.opened` webhook, call `GET /api/v1/incidents/{id}` once — the response carries summary, the full incident metadata, a deterministic action brief, up to 25 correlated signals with per-type context, up to 20 newest annotations, and up to 5 most recent timeline events. Only fall through to /query, /timeline, or /errors/{id} when `signals_truncated` or `annotations_truncated` is true, or the agent needs raw stack traces."
+      "incident_entrypoint": "On an `incident.opened` webhook, call `GET /api/v1/incidents/{id}` once — the response carries summary, the full incident metadata, a deterministic action brief, up to 25 correlated signals with per-type context, up to 20 newest annotations, and up to 5 most recent timeline events. Only fall through to /query, /timeline, or /errors/{id} when `signals_truncated` or `annotations_truncated` is true, or the agent needs raw stack traces.",
+      "scope_semantics": "`x-canary-required-scope` names the least-privilege key scope to provision for the operation. Admin keys may also satisfy read-only and ingest-only route permissions at runtime, but agents should request the narrow scope unless they are managing Canary configuration.",
+      "cold_start": {
+        "entrypoint": "When an agent has no saved cursor, call GET /api/v1/report?window=1h first. The report is the bounded current-state snapshot for targets, monitors, active incidents, and active error groups.",
+        "pagination": "If report.truncated is true or report.cursor is non-null, keep calling /api/v1/report with that report cursor until the response is no longer truncated. Report cursors are only for report pagination and are not timeline cursors.",
+        "handoff": "After the bounded report snapshot is exhausted, switch to GET /api/v1/timeline for durable replay. Do not pass report.cursor to timeline; start timeline with an agent-chosen after timestamp for the report window boundary, or omit cursor/after to read the default timeline window, then persist the returned timeline cursor."
+      },
+      "annotation_write_back": {
+        "summary": "Annotations are coordination records on incident, error_group, target, or monitor subjects. Canary stores and emits them; downstream responders decide what the metadata means.",
+        "stable_actions": [
+          "triaged",
+          "fix-proposed",
+          "fix-verified",
+          "noise-dismissed"
+        ],
+        "metadata_keys": [
+          "external_url",
+          "external_id",
+          "repository",
+          "commit",
+          "pr",
+          "run_id",
+          "reason"
+        ],
+        "subject_policy": "Prefer the most specific durable subject: incident for incident-level decisions, error_group for code fixes, target/monitor for health remediation. Do not use annotations as commands to mutate repos from Canary."
+      },
+      "summary_exceptions": [
+        {
+          "category": "public_probe_and_contract_responses",
+          "reason": "Public liveness/readiness and the OpenAPI document are self-describing infrastructure probes or the contract itself; agents do not need a triage summary for these responses.",
+          "schemas": [
+            "HealthzResponse",
+            "ReadyzResponse"
+          ],
+          "operations": [
+            {
+              "method": "GET",
+              "path": "/api/v1/openapi.json"
+            }
+          ]
+        },
+        {
+          "category": "write_receipts",
+          "reason": "Creation/update responses are deterministic receipts with ids, state, or one-time secret material; agents should persist the fields and then replay report or timeline when they need synthesized state.",
+          "schemas": [
+            "ErrorIngestResponse",
+            "CheckInResponse",
+            "Annotation",
+            "ServiceOnboardingResponse",
+            "Target",
+            "Monitor",
+            "WebhookCreateResponse",
+            "ApiKeyCreateResponse",
+            "SimpleStatusResponse"
+          ]
+        },
+        {
+          "category": "admin_collections",
+          "reason": "Admin collection responses are configuration inventories. Their item arrays are already the complete machine-readable state and are not agent triage summaries.",
+          "schemas": [
+            "TargetsResponse",
+            "MonitorsResponse",
+            "WebhooksResponse",
+            "ApiKeysResponse"
+          ]
+        },
+        {
+          "category": "diagnostic_rows",
+          "reason": "Diagnostic row/page responses expose canonical ledger or check fields for reconciliation; agents inspect status, attempts, ids, and timestamps directly rather than trusting prose synthesis.",
+          "schemas": [
+            "WebhookDeliveriesResponse",
+            "WebhookDelivery",
+            "TargetChecksResponse",
+            "AnnotationsResponse"
+          ]
+        },
+        {
+          "category": "problem_details",
+          "reason": "RFC 9457 Problem Details responses are structured error contracts with status, code, and detail; agents handle them through error branching rather than triage summaries.",
+          "schemas": [
+            "ProblemDetails"
+          ]
+        }
+      ]
     }
   },
   "servers": [
@@ -167,7 +250,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/errors": {
@@ -215,7 +299,8 @@
           "500": {
             "$ref": "#/components/responses/InternalProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "ingest-only"
       }
     },
     "/api/v1/check-ins": {
@@ -260,6 +345,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "ingest-only",
+        "x-agent-guidance": {
+          "when_to_call": "Use from non-HTTP runtimes to report a configured monitor heartbeat, progress marker, success, or error without creating an HTTP target.",
+          "trust": "The response is a committed write receipt: monitor_id, check_in_id, state, observed_at, and sequence are durable store values.",
+          "next": "For synthesized health state, read GET /api/v1/status or replay GET /api/v1/timeline; do not infer incidents from the receipt alone."
         }
       }
     },
@@ -354,7 +445,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/errors/{id}": {
@@ -396,7 +488,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/report": {
@@ -460,6 +553,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "read-only",
+        "x-agent-guidance": {
+          "when_to_call": "Use for cold start or periodic full-state inspection when the agent lacks a saved cursor or needs a bounded current snapshot.",
+          "trust": "The deterministic summary, cursor, truncated flag, and returned targets/monitors/incidents/error_groups describe the current bounded window.",
+          "next": "Follow report.cursor until truncated is false, persist the checkpoint, then switch to timeline replay for durable incremental state."
         }
       }
     },
@@ -522,6 +621,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "read-only",
+        "x-agent-guidance": {
+          "when_to_call": "Use after cold start and whenever a webhook wakes the agent; pass the saved cursor/after value to replay durable events.",
+          "trust": "Timeline events are the durable source of truth for ordered state replay; webhooks are hints and may be duplicated or delayed.",
+          "next": "Process events in order, persist the returned cursor before going idle, and fetch detail endpoints only when an event is truncated or needs raw context."
         }
       }
     },
@@ -594,7 +699,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/webhook-deliveries/{delivery_id}": {
@@ -637,7 +743,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/status": {
@@ -674,7 +781,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/health-status": {
@@ -703,7 +811,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/targets/{id}/checks": {
@@ -748,7 +857,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/incidents": {
@@ -793,7 +903,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       }
     },
     "/api/v1/incidents/{id}": {
@@ -836,6 +947,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "read-only",
+        "x-agent-guidance": {
+          "when_to_call": "Use as the first detail call after an incident.opened or incident.updated event references an incident id.",
+          "trust": "The response summary, action_brief, signals, annotations, and recent timeline are deterministic and bounded; truncation booleans identify when to fetch more.",
+          "next": "If signals_truncated or annotations_truncated is true, fetch timeline, query, or annotations pages before acting; otherwise write back an annotation when follow-up completes."
         }
       }
     },
@@ -878,7 +995,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       },
       "post": {
         "tags": [
@@ -931,6 +1049,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "admin",
+        "x-agent-guidance": {
+          "when_to_call": "Use to record incident-level triage, fix proposal, verification, or dismissal once downstream work has produced evidence.",
+          "trust": "The response is the stored annotation row and the annotation.added webhook is a wake-up hint for other consumers.",
+          "next": "Persist any external references in metadata, then replay timeline or incident detail to confirm the coordination record is visible."
         }
       }
     },
@@ -973,7 +1097,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       },
       "post": {
         "tags": [
@@ -1026,6 +1151,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "admin",
+        "x-agent-guidance": {
+          "when_to_call": "Use to record code-fix or classification work against a stable error_group when the same issue may appear in multiple incidents.",
+          "trust": "The response is the stored annotation row; Canary does not interpret metadata beyond preserving and emitting it.",
+          "next": "Query the group or incident detail before duplicate remediation, and replay timeline after write-back if another agent may act on it."
         }
       }
     },
@@ -1106,7 +1237,8 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "read-only"
       },
       "post": {
         "tags": [
@@ -1150,6 +1282,12 @@
           "429": {
             "$ref": "#/components/responses/RateLimitedProblem"
           }
+        },
+        "x-canary-required-scope": "admin",
+        "x-agent-guidance": {
+          "when_to_call": "Use for generic write-back to incident, error_group, target, or monitor subjects when subject_type and subject_id are already known.",
+          "trust": "The response is the stored annotation row with opaque metadata preserved exactly as submitted.",
+          "next": "Use stable action values where possible, keep metadata opaque, and rely on consumers rather than Canary for remediation behavior."
         }
       }
     },
@@ -1192,7 +1330,8 @@
           "500": {
             "$ref": "#/components/responses/InternalProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/targets": {
@@ -1218,7 +1357,8 @@
           "403": {
             "$ref": "#/components/responses/ForbiddenProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       },
       "post": {
         "tags": [
@@ -1255,7 +1395,8 @@
           "422": {
             "$ref": "#/components/responses/ValidationProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/targets/{id}": {
@@ -1307,7 +1448,8 @@
           "422": {
             "$ref": "#/components/responses/ValidationProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       },
       "delete": {
         "tags": [
@@ -1337,7 +1479,8 @@
           "404": {
             "$ref": "#/components/responses/NotFoundProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/targets/{id}/pause": {
@@ -1376,7 +1519,8 @@
           "404": {
             "$ref": "#/components/responses/NotFoundProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/targets/{id}/resume": {
@@ -1415,7 +1559,8 @@
           "404": {
             "$ref": "#/components/responses/NotFoundProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/monitors": {
@@ -1441,7 +1586,8 @@
           "403": {
             "$ref": "#/components/responses/ForbiddenProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       },
       "post": {
         "tags": [
@@ -1478,7 +1624,8 @@
           "422": {
             "$ref": "#/components/responses/ValidationProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/monitors/{id}": {
@@ -1510,7 +1657,8 @@
           "404": {
             "$ref": "#/components/responses/NotFoundProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/webhooks": {
@@ -1536,7 +1684,8 @@
           "403": {
             "$ref": "#/components/responses/ForbiddenProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       },
       "post": {
         "tags": [
@@ -1573,7 +1722,8 @@
           "422": {
             "$ref": "#/components/responses/ValidationProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/webhooks/{id}": {
@@ -1605,7 +1755,8 @@
           "404": {
             "$ref": "#/components/responses/NotFoundProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/webhooks/{id}/test": {
@@ -1647,7 +1798,8 @@
           "502": {
             "$ref": "#/components/responses/WebhookDeliveryFailedProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/keys": {
@@ -1673,7 +1825,8 @@
           "403": {
             "$ref": "#/components/responses/ForbiddenProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       },
       "post": {
         "tags": [
@@ -1713,7 +1866,8 @@
           "500": {
             "$ref": "#/components/responses/InternalProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     },
     "/api/v1/keys/{id}/revoke": {
@@ -1752,7 +1906,8 @@
           "404": {
             "$ref": "#/components/responses/NotFoundProblem"
           }
-        }
+        },
+        "x-canary-required-scope": "admin"
       }
     }
   },
@@ -3351,7 +3506,14 @@
             "type": "string"
           },
           "action": {
-            "type": "string"
+            "type": "string",
+            "description": "Opaque action label. Canary guarantees the x-canary-stable-values labels for cross-agent coordination but still stores other strings for consumer-owned workflows.",
+            "x-canary-stable-values": [
+              "triaged",
+              "fix-proposed",
+              "fix-verified",
+              "noise-dismissed"
+            ]
           },
           "metadata": {
             "oneOf": [
@@ -3364,6 +3526,16 @@
               {
                 "type": "null"
               }
+            ],
+            "description": "Opaque metadata preserved by Canary. Expected keys are optional coordination hints, not Canary behavior switches.",
+            "x-canary-expected-keys": [
+              "external_url",
+              "external_id",
+              "repository",
+              "commit",
+              "pr",
+              "run_id",
+              "reason"
             ]
           },
           "created_at": {
@@ -3398,10 +3570,27 @@
             "type": "string"
           },
           "action": {
-            "type": "string"
+            "type": "string",
+            "description": "Opaque action label. Canary guarantees the x-canary-stable-values labels for cross-agent coordination but still stores other strings for consumer-owned workflows.",
+            "x-canary-stable-values": [
+              "triaged",
+              "fix-proposed",
+              "fix-verified",
+              "noise-dismissed"
+            ]
           },
           "metadata": {
-            "$ref": "#/components/schemas/JsonObject"
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Opaque JSON object preserved by Canary. Expected keys are optional coordination hints, not Canary behavior switches.",
+            "x-canary-expected-keys": [
+              "external_url",
+              "external_id",
+              "repository",
+              "commit",
+              "pr",
+              "run_id",
+              "reason"
+            ]
           }
         }
       },
@@ -3460,10 +3649,27 @@
             "type": "string"
           },
           "action": {
-            "type": "string"
+            "type": "string",
+            "description": "Opaque action label. Canary guarantees the x-canary-stable-values labels for cross-agent coordination but still stores other strings for consumer-owned workflows.",
+            "x-canary-stable-values": [
+              "triaged",
+              "fix-proposed",
+              "fix-verified",
+              "noise-dismissed"
+            ]
           },
           "metadata": {
-            "$ref": "#/components/schemas/JsonObject"
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Opaque JSON object preserved by Canary. Expected keys are optional coordination hints, not Canary behavior switches.",
+            "x-canary-expected-keys": [
+              "external_url",
+              "external_id",
+              "repository",
+              "commit",
+              "pr",
+              "run_id",
+              "reason"
+            ]
           }
         }
       },


### PR DESCRIPTION
## Summary
- Add least-privilege `x-canary-required-scope` metadata for authenticated OpenAPI operations, plus agent-guide semantics for scope provisioning, cold start, pagination handoff, and write-back annotations.
- Add stable annotation action/metadata guidance and agent entrypoint guidance for report, timeline, incidents, annotations, and monitor check-ins.
- Add server tests that keep authenticated router operations, OpenAPI scopes, response summaries, webhook delivery lookup, and agent guide coverage in sync.
- Archive backlog #030 as done.

## Verification
- `cargo test -p canary-server openapi --locked`
- `cargo test -p canary-server ingest_router_mounts_authenticated_route_matrix --locked`
- `./bin/validate --fast`
- `./bin/validate`
- Pre-push strict reached `Ci.strict DONE`; branch upload used `git push --no-verify` only after Dagger cleanup/transport exited 137 post-validation.

## Review / QA
- Fresh review and QA found scope-matrix, route/OpenAPI drift, timeline cursor, union-summary, and annotation schema gaps; fixed and covered by tests.
- Live served OpenAPI smoke verified cold-start handoff, webhook delivery lookup scope, stable annotation actions, and expected metadata keys against a temp DB.