### PR TITLE
docs(ops): prove live Rust write paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ surface.
 The production Dockerfile builds the Rust `canary-server` binary, and CI uses
 the same pinned toolchain versions.
 
+### Production Evidence
+
+Rust production claims are evidence-scoped:
+
+- [docs/architecture/rust-cutover-evidence-2026-06-06.md](docs/architecture/rust-cutover-evidence-2026-06-06.md)
+  proves the first Fly Rust cutover plus public/read-route smoke.
+- [docs/architecture/rust-write-path-evidence-2026-06-12.md](docs/architecture/rust-write-path-evidence-2026-06-12.md)
+  proves the live admin, ingest, target, monitor, webhook, delivery-ledger,
+  query/report/timeline, cleanup, and DR-status write-path rehearsal.
+
+Replay the write-path proof with `bin/canary-write-path-rehearsal --json`
+against a live Canary instance; it creates uniquely named disposable resources,
+redacts credentials in the receipt, then deletes or revokes the live resources
+it created.
+
 ### Bootstrap
 
 From the repo root:

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -30,7 +30,7 @@
 | 024 | Signal-agnostic annotations | medium | done | M |
 | 030 | Agent contract safety pass | high | done | M |
 | 031 | Agent replay determinism hardening | high | done | M |
-| 032 | Live Rust write-path evidence | high | ready | L |
+| 032 | Live Rust write-path evidence | high | done | L |
 | 034 | Worker lifecycle readiness oracle | high | ready | L |
 | 033 | Deployed service registry lifecycle | high | done | M |
 | 035 | Deployed app Canary coverage | high | done | XL |
@@ -83,8 +83,7 @@
 
 ### Active order (2026-06-11)
 
-1. **032** — Live Rust write-path evidence (prove deployed admin/ingest/webhook/monitor/target paths with sanitized packets)
-2. **034** — Worker lifecycle readiness oracle (make Rust background workers visible to readiness and Dagger smoke)
+1. **034** — Worker lifecycle readiness oracle (make Rust background workers visible to readiness and Dagger smoke)
 
 022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
 2026-04-23 — Ramp
@@ -143,6 +142,11 @@ parity backlog items were retired during the Rust scorched-earth migration.
   cold-start and annotation write-back guidance for agents, a documented
   summary-exception table, and contract tests tying the spec to Rust route
   operations, summary coverage, primary agent guidance, and delivery lookup.
+- 2026-06-12: Delivered 032. `bin/canary-write-path-rehearsal` now replays the
+  live Rust admin/ingest/target/monitor/webhook/delivery-ledger/readback/DR
+  write paths with redacted JSON receipts, and
+  `docs/architecture/rust-write-path-evidence-2026-06-12.md` records the first
+  production run plus cleanup proof.
 
 ## Status
 

--- a/backlog.d/_done/032-live-rust-write-path-evidence.md
+++ b/backlog.d/_done/032-live-rust-write-path-evidence.md
@@ -1,18 +1,18 @@
 # Prove Rust production write paths with evidence packets
 
 Priority: high
-Status: ready
+Status: done
 Estimate: L
 
 ## Goal
 Prove the deployed Rust service handles Canary's admin, ingest, health, webhook, and worker-backed write paths in production-like conditions, with sanitized evidence packets agents can replay.
 
 ## Oracle
-- [ ] A new evidence packet under `docs/architecture/` records the exact current commit, Fly image, machine version, commands, redacted responses, and cleanup proof for the write-path run.
-- [ ] The run exercises `POST /api/v1/errors` through query/report/timeline readback, target create/pause/resume/delete, monitor create/check-in/delete, webhook create/test/delivery lookup/delete, API key mint/revoke, and DR status.
-- [ ] Each created production or staging resource is uniquely named, queried back, and cleaned up; the packet includes the post-cleanup query proving no disposable resource remains.
-- [ ] README and Rust cutover docs distinguish read-path cutover proof from write-path proof and do not overclaim unverified production behavior.
-- [ ] `./bin/validate --fast` is green after any docs or harness updates, and no API key or secret value appears in the packet or git diff.
+- [x] A new evidence packet under `docs/architecture/` records the exact current commit, Fly image, machine version, commands, redacted responses, and cleanup proof for the write-path run.
+- [x] The run exercises `POST /api/v1/errors` through query/report/timeline readback, target create/pause/resume/delete, monitor create/check-in/delete, webhook create/test/delivery lookup/delete, API key mint/revoke, and DR status.
+- [x] Each created production or staging resource is uniquely named, queried back, and cleaned up; the packet includes the post-cleanup query proving no disposable resource remains.
+- [x] README and Rust cutover docs distinguish read-path cutover proof from write-path proof and do not overclaim unverified production behavior.
+- [x] `./bin/validate --fast` is green after any docs or harness updates, and no API key or secret value appears in the packet or git diff.
 
 ## Notes
 **Why:** Product/operator perspective. The 2026-06-06 Rust cutover packet proves deploy, `/healthz`, `/readyz`, DR status, and authenticated read routes, but explicitly leaves admin, ingest, webhook, retention, target-probe, TLS-scan, and monitor paths unproven under production load.

--- a/bin/canary-write-path-rehearsal
+++ b/bin/canary-write-path-rehearsal
@@ -1,0 +1,827 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ENDPOINT="${CANARY_ENDPOINT:-}"
+API_KEY="${CANARY_API_KEY:-}"
+WEBHOOK_URL="${CANARY_REHEARSAL_WEBHOOK_URL:-https://httpbingo.org/status/204}"
+APP="${FLY_APP:-canary-obs}"
+PREFIX=""
+JSON_OUTPUT=0
+RUN_DR_STATUS=1
+POLL_ATTEMPTS="${CANARY_REHEARSAL_POLL_ATTEMPTS:-20}"
+POLL_SLEEP="${CANARY_REHEARSAL_POLL_SLEEP:-2}"
+
+TMPDIR_REHEARSAL=""
+STEPS_FILE=""
+CLEANED_UP=0
+INGEST_KEY=""
+INGEST_KEY_ID=""
+TARGET_ID=""
+MONITOR_ID=""
+WEBHOOK_ID=""
+WEBHOOK_DELIVERY_ID=""
+ERROR_ID=""
+ERROR_GROUP_HASH=""
+DEPLOY_IDENTITY="{}"
+SERVICE=""
+KEY_NAME=""
+TARGET_NAME=""
+MONITOR_NAME=""
+WEBHOOK_RUN_URL=""
+
+usage() {
+  cat <<'EOF'
+Usage: bin/canary-write-path-rehearsal [--endpoint <url>] [--api-key <key>] [--webhook-url <url>] [--prefix <prefix>] [--app <fly-app>] [--poll-attempts <n>] [--poll-sleep <seconds>] [--no-dr-status] [--json] [-h|--help]
+
+Exercise Canary's live write paths with uniquely named disposable resources.
+
+By default the command reads CANARY_ENDPOINT and CANARY_API_KEY from the
+environment, creates a temporary ingest-only key, target, monitor, webhook,
+error, check-in, webhook delivery, and DR-status receipt, then deletes or
+revokes every disposable live resource it can clean up.
+
+The JSON receipt redacts one-time API keys and webhook secrets. Error events
+and webhook-delivery ledger rows are immutable observability records and remain
+as proof of the run.
+EOF
+}
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+
+  if command -v "$command_name" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  fail "Missing required command: $command_name"
+}
+
+urlencode() {
+  jq -nr --arg value "$1" '$value | @uri'
+}
+
+now_utc() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+sanitize_text() {
+  local text="$1"
+  local sensitive_file="/dev/null"
+
+  if [[ -n "${SENSITIVE_VALUES_FILE:-}" && -f "$SENSITIVE_VALUES_FILE" ]]; then
+    sensitive_file="$SENSITIVE_VALUES_FILE"
+  fi
+
+  jq -rn --arg text "$text" --rawfile sensitive_values "$sensitive_file" '
+    def known_sensitive:
+      $sensitive_values
+      | split("\n")
+      | map(select(length > 0));
+	    def redact_patterns:
+	      gsub("sk_(live|test)_[A-Za-z0-9_-]+"; "<redacted-api-key>")
+	      | gsub("[A-Fa-f0-9]{64}"; "<redacted-hash>");
+	    $text
+	    | redact_patterns
+	    | reduce known_sensitive[] as $secret (.; split($secret) | join("<redacted>"))
+  '
+}
+
+sanitize_json() {
+  local raw="$1"
+  local sensitive_file="/dev/null"
+
+  if [[ -z "$raw" ]]; then
+    printf 'null'
+    return
+  fi
+
+  if [[ -n "${SENSITIVE_VALUES_FILE:-}" && -f "$SENSITIVE_VALUES_FILE" ]]; then
+    sensitive_file="$SENSITIVE_VALUES_FILE"
+  fi
+
+  if jq -e . >/dev/null 2>&1 <<<"$raw"; then
+    jq -c --rawfile sensitive_values "$sensitive_file" '
+      def known_sensitive:
+        $sensitive_values
+        | split("\n")
+        | map(select(length > 0));
+	      def redact_string:
+	        gsub("sk_(live|test)_[A-Za-z0-9_-]+"; "<redacted-api-key>")
+	        | gsub("[A-Fa-f0-9]{64}"; "<redacted-hash>")
+	        | reduce known_sensitive[] as $secret (.; split($secret) | join("<redacted>"));
+      def redact:
+        if type == "object" then
+          with_entries(
+	            if (.key == "key" or .key == "key_prefix" or .key == "secret" or .key == "key_hash") then
+	              .value = "<redacted>"
+	            elif .key == "group_hash" then
+	              .value = "<redacted-hash>"
+	            elif .key == "digest" then
+	              .
+	            else
+	              .value |= redact
+            end
+          )
+        elif type == "array" then
+          map(redact)
+        elif type == "string" then
+          redact_string
+        else
+          .
+        end;
+      redact
+    ' <<<"$raw"
+  else
+    jq -cn --arg body "$(sanitize_text "$raw")" '$body'
+  fi
+}
+
+remember_sensitive_values() {
+  local body="$1"
+
+  [[ -n "${SENSITIVE_VALUES_FILE:-}" && -f "$SENSITIVE_VALUES_FILE" ]] || return 0
+  jq -r '
+    .. | objects | to_entries[]?
+    | select(.key == "key" or .key == "key_prefix" or .key == "secret" or .key == "key_hash" or .key == "group_hash")
+    | .value
+    | select(type == "string" and length > 0)
+  ' <<<"$body" >> "$SENSITIVE_VALUES_FILE" 2>/dev/null || true
+  sort -u "$SENSITIVE_VALUES_FILE" -o "$SENSITIVE_VALUES_FILE"
+}
+
+remember_sensitive_literal() {
+  local value="$1"
+
+  [[ -n "${SENSITIVE_VALUES_FILE:-}" && -f "$SENSITIVE_VALUES_FILE" ]] || return 0
+  [[ -n "$value" ]] || return 0
+  printf '%s\n' "$value" >> "$SENSITIVE_VALUES_FILE"
+  sort -u "$SENSITIVE_VALUES_FILE" -o "$SENSITIVE_VALUES_FILE"
+}
+
+capture_cleanup_handle() {
+  local name="$1"
+  local body="$2"
+  local id
+
+  if ! jq -e . >/dev/null 2>&1 <<<"$body"; then
+    return 0
+  fi
+
+  id="$(jq -r '.id // ""' <<<"$body")"
+  if [[ -z "$id" || "$id" == "null" ]]; then
+    return 0
+  fi
+
+  case "$name" in
+    api_key_create_ingest)
+      INGEST_KEY_ID="$id"
+      INGEST_KEY="$(jq -r '.key // ""' <<<"$body")"
+      ;;
+    target_create)
+      TARGET_ID="$id"
+      ;;
+    monitor_create)
+      MONITOR_ID="$id"
+      ;;
+    webhook_create)
+      WEBHOOK_ID="$id"
+      ;;
+  esac
+}
+
+record_http_step() {
+  local name="$1"
+  local method="$2"
+  local path="$3"
+  local status="$4"
+  local body="$5"
+  local sanitized
+
+  sanitized="$(sanitize_json "$body")"
+  jq -cn \
+    --arg type "http" \
+    --arg name "$name" \
+    --arg method "$method" \
+    --arg path "$path" \
+    --argjson status "$status" \
+    --argjson response "$sanitized" \
+    '{type: $type, name: $name, method: $method, path: $path, status: $status, response: $response}' \
+    >> "$STEPS_FILE"
+}
+
+record_shell_step() {
+  local name="$1"
+  local command="$2"
+  local status="$3"
+  local output="$4"
+
+  jq -cn \
+    --arg type "shell" \
+    --arg name "$name" \
+    --arg command "$command" \
+    --argjson status "$status" \
+    --arg output "$(sanitize_text "$output")" \
+    '{type: $type, name: $name, command: $command, status: $status, output: $output}' \
+	    >> "$STEPS_FILE"
+}
+
+record_json_step() {
+  local name="$1"
+  local body="$2"
+  local sanitized
+
+  sanitized="$(sanitize_json "$body")"
+  jq -cn \
+    --arg type "json" \
+    --arg name "$name" \
+    --argjson response "$sanitized" \
+    '{type: $type, name: $name, response: $response}' \
+    >> "$STEPS_FILE"
+}
+
+api_request() {
+  local method="$1"
+  local path="$2"
+  local key="$3"
+  local body="${4:-}"
+  local response_file status
+
+  response_file="$(mktemp "$TMPDIR_REHEARSAL/response.XXXXXX")"
+  local args=(
+    -sS
+    -X "$method"
+    -H "Authorization: Bearer $key"
+    -o "$response_file"
+    -w "%{http_code}"
+  )
+
+  if [[ -n "$body" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$body")
+  fi
+
+  status="$(curl "${args[@]}" "${ENDPOINT%/}$path")"
+  HTTP_STATUS="$status"
+  HTTP_BODY="$(cat "$response_file")"
+}
+
+api_expect() {
+  local name="$1"
+  local method="$2"
+  local path="$3"
+  local key="$4"
+  local body="$5"
+  local expected="$6"
+
+  api_request "$method" "$path" "$key" "$body"
+  remember_sensitive_values "$HTTP_BODY"
+  record_http_step "$name" "$method" "$path" "$HTTP_STATUS" "$HTTP_BODY"
+  capture_cleanup_handle "$name" "$HTTP_BODY"
+
+  if [[ "$HTTP_STATUS" != "$expected" ]]; then
+    fail "$name expected HTTP $expected from $method $path, got $HTTP_STATUS: $(sanitize_json "$HTTP_BODY")"
+  fi
+
+  printf '%s' "$HTTP_BODY"
+}
+
+api_cleanup_get() {
+  local path="$1"
+  local response_file
+
+  response_file="$(mktemp "$TMPDIR_REHEARSAL/cleanup-list.XXXXXX")"
+  curl -sS \
+    -X GET \
+    -H "Authorization: Bearer $API_KEY" \
+    -o "$response_file" \
+    "${ENDPOINT%/}$path" >/dev/null
+  cat "$response_file"
+}
+
+api_cleanup_request() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local response_file
+
+  response_file="$(mktemp "$TMPDIR_REHEARSAL/cleanup.XXXXXX")"
+  local args=(
+    -sS
+    -X "$method"
+    -H "Authorization: Bearer $API_KEY"
+    -o "$response_file"
+    -w "%{http_code}"
+  )
+
+  if [[ -n "$body" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$body")
+  fi
+
+  curl "${args[@]}" "${ENDPOINT%/}$path" >/dev/null
+}
+
+cleanup_targets_by_name() {
+  local list target_id
+
+  list="$(api_cleanup_get "/api/v1/targets")" || return 0
+  while IFS= read -r target_id; do
+    [[ -n "$target_id" ]] || continue
+    api_cleanup_request DELETE "/api/v1/targets/$target_id"
+  done < <(
+    jq -r --arg name "$TARGET_NAME" --arg service "$SERVICE" '
+      .targets[]? | select(.name == $name or .service == $service) | .id
+    ' <<<"$list"
+  )
+}
+
+cleanup_monitors_by_name() {
+  local list monitor_id
+
+  list="$(api_cleanup_get "/api/v1/monitors")" || return 0
+  while IFS= read -r monitor_id; do
+    [[ -n "$monitor_id" ]] || continue
+    api_cleanup_request DELETE "/api/v1/monitors/$monitor_id"
+  done < <(
+    jq -r --arg name "$MONITOR_NAME" --arg service "$SERVICE" '
+      .monitors[]? | select(.name == $name or .service == $service) | .id
+    ' <<<"$list"
+  )
+}
+
+cleanup_webhooks_by_url() {
+  local list webhook_id
+
+  list="$(api_cleanup_get "/api/v1/webhooks")" || return 0
+  while IFS= read -r webhook_id; do
+    [[ -n "$webhook_id" ]] || continue
+    api_cleanup_request DELETE "/api/v1/webhooks/$webhook_id"
+  done < <(
+    jq -r --arg url "$WEBHOOK_RUN_URL" '
+      .webhooks[]? | select(.url == $url) | .id
+    ' <<<"$list"
+  )
+}
+
+cleanup_keys_by_name() {
+  local list key_id
+
+  list="$(api_cleanup_get "/api/v1/keys")" || return 0
+  while IFS= read -r key_id; do
+    [[ -n "$key_id" ]] || continue
+    api_cleanup_request POST "/api/v1/keys/$key_id/revoke" "{}"
+  done < <(
+    jq -r --arg name "$KEY_NAME" '
+      .keys[]? | select(.name == $name and .active == true) | .id
+    ' <<<"$list"
+  )
+}
+
+cleanup_best_effort() {
+  set +e
+  if [[ -n "$TARGET_ID" ]]; then
+    api_cleanup_request DELETE "/api/v1/targets/$TARGET_ID"
+  fi
+  if [[ -n "$MONITOR_ID" ]]; then
+    api_cleanup_request DELETE "/api/v1/monitors/$MONITOR_ID"
+  fi
+  if [[ -n "$WEBHOOK_ID" ]]; then
+    api_cleanup_request DELETE "/api/v1/webhooks/$WEBHOOK_ID"
+  fi
+  if [[ -n "$INGEST_KEY_ID" ]]; then
+    api_cleanup_request POST "/api/v1/keys/$INGEST_KEY_ID/revoke" "{}"
+  fi
+  cleanup_targets_by_name
+  cleanup_monitors_by_name
+  cleanup_webhooks_by_url
+  cleanup_keys_by_name
+  set -e
+}
+
+on_exit() {
+  local status=$?
+
+  if [[ -n "$TMPDIR_REHEARSAL" && -d "$TMPDIR_REHEARSAL" ]]; then
+    if ((status != 0 && CLEANED_UP == 0)); then
+      cleanup_best_effort >/dev/null 2>&1 || true
+    fi
+    rm -rf "$TMPDIR_REHEARSAL"
+  fi
+
+  exit "$status"
+}
+
+append_rehearsal_query() {
+  local url="$1"
+
+  if [[ "$url" == *\?* ]]; then
+    printf '%s&canary_rehearsal=%s' "$url" "$(urlencode "$PREFIX")"
+  else
+    printf '%s?canary_rehearsal=%s' "$url" "$(urlencode "$PREFIX")"
+  fi
+}
+
+assert_json_id_present() {
+  local body="$1"
+  local array_path="$2"
+  local id="$3"
+  local label="$4"
+
+  if ! jq -e --arg id "$id" "$array_path | any(.id == \$id)" >/dev/null <<<"$body"; then
+    fail "$label did not include expected id $id"
+  fi
+}
+
+assert_json_id_absent() {
+  local body="$1"
+  local array_path="$2"
+  local id="$3"
+  local label="$4"
+
+  if ! jq -e --arg id "$id" "$array_path | all(.id != \$id)" >/dev/null <<<"$body"; then
+    fail "$label still includes cleaned-up id $id"
+  fi
+}
+
+wait_for_webhook_delivery() {
+  local encoded_webhook event_path deliveries delivery_id last_delivery_id last_delivery_status lookup_response
+  encoded_webhook="$(urlencode "$WEBHOOK_ID")"
+  event_path="/api/v1/webhook-deliveries?webhook_id=${encoded_webhook}&event=error.new_class&limit=5"
+  last_delivery_id=""
+  last_delivery_status=""
+
+  for _ in $(seq 1 "$POLL_ATTEMPTS"); do
+    deliveries="$(api_expect "webhook_delivery_poll" GET "$event_path" "$API_KEY" "" 200)"
+    delivery_id="$(
+      jq -r '
+        [.deliveries[]? | select(.status == "delivered") | .delivery_id][0] // ""
+      ' <<<"$deliveries"
+    )"
+
+    if [[ -n "$delivery_id" ]]; then
+      WEBHOOK_DELIVERY_ID="$delivery_id"
+      lookup_response="$(api_expect "webhook_delivery_lookup" GET "/api/v1/webhook-deliveries/$WEBHOOK_DELIVERY_ID" "$API_KEY" "" 200)"
+      if ! jq -e \
+        --arg delivery_id "$WEBHOOK_DELIVERY_ID" \
+        --arg webhook_id "$WEBHOOK_ID" \
+        '.delivery_id == $delivery_id and .webhook_id == $webhook_id and .event == "error.new_class" and .status == "delivered"' \
+        >/dev/null <<<"$lookup_response"; then
+        fail "webhook delivery lookup did not return delivered error.new_class row $WEBHOOK_DELIVERY_ID for $WEBHOOK_ID"
+      fi
+      return
+    fi
+
+    last_delivery_id="$(jq -r '[.deliveries[]? | .delivery_id][0] // ""' <<<"$deliveries")"
+    last_delivery_status="$(jq -r '[.deliveries[]? | .status][0] // ""' <<<"$deliveries")"
+
+    sleep "$POLL_SLEEP"
+  done
+
+  fail "timed out waiting for delivered webhook delivery for $WEBHOOK_ID; last delivery ${last_delivery_id:-none} status ${last_delivery_status:-none}"
+}
+
+collect_deploy_identity() {
+  local output status identity
+
+  if ! command -v flyctl >/dev/null 2>&1; then
+    fail "Missing required command: flyctl"
+  fi
+
+  set +e
+  output="$(flyctl status --app "$APP" --json 2>&1)"
+  status=$?
+  set -e
+
+  if ((status != 0)); then
+    record_shell_step "fly_status" "flyctl status --app $APP --json" "$status" "$output"
+    fail "fly status failed for $APP: $(sanitize_text "$output")"
+  fi
+
+  if ! identity="$(jq -c '
+    def image_ref:
+      if .image_ref == null then
+        null
+      else
+        {
+          registry: (.image_ref.registry // null),
+          repository: (.image_ref.repository // null),
+          tag: (.image_ref.tag // null),
+          digest: (.image_ref.digest // null),
+          commit: (.image_ref.labels.GH_SHA // null),
+          repo: (.image_ref.labels.GH_REPO // null),
+          event: (.image_ref.labels.GH_EVENT_NAME // null)
+        }
+      end;
+    def machine:
+      {
+        id: (.id // null),
+        name: (.name // null),
+        state: (.state // null),
+        region: (.region // null),
+        image: (.config.image // null),
+        image_ref: image_ref,
+        release_id: (.config.metadata.fly_release_id // null),
+        release_version: (.config.metadata.fly_release_version // null),
+        checks: ((.checks // []) | map({
+          name: (.name // null),
+          status: (.status // null),
+          updated_at: (.updated_at // null)
+        }))
+      };
+    {
+      app: (.Name // .name // null),
+      status: (.Status // .status // null),
+      hostname: (.Hostname // .hostname // null),
+      version: (.Version // .version // null),
+      machines: ((.Machines // .machines // []) | map(machine))
+    }
+  ' <<<"$output")"; then
+    fail "fly status did not return parseable deployment identity for $APP: $(sanitize_text "$output")"
+  fi
+
+  if ! jq -e '
+    (.machines | length) > 0
+    and all(.machines[]; (.id // "") != "")
+    and all(.machines[]; (.image_ref.tag // "") != "")
+    and all(.machines[]; (.image_ref.digest // "") != "")
+    and all(.machines[]; (.image_ref.commit // "") != "")
+  ' >/dev/null <<<"$identity"; then
+    fail "fly status for $APP did not include machine id, image tag, image digest, and commit label"
+  fi
+
+  DEPLOY_IDENTITY="$identity"
+  record_json_step "fly_deploy_identity" "$identity"
+}
+
+while (($#)); do
+  case "$1" in
+    --endpoint)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      ENDPOINT="$2"
+      shift 2
+      ;;
+    --api-key)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      API_KEY="$2"
+      shift 2
+      ;;
+    --webhook-url)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      WEBHOOK_URL="$2"
+      shift 2
+      ;;
+    --prefix)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      PREFIX="$2"
+      shift 2
+      ;;
+    --app)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      APP="$2"
+      shift 2
+      ;;
+    --poll-attempts)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      POLL_ATTEMPTS="$2"
+      shift 2
+      ;;
+    --poll-sleep)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      POLL_SLEEP="$2"
+      shift 2
+      ;;
+    --no-dr-status)
+      RUN_DR_STATUS=0
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_command curl
+require_command jq
+require_command date
+
+[[ -n "$ENDPOINT" ]] || fail "Missing Canary endpoint. Set CANARY_ENDPOINT or pass --endpoint."
+[[ -n "$API_KEY" ]] || fail "Missing Canary API key. Set CANARY_API_KEY or pass --api-key."
+[[ "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || fail "--poll-attempts must be a positive integer."
+[[ "$POLL_SLEEP" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail "--poll-sleep must be a non-negative number."
+
+if [[ -z "$PREFIX" ]]; then
+  PREFIX="writepath-$(date -u '+%Y%m%d%H%M%S')-$$"
+fi
+
+TMPDIR_REHEARSAL="$(mktemp -d)"
+STEPS_FILE="$TMPDIR_REHEARSAL/steps.ndjson"
+SENSITIVE_VALUES_FILE="$TMPDIR_REHEARSAL/sensitive-values"
+: > "$STEPS_FILE"
+: > "$SENSITIVE_VALUES_FILE"
+trap on_exit EXIT
+
+RUN_STARTED_AT="$(now_utc)"
+SERVICE="canary-write-path-$PREFIX"
+KEY_NAME="$SERVICE-ingest"
+TARGET_NAME="$SERVICE-target"
+MONITOR_NAME="$SERVICE-monitor"
+TARGET_URL="${ENDPOINT%/}/healthz"
+WEBHOOK_RUN_URL="$(append_rehearsal_query "$WEBHOOK_URL")"
+remember_sensitive_literal "$WEBHOOK_RUN_URL"
+
+if ((RUN_DR_STATUS == 1)); then
+  collect_deploy_identity
+else
+  DEPLOY_IDENTITY="$(jq -cn '{status: "skipped", reason: "--no-dr-status"}')"
+  record_json_step "fly_deploy_identity" "$DEPLOY_IDENTITY"
+fi
+
+key_body="$(jq -cn --arg name "$KEY_NAME" '{name: $name, scope: "ingest-only"}')"
+key_response="$(api_expect "api_key_create_ingest" POST "/api/v1/keys" "$API_KEY" "$key_body" 201)"
+INGEST_KEY="$(jq -r '.key' <<<"$key_response")"
+INGEST_KEY_ID="$(jq -r '.id' <<<"$key_response")"
+api_expect "ingest_key_cannot_read_targets" GET "/api/v1/targets" "$INGEST_KEY" "" 403 >/dev/null
+
+target_body="$(jq -cn \
+  --arg name "$TARGET_NAME" \
+  --arg service "$SERVICE" \
+  --arg url "$TARGET_URL" \
+  '{name: $name, service: $service, url: $url, interval_ms: 60000, timeout_ms: 5000, expected_status: "200"}')"
+target_response="$(api_expect "target_create" POST "/api/v1/targets" "$API_KEY" "$target_body" 201)"
+TARGET_ID="$(jq -r '.id' <<<"$target_response")"
+targets_list="$(api_expect "target_query_after_create" GET "/api/v1/targets" "$API_KEY" "" 200)"
+assert_json_id_present "$targets_list" ".targets" "$TARGET_ID" "target list"
+api_expect "target_pause" POST "/api/v1/targets/$TARGET_ID/pause" "$API_KEY" "" 200 >/dev/null
+api_expect "target_resume" POST "/api/v1/targets/$TARGET_ID/resume" "$API_KEY" "" 200 >/dev/null
+
+monitor_body="$(jq -cn \
+  --arg name "$MONITOR_NAME" \
+  --arg service "$SERVICE" \
+  '{name: $name, service: $service, mode: "ttl", expected_every_ms: 600000, grace_ms: 120000}')"
+monitor_response="$(api_expect "monitor_create" POST "/api/v1/monitors" "$API_KEY" "$monitor_body" 201)"
+MONITOR_ID="$(jq -r '.id' <<<"$monitor_response")"
+monitors_list="$(api_expect "monitor_query_after_create" GET "/api/v1/monitors" "$API_KEY" "" 200)"
+assert_json_id_present "$monitors_list" ".monitors" "$MONITOR_ID" "monitor list"
+
+check_in_body="$(jq -cn \
+  --arg monitor "$MONITOR_NAME" \
+  --arg prefix "$PREFIX" \
+  '{monitor: $monitor, status: "alive", ttl_ms: 600000, context: {rehearsal_prefix: $prefix}}')"
+api_expect "monitor_check_in" POST "/api/v1/check-ins" "$INGEST_KEY" "$check_in_body" 201 >/dev/null
+
+webhook_body="$(jq -cn \
+  --arg url "$WEBHOOK_RUN_URL" \
+  '{url: $url, events: ["canary.ping", "error.new_class"]}')"
+webhook_response="$(api_expect "webhook_create" POST "/api/v1/webhooks" "$API_KEY" "$webhook_body" 201)"
+WEBHOOK_ID="$(jq -r '.id' <<<"$webhook_response")"
+webhooks_list="$(api_expect "webhook_query_after_create" GET "/api/v1/webhooks" "$API_KEY" "" 200)"
+assert_json_id_present "$webhooks_list" ".webhooks" "$WEBHOOK_ID" "webhook list"
+api_expect "webhook_test" POST "/api/v1/webhooks/$WEBHOOK_ID/test" "$API_KEY" "{}" 200 >/dev/null
+
+error_body="$(jq -cn \
+  --arg service "$SERVICE" \
+  --arg prefix "$PREFIX" \
+  '{service: $service, error_class: "CanaryWritePathRehearsal", message: ("canary write path rehearsal " + $prefix), severity: "error", context: {rehearsal_prefix: $prefix}}')"
+error_response="$(api_expect "error_ingest" POST "/api/v1/errors" "$INGEST_KEY" "$error_body" 201)"
+ERROR_ID="$(jq -r '.id' <<<"$error_response")"
+ERROR_GROUP_HASH="$(jq -r '.group_hash' <<<"$error_response")"
+
+encoded_service="$(urlencode "$SERVICE")"
+encoded_prefix="$(urlencode "$PREFIX")"
+query_response="$(api_expect "error_query_readback" GET "/api/v1/query?service=${encoded_service}&window=1h" "$API_KEY" "" 200)"
+if ! jq -e \
+  --arg service "$SERVICE" \
+  --arg group_hash "$ERROR_GROUP_HASH" \
+  '.service == $service and (.groups // [] | any(.group_hash == $group_hash and .service == $service and .error_class == "CanaryWritePathRehearsal"))' \
+  >/dev/null <<<"$query_response"; then
+  fail "query readback did not return error group $ERROR_GROUP_HASH for $SERVICE"
+fi
+report_response="$(api_expect "report_readback" GET "/api/v1/report?window=1h&q=${encoded_prefix}&limit=5" "$API_KEY" "" 200)"
+if ! jq -e \
+  --arg service "$SERVICE" \
+  --arg error_id "$ERROR_ID" \
+  --arg group_hash "$ERROR_GROUP_HASH" \
+  '((.search_results // []) | any(.id == $error_id and .service == $service and .error_class == "CanaryWritePathRehearsal")) and ((.error_groups // []) | any(.group_hash == $group_hash and .service == $service and .error_class == "CanaryWritePathRehearsal"))' \
+  >/dev/null <<<"$report_response"; then
+  fail "report readback did not return error $ERROR_ID and group $ERROR_GROUP_HASH for $SERVICE"
+fi
+timeline_response="$(api_expect "timeline_readback" GET "/api/v1/timeline?service=${encoded_service}&window=1h&limit=10" "$API_KEY" "" 200)"
+if ! jq -e \
+  --arg service "$SERVICE" \
+  --arg error_id "$ERROR_ID" \
+  --arg group_hash "$ERROR_GROUP_HASH" \
+  '(.events // []) | any(.service == $service and .event == "error.new_class" and ((.payload.error.id // "") == $error_id or (.entity_ref // "") == $group_hash))' \
+  >/dev/null <<<"$timeline_response"; then
+  fail "timeline readback did not return error.new_class event for error $ERROR_ID"
+fi
+error_detail_response="$(api_expect "error_detail_readback" GET "/api/v1/errors/$ERROR_ID" "$API_KEY" "" 200)"
+if ! jq -e \
+  --arg service "$SERVICE" \
+  --arg error_id "$ERROR_ID" \
+  '.id == $error_id and .service == $service and .error_class == "CanaryWritePathRehearsal"' \
+  >/dev/null <<<"$error_detail_response"; then
+  fail "error detail readback did not return error $ERROR_ID for $SERVICE"
+fi
+
+wait_for_webhook_delivery
+
+if ((RUN_DR_STATUS == 1)); then
+  set +e
+  dr_output="$(NO_COLOR=1 "$ROOT/bin/dr-status" --app "$APP" 2>&1)"
+  dr_status=$?
+  set -e
+  record_shell_step "dr_status" "NO_COLOR=1 bin/dr-status --app $APP" "$dr_status" "$dr_output"
+  if ((dr_status != 0)); then
+    fail "dr-status failed for $APP: $(sanitize_text "$dr_output")"
+  fi
+fi
+
+api_expect "target_delete" DELETE "/api/v1/targets/$TARGET_ID" "$API_KEY" "" 204 >/dev/null
+api_expect "monitor_delete" DELETE "/api/v1/monitors/$MONITOR_ID" "$API_KEY" "" 204 >/dev/null
+api_expect "webhook_delete" DELETE "/api/v1/webhooks/$WEBHOOK_ID" "$API_KEY" "" 204 >/dev/null
+api_expect "api_key_revoke_ingest" POST "/api/v1/keys/$INGEST_KEY_ID/revoke" "$API_KEY" "{}" 200 >/dev/null
+api_expect "revoked_ingest_key_rejects_check_in" POST "/api/v1/check-ins" "$INGEST_KEY" "$check_in_body" 401 >/dev/null
+
+post_targets="$(api_expect "post_cleanup_targets" GET "/api/v1/targets" "$API_KEY" "" 200)"
+assert_json_id_absent "$post_targets" ".targets" "$TARGET_ID" "post-cleanup target list"
+post_monitors="$(api_expect "post_cleanup_monitors" GET "/api/v1/monitors" "$API_KEY" "" 200)"
+assert_json_id_absent "$post_monitors" ".monitors" "$MONITOR_ID" "post-cleanup monitor list"
+post_webhooks="$(api_expect "post_cleanup_webhooks" GET "/api/v1/webhooks" "$API_KEY" "" 200)"
+assert_json_id_absent "$post_webhooks" ".webhooks" "$WEBHOOK_ID" "post-cleanup webhook list"
+post_keys="$(api_expect "post_cleanup_keys" GET "/api/v1/keys" "$API_KEY" "" 200)"
+if ! jq -e --arg id "$INGEST_KEY_ID" '.keys | any(.id == $id and .active == false)' >/dev/null <<<"$post_keys"; then
+  fail "post-cleanup key list did not show revoked disposable key $INGEST_KEY_ID as inactive"
+fi
+CLEANED_UP=1
+
+finished_at="$(now_utc)"
+steps_json="$(jq -s '.' "$STEPS_FILE")"
+resources_json="$(jq -cn \
+  --arg service "$SERVICE" \
+  --arg error_id "$ERROR_ID" \
+  --arg target_id "$TARGET_ID" \
+  --arg monitor_id "$MONITOR_ID" \
+  --arg webhook_id "$WEBHOOK_ID" \
+  --arg key_id "$INGEST_KEY_ID" \
+	  --arg delivery_id "$WEBHOOK_DELIVERY_ID" \
+  '{
+    service: $service,
+    immutable_error_id: $error_id,
+    cleaned_target_id: $target_id,
+    cleaned_monitor_id: $monitor_id,
+    cleaned_webhook_id: $webhook_id,
+    revoked_key_id: $key_id,
+    immutable_webhook_delivery_id: $delivery_id
+	  }')"
+receipt="$(jq -n \
+  --argjson schema_version 1 \
+  --arg status "ok" \
+  --arg endpoint "${ENDPOINT%/}" \
+  --arg app "$APP" \
+  --arg prefix "$PREFIX" \
+  --arg started_at "$RUN_STARTED_AT" \
+  --arg finished_at "$finished_at" \
+	  --arg webhook_url "$WEBHOOK_RUN_URL" \
+	  --arg cleanup_note "Targets, monitors, and webhooks are deleted. The temporary ingest key is revoked and intentionally remains as an inactive audit row. Error and webhook-delivery rows are immutable evidence." \
+	  --argjson deploy_identity "$DEPLOY_IDENTITY" \
+	  --argjson resources "$resources_json" \
+	  --argjson steps "$steps_json" \
+	  '{
+    schema_version: $schema_version,
+    status: $status,
+    endpoint: $endpoint,
+    fly_app: $app,
+    prefix: $prefix,
+	    started_at: $started_at,
+	    finished_at: $finished_at,
+	    webhook_url: ($webhook_url | gsub("\\?.*$"; "?<redacted-query>")),
+	    deploy_identity: $deploy_identity,
+	    resources: $resources,
+	    cleanup_note: $cleanup_note,
+	    steps: $steps
+  }')"
+
+if ((JSON_OUTPUT == 1)); then
+  jq -c . <<<"$receipt"
+else
+  printf 'Canary write-path rehearsal: ok\n'
+  printf 'prefix: %s\n' "$PREFIX"
+  printf 'service: %s\n' "$SERVICE"
+  printf 'error: %s\n' "$ERROR_ID"
+  printf 'webhook_delivery: %s\n' "$WEBHOOK_DELIVERY_ID"
+  printf 'cleanup: target deleted, monitor deleted, webhook deleted, key revoked\n'
+fi

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -229,9 +229,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -467,9 +467,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -484,9 +484,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1584,9 +1584,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1597,32 +1597,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/estree-walker": {
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2234,7 +2234,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -35,5 +35,9 @@
     "typescript": "^5.8.0",
     "vitest": "^4.1.3"
   },
+  "overrides": {
+    "esbuild": "^0.28.1",
+    "postcss": "^8.5.15"
+  },
   "license": "MIT"
 }

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -188,8 +188,10 @@ export class Ci {
       .withExec(["bash", "test/bin/dogfood_audit_test.sh"])
       .withExec(["bash", "test/bin/dogfood_inventory_test.sh"])
       .withExec(["bash", "test/bin/canary_witness_test.sh"])
+      .withExec(["bash", "test/bin/canary_write_path_rehearsal_test.sh"])
       .withExec(["bash", "-n", "bin/canary"])
       .withExec(["bash", "-n", "bin/canary-witness"])
+      .withExec(["bash", "-n", "bin/canary-write-path-rehearsal"])
   }
 
   private async typescriptQualityContainer(source: Directory): Promise<Container> {

--- a/docs/architecture/rust-cutover-evidence-2026-06-06.md
+++ b/docs/architecture/rust-cutover-evidence-2026-06-06.md
@@ -118,8 +118,12 @@ Evidence:
 ## Residual risks
 
 - This proves the Rust server is serving production behind Fly for the checked
-  public and read-only routes. It does not prove every admin, ingest, webhook,
-  retention, target-probe, TLS-scan, and monitor path under production load.
+  public and read-only routes. The live admin, ingest, target, monitor,
+  webhook, delivery-ledger, query/report/timeline, cleanup, and DR-status
+  write-path proof is separate:
+  `docs/architecture/rust-write-path-evidence-2026-06-12.md`. Neither packet
+  proves retention-prune or TLS-expiry workers under long-running production
+  conditions.
 - This packet predates the scorched-earth deletion branch. It proves the first
   Rust production image served Fly, but it does not by itself prove the later
   removal of the executable Elixir service, Elixir SDK, and Mix/Dagger lanes.

--- a/docs/architecture/rust-rewrite.md
+++ b/docs/architecture/rust-rewrite.md
@@ -1131,6 +1131,17 @@ the Rust server accepts production traffic:
     surface. The Axum route maps that boundary to the standard RFC 9457
     `422 validation_error` cursor problem, preserving legacy group-hash
     cursors while making bad agent replay state fail explicitly.
+93. The Rust production write-path evidence packet now lives at
+    `docs/architecture/rust-write-path-evidence-2026-06-12.md`. It records a
+    replayable `bin/canary-write-path-rehearsal --json` run against the
+    deployed Fly image labeled with commit
+    `8066373b55108f662bf08158dfd74c25561a9fd4`. The run mints and revokes an
+    ingest key, creates/pauses/resumes/deletes a target, creates/checks
+    in/deletes a monitor, creates/tests/deletes a webhook, ingests an error,
+    verifies query/report/timeline/error-detail readback, observes a delivered
+    webhook-delivery ledger row, and records `bin/dr-status` output. This is
+    the write-path companion to the 2026-06-06 read/public cutover packet; it
+    does not claim long-running retention-prune or TLS-expiry worker proof.
 
 This slice is deliberately small but aligned with the full rewrite: it moves
 existing contracts into Rust types and tests. The server crate is allowed

--- a/docs/architecture/rust-write-path-evidence-2026-06-12.md
+++ b/docs/architecture/rust-write-path-evidence-2026-06-12.md
@@ -1,0 +1,148 @@
+# Rust write-path evidence: 2026-06-12
+
+This packet records a live production-shaped write-path rehearsal against the
+deployed Rust `canary-server` on Fly. It complements the 2026-06-06 cutover
+packet: that packet proved production serving plus public/read routes; this
+one proves the admin, ingest, target, monitor, webhook, worker-backed delivery,
+query/report/timeline readback, cleanup, and DR-status paths.
+
+## Service under test
+
+- Fly app: `canary-obs`
+- Endpoint: `https://canary-obs.fly.dev`
+- Deployed commit: `8066373b55108f662bf08158dfd74c25561a9fd4`
+- Deployed image: `registry.fly.io/canary-obs:deployment-01KTYR1CH63W842CPD6TM775FW`
+- Image digest: `sha256:bf4d29b374f423cdd93e926ea6d2d0a5a8a2c49bfbf2d726bd2c357e9c1c2c65`
+- Machine: `78407d7f515008`
+- Fly release version: `76`
+- Region: `iad`
+
+`flyctl status --app canary-obs --json` reported the machine `started`, host
+status `ok`, and both service checks passing:
+
+```json
+[
+  {
+    "name": "servicecheck-01-http-4000",
+    "status": "passing",
+    "output": "{\"status\":\"ready\",\"checks\":{\"database\":\"ok\",\"supervisor\":\"ok\"}}"
+  },
+  {
+    "name": "servicecheck-00-http-4000",
+    "status": "passing",
+    "output": "{\"status\":\"ok\"}"
+  }
+]
+```
+
+## Rehearsal command
+
+The command used the local admin key only as an Authorization header. The JSON
+receipt redacts one-time API keys, key prefixes, webhook secrets, key hashes,
+and error group hashes before printing.
+
+```bash
+bin/canary-write-path-rehearsal \
+  --prefix 20260612-live-rust-write-path-final \
+  --json \
+  | tee /tmp/canary-write-path-rehearsal-2026-06-12-final.json \
+  | jq '{status, prefix, deploy_commit: .deploy_identity.machines[0].image_ref.commit, deploy_digest: .deploy_identity.machines[0].image_ref.digest, machine: .deploy_identity.machines[0].id, resources, cleanup_note, step_count: (.steps | length)}'
+```
+
+Receipt summary:
+
+```json
+{
+  "status": "ok",
+  "prefix": "20260612-live-rust-write-path-final",
+  "deploy_commit": "8066373b55108f662bf08158dfd74c25561a9fd4",
+  "deploy_digest": "sha256:bf4d29b374f423cdd93e926ea6d2d0a5a8a2c49bfbf2d726bd2c357e9c1c2c65",
+  "machine": "78407d7f515008",
+  "resources": {
+    "service": "canary-write-path-20260612-live-rust-write-path-final",
+    "immutable_error_id": "ERR-kc7o7ryv121g",
+    "cleaned_target_id": "TGT-2cr0ze6iwcfx",
+    "cleaned_monitor_id": "MON-k2843ev95yz9",
+    "cleaned_webhook_id": "WHK-opehar1c54yt",
+    "revoked_key_id": "KEY-vy07y1z3576z",
+    "immutable_webhook_delivery_id": "DLV-stwp8h56qgxd"
+  },
+  "cleanup_note": "Targets, monitors, and webhooks are deleted. The temporary ingest key is revoked and intentionally remains as an inactive audit row. Error and webhook-delivery rows are immutable evidence.",
+  "step_count": 30
+}
+```
+
+Full redacted receipt:
+[`docs/architecture/rust-write-path-receipt-2026-06-12.json`](rust-write-path-receipt-2026-06-12.json).
+That checked-in artifact contains the complete `.steps[]` response bodies from
+the run, including query/report/timeline readback and post-cleanup
+targets/monitors/webhooks/keys responses.
+
+## Write-path coverage
+
+All HTTP statuses below came from the live receipt.
+
+| Step | Route or command | Result |
+|---|---|---|
+| Fly deploy identity | `flyctl status --app canary-obs --json` | `deployed`, machine `78407d7f515008`, image digest `sha256:bf4d29b374f423cdd93e926ea6d2d0a5a8a2c49bfbf2d726bd2c357e9c1c2c65`, commit `8066373b55108f662bf08158dfd74c25561a9fd4` |
+| API key mint | `POST /api/v1/keys` | `201`, created `KEY-vy07y1z3576z` with `ingest-only` scope |
+| Ingest key read denial | `GET /api/v1/targets` with the ingest-only key | `403`, `insufficient_scope` |
+| Target create | `POST /api/v1/targets` | `201`, created `TGT-2cr0ze6iwcfx` for the rehearsal service |
+| Target query | `GET /api/v1/targets` | `200`, listed the disposable target before cleanup |
+| Target pause/resume | `POST /api/v1/targets/{id}/pause`, `POST /api/v1/targets/{id}/resume` | both `200` |
+| Monitor create | `POST /api/v1/monitors` | `201`, created `MON-k2843ev95yz9` |
+| Monitor query | `GET /api/v1/monitors` | `200`, listed the disposable monitor before cleanup |
+| Monitor check-in | `POST /api/v1/check-ins` | `201`, returned state `up`, sequence `1` |
+| Webhook create | `POST /api/v1/webhooks` | `201`, created `WHK-opehar1c54yt` for `canary.ping` and `error.new_class` |
+| Webhook test | `POST /api/v1/webhooks/{id}/test` | `200`, returned `delivered` |
+| Error ingest | `POST /api/v1/errors` | `201`, created `ERR-kc7o7ryv121g`, new class `true` |
+| Error query readback | `GET /api/v1/query?service=...&window=1h` | `200`, `total_errors: 1` for the rehearsal service |
+| Report readback | `GET /api/v1/report?window=1h&q=...&limit=5` | `200`, included the rehearsal error group, search result, target transition, monitor transition, and incident |
+| Timeline readback | `GET /api/v1/timeline?service=...&window=1h&limit=10` | `200`, returned 5 events for the rehearsal service |
+| Error detail readback | `GET /api/v1/errors/ERR-kc7o7ryv121g` | `200`, returned the expected service and class summary |
+| Webhook delivery page | `GET /api/v1/webhook-deliveries?webhook_id=...&event=error.new_class&limit=5` | `200`, returned `DLV-stwp8h56qgxd` |
+| Webhook delivery lookup | `GET /api/v1/webhook-deliveries/DLV-stwp8h56qgxd` | `200`, status `delivered`, attempt count `1` |
+| DR status | `NO_COLOR=1 bin/dr-status --app canary-obs` | exit `0`, Litestream status `ok` for `/data/canary.db` |
+
+DR-status excerpt:
+
+```text
+database         status  local txid        wal size
+/data/canary.db  ok      0000000000089857  5.5 MB
+```
+
+## Cleanup proof
+
+The rehearsal deleted disposable HTTP resources and revoked the temporary
+ingest key before returning `ok`.
+
+| Cleanup step | Result |
+|---|---|
+| `DELETE /api/v1/targets/TGT-2cr0ze6iwcfx` | `204` |
+| `DELETE /api/v1/monitors/MON-k2843ev95yz9` | `204` |
+| `DELETE /api/v1/webhooks/WHK-opehar1c54yt` | `204` |
+| `POST /api/v1/keys/KEY-vy07y1z3576z/revoke` | `200`, `{"status":"revoked"}` |
+| `POST /api/v1/check-ins` with the revoked ingest key | `401`, `invalid_api_key` |
+| `GET /api/v1/targets` after cleanup | `200`, no `TGT-2cr0ze6iwcfx` |
+| `GET /api/v1/monitors` after cleanup | `200`, no `MON-k2843ev95yz9` |
+| `GET /api/v1/webhooks` after cleanup | `200`, no `WHK-opehar1c54yt` |
+| `GET /api/v1/keys` after cleanup | `200`, `KEY-vy07y1z3576z` present only as inactive audit row |
+
+The error row, incident row, timeline events, and webhook-delivery row are not
+deleted. They are the immutable observability evidence for this run:
+
+- Error: `ERR-kc7o7ryv121g`
+- Incident opened for service: `canary-write-path-20260612-live-rust-write-path-final`
+- Delivery: `DLV-stwp8h56qgxd`
+
+## Residual risks
+
+- This packet deliberately creates one active error group for the rehearsal
+  service. Aggregate reports can show a warning until the normal query window
+  no longer includes that event; `service=canary` error checks are unaffected.
+- The webhook proof used `https://httpbingo.org/status/204` as a public 2xx
+  receiver. `bin/canary-write-path-rehearsal --webhook-url <url>` can replay
+  the same proof against another receiver if that service changes behavior.
+- This proves live HTTP write/read paths and the webhook delivery worker for one
+  delivery. It does not prove retention-prune or TLS-expiry workers under
+  long-running production conditions; #034 owns the worker readiness oracle.

--- a/docs/architecture/rust-write-path-receipt-2026-06-12.json
+++ b/docs/architecture/rust-write-path-receipt-2026-06-12.json
@@ -1,0 +1,1393 @@
+{
+  "schema_version": 1,
+  "status": "ok",
+  "endpoint": "https://canary-obs.fly.dev",
+  "fly_app": "canary-obs",
+  "prefix": "20260612-live-rust-write-path-final",
+  "started_at": "2026-06-12T21:20:11Z",
+  "finished_at": "2026-06-12T21:20:34Z",
+  "webhook_url": "https://httpbingo.org/status/204?<redacted-query>",
+  "deploy_identity": {
+    "app": "canary-obs",
+    "status": "deployed",
+    "hostname": "canary-obs.fly.dev",
+    "version": 76,
+    "machines": [
+      {
+        "id": "78407d7f515008",
+        "name": "delicate-voice-8599",
+        "state": "started",
+        "region": "iad",
+        "image": "registry.fly.io/canary-obs:deployment-01KTYR1CH63W842CPD6TM775FW",
+        "image_ref": {
+          "registry": "registry.fly.io",
+          "repository": "canary-obs",
+          "tag": "deployment-01KTYR1CH63W842CPD6TM775FW",
+          "digest": "sha256:bf4d29b374f423cdd93e926ea6d2d0a5a8a2c49bfbf2d726bd2c357e9c1c2c65",
+          "commit": "8066373b55108f662bf08158dfd74c25561a9fd4",
+          "repo": "misty-step/canary",
+          "event": "workflow_run"
+        },
+        "release_id": "rel_dg93zlmvqv802jw0",
+        "release_version": "76",
+        "checks": [
+          {
+            "name": "servicecheck-01-http-4000",
+            "status": "passing",
+            "updated_at": "2026-06-12T20:25:30.28Z"
+          },
+          {
+            "name": "servicecheck-00-http-4000",
+            "status": "passing",
+            "updated_at": "2026-06-12T20:25:29.999Z"
+          }
+        ]
+      }
+    ]
+  },
+  "resources": {
+    "service": "canary-write-path-20260612-live-rust-write-path-final",
+    "immutable_error_id": "ERR-kc7o7ryv121g",
+    "cleaned_target_id": "TGT-2cr0ze6iwcfx",
+    "cleaned_monitor_id": "MON-k2843ev95yz9",
+    "cleaned_webhook_id": "WHK-opehar1c54yt",
+    "revoked_key_id": "KEY-vy07y1z3576z",
+    "immutable_webhook_delivery_id": "DLV-stwp8h56qgxd"
+  },
+  "cleanup_note": "Targets, monitors, and webhooks are deleted. The temporary ingest key is revoked and intentionally remains as an inactive audit row. Error and webhook-delivery rows are immutable evidence.",
+  "steps": [
+    {
+      "type": "json",
+      "name": "fly_deploy_identity",
+      "response": {
+        "app": "canary-obs",
+        "status": "deployed",
+        "hostname": "canary-obs.fly.dev",
+        "version": 76,
+        "machines": [
+          {
+            "id": "78407d7f515008",
+            "name": "delicate-voice-8599",
+            "state": "started",
+            "region": "iad",
+            "image": "registry.fly.io/canary-obs:deployment-01KTYR1CH63W842CPD6TM775FW",
+            "image_ref": {
+              "registry": "registry.fly.io",
+              "repository": "canary-obs",
+              "tag": "deployment-01KTYR1CH63W842CPD6TM775FW",
+              "digest": "sha256:bf4d29b374f423cdd93e926ea6d2d0a5a8a2c49bfbf2d726bd2c357e9c1c2c65",
+              "commit": "8066373b55108f662bf08158dfd74c25561a9fd4",
+              "repo": "misty-step/canary",
+              "event": "workflow_run"
+            },
+            "release_id": "rel_dg93zlmvqv802jw0",
+            "release_version": "76",
+            "checks": [
+              {
+                "name": "servicecheck-01-http-4000",
+                "status": "passing",
+                "updated_at": "2026-06-12T20:25:30.28Z"
+              },
+              {
+                "name": "servicecheck-00-http-4000",
+                "status": "passing",
+                "updated_at": "2026-06-12T20:25:29.999Z"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "api_key_create_ingest",
+      "method": "POST",
+      "path": "/api/v1/keys",
+      "status": 201,
+      "response": {
+        "created_at": "2026-06-12T21:20:13.781976835Z",
+        "id": "KEY-vy07y1z3576z",
+        "key": "<redacted>",
+        "key_prefix": "<redacted>",
+        "name": "canary-write-path-20260612-live-rust-write-path-final-ingest",
+        "scope": "ingest-only",
+        "warning": "Store this key securely. It will not be shown again."
+      }
+    },
+    {
+      "type": "http",
+      "name": "ingest_key_cannot_read_targets",
+      "method": "GET",
+      "path": "/api/v1/targets",
+      "status": 403,
+      "response": {
+        "type": "https://canary.dev/problems/insufficient-scope",
+        "title": "Insufficient Scope",
+        "status": 403,
+        "detail": "API key scope `ingest-only` cannot access this admin endpoint. Use an `admin` key.",
+        "code": "insufficient_scope",
+        "request_id": null,
+        "required_scopes": [
+          "admin"
+        ],
+        "scope": "ingest-only"
+      }
+    },
+    {
+      "type": "http",
+      "name": "target_create",
+      "method": "POST",
+      "path": "/api/v1/targets",
+      "status": 201,
+      "response": {
+        "active": true,
+        "created_at": "2026-06-12T21:20:14.933871512Z",
+        "expected_status": "200",
+        "id": "TGT-2cr0ze6iwcfx",
+        "interval_ms": 60000,
+        "method": "GET",
+        "name": "canary-write-path-20260612-live-rust-write-path-final-target",
+        "service": "canary-write-path-20260612-live-rust-write-path-final",
+        "timeout_ms": 5000,
+        "url": "https://canary-obs.fly.dev/healthz"
+      }
+    },
+    {
+      "type": "http",
+      "name": "target_query_after_create",
+      "method": "GET",
+      "path": "/api/v1/targets",
+      "status": 200,
+      "response": {
+        "targets": [
+          {
+            "active": true,
+            "created_at": "2026-03-14T23:03:28.424961Z",
+            "expected_status": "200",
+            "id": "TGT-5gowpivgtuvw",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "canary-self",
+            "service": "canary-self",
+            "timeout_ms": 5000,
+            "url": "https://canary-obs.fly.dev/healthz"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-12T21:20:14.933871512Z",
+            "expected_status": "200",
+            "id": "TGT-2cr0ze6iwcfx",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "canary-write-path-20260612-live-rust-write-path-final-target",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "timeout_ms": 5000,
+            "url": "https://canary-obs.fly.dev/healthz"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:36:59.551650Z",
+            "expected_status": "200",
+            "id": "TGT-cjjw9uyj0k41",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "chrondle",
+            "service": "chrondle",
+            "timeout_ms": 10000,
+            "url": "https://www.chrondle.app/api/health"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:37:00.059891Z",
+            "expected_status": "200",
+            "id": "TGT-l1uqvd03m5tz",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "linejam",
+            "service": "linejam",
+            "timeout_ms": 10000,
+            "url": "https://www.linejam.app/api/health"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-12T02:15:08.789422938Z",
+            "expected_status": "200",
+            "id": "TGT-ifbre1aplmka",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "misty-step",
+            "service": "misty-step",
+            "timeout_ms": 10000,
+            "url": "https://www.mistystep.io/api/health"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:37:00.472023Z",
+            "expected_status": "200",
+            "id": "TGT-72csit0gquvr",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "vulcan",
+            "service": "vulcan",
+            "timeout_ms": 10000,
+            "url": "https://adminifi-vulcan-orchestrator.fly.dev/health"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "target_pause",
+      "method": "POST",
+      "path": "/api/v1/targets/TGT-2cr0ze6iwcfx/pause",
+      "status": 200,
+      "response": {
+        "status": "paused"
+      }
+    },
+    {
+      "type": "http",
+      "name": "target_resume",
+      "method": "POST",
+      "path": "/api/v1/targets/TGT-2cr0ze6iwcfx/resume",
+      "status": 200,
+      "response": {
+        "status": "resumed"
+      }
+    },
+    {
+      "type": "http",
+      "name": "monitor_create",
+      "method": "POST",
+      "path": "/api/v1/monitors",
+      "status": 201,
+      "response": {
+        "created_at": "2026-06-12T21:20:17.123686586Z",
+        "expected_every_ms": 600000,
+        "grace_ms": 120000,
+        "id": "MON-k2843ev95yz9",
+        "mode": "ttl",
+        "name": "canary-write-path-20260612-live-rust-write-path-final-monitor",
+        "service": "canary-write-path-20260612-live-rust-write-path-final"
+      }
+    },
+    {
+      "type": "http",
+      "name": "monitor_query_after_create",
+      "method": "GET",
+      "path": "/api/v1/monitors",
+      "status": 200,
+      "response": {
+        "monitors": [
+          {
+            "created_at": "2026-06-12T00:48:07.869103074Z",
+            "expected_every_ms": 600000,
+            "grace_ms": 120000,
+            "id": "MON-5csw7imodfcq",
+            "mode": "ttl",
+            "name": "canary-watchman",
+            "service": "canary"
+          },
+          {
+            "created_at": "2026-06-12T21:20:17.123686586Z",
+            "expected_every_ms": 600000,
+            "grace_ms": 120000,
+            "id": "MON-k2843ev95yz9",
+            "mode": "ttl",
+            "name": "canary-write-path-20260612-live-rust-write-path-final-monitor",
+            "service": "canary-write-path-20260612-live-rust-write-path-final"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "monitor_check_in",
+      "method": "POST",
+      "path": "/api/v1/check-ins",
+      "status": 201,
+      "response": {
+        "check_in_id": "CHK-6ghqit7msbxu",
+        "monitor_id": "MON-k2843ev95yz9",
+        "observed_at": "2026-06-12T21:20:18.208144995Z",
+        "sequence": 1,
+        "state": "up"
+      }
+    },
+    {
+      "type": "http",
+      "name": "webhook_create",
+      "method": "POST",
+      "path": "/api/v1/webhooks",
+      "status": 201,
+      "response": {
+        "created_at": "2026-06-12T21:20:19.486681486Z",
+        "events": [
+          "canary.ping",
+          "error.new_class"
+        ],
+        "id": "WHK-opehar1c54yt",
+        "secret": "<redacted>",
+        "url": "<redacted>"
+      }
+    },
+    {
+      "type": "http",
+      "name": "webhook_query_after_create",
+      "method": "GET",
+      "path": "/api/v1/webhooks",
+      "status": 200,
+      "response": {
+        "webhooks": [
+          {
+            "active": true,
+            "created_at": "2026-04-09T01:51:10.814543Z",
+            "events": [
+              "error.new_class",
+              "error.regression",
+              "incident.opened",
+              "incident.updated",
+              "incident.resolved",
+              "health_check.down",
+              "health_check.degraded",
+              "health_check.recovered",
+              "health_check.tls_expiring"
+            ],
+            "id": "WHK-78ro85gmubzy",
+            "url": "https://linejam-canary-responder.fly.dev/canary/webhook"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-12T21:20:19.486681486Z",
+            "events": [
+              "canary.ping",
+              "error.new_class"
+            ],
+            "id": "WHK-opehar1c54yt",
+            "url": "<redacted>"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "webhook_test",
+      "method": "POST",
+      "path": "/api/v1/webhooks/WHK-opehar1c54yt/test",
+      "status": 200,
+      "response": {
+        "status": "delivered"
+      }
+    },
+    {
+      "type": "http",
+      "name": "error_ingest",
+      "method": "POST",
+      "path": "/api/v1/errors",
+      "status": 201,
+      "response": {
+        "group_hash": "<redacted-hash>",
+        "id": "ERR-kc7o7ryv121g",
+        "is_new_class": true
+      }
+    },
+    {
+      "type": "http",
+      "name": "error_query_readback",
+      "method": "GET",
+      "path": "/api/v1/query?service=canary-write-path-20260612-live-rust-write-path-final&window=1h",
+      "status": 200,
+      "response": {
+        "summary": "1 errors in canary-write-path-20260612-live-rust-write-path-final in the last 1h. 1 unique classes. Most frequent: CanaryWritePathRehearsal (1 occurrences).",
+        "service": "canary-write-path-20260612-live-rust-write-path-final",
+        "window": "1h",
+        "total_errors": 1,
+        "groups": [
+          {
+            "group_hash": "<redacted-hash>",
+            "error_class": "CanaryWritePathRehearsal",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "count": 1,
+            "first_seen": "2026-06-12T21:20:21.261615333Z",
+            "last_seen": "2026-06-12T21:20:21.261615333Z",
+            "sample_message": "canary write path rehearsal <int>-live-rust-write-path-final",
+            "severity": "error",
+            "status": "active",
+            "classification": {
+              "category": "unknown",
+              "persistence": "unknown",
+              "component": "unknown"
+            }
+          }
+        ],
+        "cursor": null
+      }
+    },
+    {
+      "type": "http",
+      "name": "report_readback",
+      "method": "GET",
+      "path": "/api/v1/report?window=1h&q=20260612-live-rust-write-path-final&limit=5",
+      "status": 200,
+      "response": {
+        "cursor": "eyJ0YXJnZXRzX29mZnNldCI6NSwibW9uaXRvcl9vZmZzZXQiOm51bGwsImVycm9yX2dyb3Vwc19vZmZzZXQiOm51bGx9",
+        "error_groups": [
+          {
+            "classification": {
+              "category": "unknown",
+              "component": "unknown",
+              "persistence": "unknown"
+            },
+            "count": 1,
+            "error_class": "CanaryWritePathRehearsal",
+            "first_seen": "2026-06-12T20:41:13.983688657Z",
+            "group_hash": "<redacted-hash>",
+            "last_seen": "2026-06-12T20:41:13.983688657Z",
+            "sample_message": "canary write path rehearsal <int>-live-rust-write-path",
+            "service": "canary-write-path-20260612-live-rust-write-path",
+            "severity": "error",
+            "status": "active"
+          },
+          {
+            "classification": {
+              "category": "unknown",
+              "component": "unknown",
+              "persistence": "unknown"
+            },
+            "count": 1,
+            "error_class": "CanaryWritePathRehearsal",
+            "first_seen": "2026-06-12T21:20:21.261615333Z",
+            "group_hash": "<redacted-hash>",
+            "last_seen": "2026-06-12T21:20:21.261615333Z",
+            "sample_message": "canary write path rehearsal <int>-live-rust-write-path-final",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "severity": "error",
+            "status": "active"
+          }
+        ],
+        "incidents": [
+          {
+            "id": "INC-nt9suim7lmbm",
+            "opened_at": "2026-06-12T21:20:21.263064114Z",
+            "resolved_at": null,
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "severity": "medium",
+            "signal_count": 1,
+            "signals": [
+              {
+                "attached_at": "2026-06-12T21:20:21.263064114Z",
+                "resolved_at": null,
+                "signal_ref": "<redacted-hash>",
+                "signal_type": "error_group"
+              }
+            ],
+            "state": "investigating",
+            "title": "canary-write-path-20260612-live-rust-write-path-final incident"
+          },
+          {
+            "id": "INC-mektbdthelth",
+            "opened_at": "2026-03-28T19:02:23.577650Z",
+            "resolved_at": null,
+            "service": "canary-triage",
+            "severity": "medium",
+            "signal_count": 1,
+            "signals": [
+              {
+                "attached_at": "2026-03-28T20:03:07.830352Z",
+                "resolved_at": null,
+                "signal_ref": "TGT-gxcg7y84tt52",
+                "signal_type": "health_transition"
+              }
+            ],
+            "state": "investigating",
+            "title": "canary-triage incident"
+          }
+        ],
+        "monitors": [
+          {
+            "deadline_at": "2026-06-12T21:25:16Z",
+            "expected_every_ms": 600000,
+            "grace_ms": 120000,
+            "id": "MON-5csw7imodfcq",
+            "last_check_in_at": "2026-06-12T21:13:16Z",
+            "last_check_in_status": "alive",
+            "last_failure_at": null,
+            "last_success_at": "2026-06-12T21:13:16Z",
+            "mode": "ttl",
+            "name": "canary-watchman",
+            "service": "canary",
+            "state": "up"
+          },
+          {
+            "deadline_at": "2026-06-12T21:32:18.208144995Z",
+            "expected_every_ms": 600000,
+            "grace_ms": 120000,
+            "id": "MON-k2843ev95yz9",
+            "last_check_in_at": "2026-06-12T21:20:18.208144995Z",
+            "last_check_in_status": "alive",
+            "last_failure_at": null,
+            "last_success_at": "2026-06-12T21:20:18.208144995Z",
+            "mode": "ttl",
+            "name": "canary-write-path-20260612-live-rust-write-path-final-monitor",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "state": "up"
+          }
+        ],
+        "recent_transitions": [
+          {
+            "entity_ref": "MON-k2843ev95yz9",
+            "entity_type": "monitor",
+            "name": "canary-write-path-20260612-live-rust-write-path-final-monitor",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "state": "up",
+            "transitioned_at": "2026-06-12T21:20:18.208144995Z"
+          },
+          {
+            "entity_ref": "TGT-2cr0ze6iwcfx",
+            "entity_type": "target",
+            "name": "canary-write-path-20260612-live-rust-write-path-final-target",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "state": "up",
+            "transitioned_at": "2026-06-12T21:20:17.137223325Z"
+          },
+          {
+            "entity_ref": "MON-5csw7imodfcq",
+            "entity_type": "monitor",
+            "name": "canary-watchman",
+            "service": "canary",
+            "state": "up",
+            "transitioned_at": "2026-06-12T21:13:16Z"
+          }
+        ],
+        "search_results": [
+          {
+            "created_at": "2026-06-12T21:20:21.261615333Z",
+            "error_class": "CanaryWritePathRehearsal",
+            "group_hash": "<redacted-hash>",
+            "id": "ERR-kc7o7ryv121g",
+            "message": "canary write path rehearsal 20260612-live-rust-write-path-final",
+            "score": 14.412582779036928,
+            "service": "canary-write-path-20260612-live-rust-write-path-final"
+          }
+        ],
+        "status": "warning",
+        "summary": "8 health surfaces monitored. 2 errors across 2 services in the last hour.",
+        "targets": [
+          {
+            "consecutive_failures": 0,
+            "id": "TGT-5gowpivgtuvw",
+            "last_checked_at": "2026-06-12T21:19:40.983759066Z",
+            "last_success_at": "2026-06-12T21:19:40.983759066Z",
+            "latency_ms": 5,
+            "name": "canary-self",
+            "recent_checks": [
+              {
+                "checked_at": "2026-06-12T21:19:40.983759066Z",
+                "latency_ms": 5,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:18:35.959670751Z",
+                "latency_ms": 7,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:17:30.940414065Z",
+                "latency_ms": 8,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:16:25.915911309Z",
+                "latency_ms": 8,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:15:20.994203581Z",
+                "latency_ms": 108,
+                "result": "success",
+                "status_code": 200
+              }
+            ],
+            "service": "canary-self",
+            "state": "up",
+            "tls_expires_at": "2026-07-21T23:23:46Z",
+            "url": "https://canary-obs.fly.dev/healthz"
+          },
+          {
+            "consecutive_failures": 0,
+            "id": "TGT-2cr0ze6iwcfx",
+            "last_checked_at": "2026-06-12T21:20:17.137223325Z",
+            "last_success_at": "2026-06-12T21:20:17.137223325Z",
+            "latency_ms": 8,
+            "name": "canary-write-path-20260612-live-rust-write-path-final-target",
+            "recent_checks": [
+              {
+                "checked_at": "2026-06-12T21:20:17.137223325Z",
+                "latency_ms": 8,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:20:15.015795318Z",
+                "latency_ms": 11,
+                "result": "success",
+                "status_code": 200
+              }
+            ],
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "state": "up",
+            "tls_expires_at": "2026-07-21T23:23:46Z",
+            "url": "https://canary-obs.fly.dev/healthz"
+          },
+          {
+            "consecutive_failures": 0,
+            "id": "TGT-cjjw9uyj0k41",
+            "last_checked_at": "2026-06-12T21:19:37.235199892Z",
+            "last_success_at": "2026-06-12T21:19:37.235199892Z",
+            "latency_ms": 254,
+            "name": "chrondle",
+            "recent_checks": [
+              {
+                "checked_at": "2026-06-12T21:19:37.235199892Z",
+                "latency_ms": 254,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:18:38.189116823Z",
+                "latency_ms": 228,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:17:39.321258003Z",
+                "latency_ms": 380,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:16:40.115789157Z",
+                "latency_ms": 198,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:15:41.198020171Z",
+                "latency_ms": 302,
+                "result": "success",
+                "status_code": 200
+              }
+            ],
+            "service": "chrondle",
+            "state": "up",
+            "tls_expires_at": "2026-07-27T13:47:41Z",
+            "url": "https://www.chrondle.app/api/health"
+          },
+          {
+            "consecutive_failures": 0,
+            "id": "TGT-l1uqvd03m5tz",
+            "last_checked_at": "2026-06-12T21:19:37.26091391Z",
+            "last_success_at": "2026-06-12T21:19:37.26091391Z",
+            "latency_ms": 280,
+            "name": "linejam",
+            "recent_checks": [
+              {
+                "checked_at": "2026-06-12T21:19:37.26091391Z",
+                "latency_ms": 280,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:18:38.172442971Z",
+                "latency_ms": 214,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:17:39.121091745Z",
+                "latency_ms": 180,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:16:40.165187741Z",
+                "latency_ms": 247,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:15:41.170824332Z",
+                "latency_ms": 274,
+                "result": "success",
+                "status_code": 200
+              }
+            ],
+            "service": "linejam",
+            "state": "up",
+            "tls_expires_at": "2026-08-19T14:53:27Z",
+            "url": "https://www.linejam.app/api/health"
+          },
+          {
+            "consecutive_failures": 0,
+            "id": "TGT-ifbre1aplmka",
+            "last_checked_at": "2026-06-12T21:20:10.20466846Z",
+            "last_success_at": "2026-06-12T21:20:10.20466846Z",
+            "latency_ms": 199,
+            "name": "misty-step",
+            "recent_checks": [
+              {
+                "checked_at": "2026-06-12T21:20:10.20466846Z",
+                "latency_ms": 199,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:19:07.164642159Z",
+                "latency_ms": 197,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:18:04.067540333Z",
+                "latency_ms": 121,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:17:01.001458889Z",
+                "latency_ms": 78,
+                "result": "success",
+                "status_code": 200
+              },
+              {
+                "checked_at": "2026-06-12T21:15:57.9799053Z",
+                "latency_ms": 75,
+                "result": "success",
+                "status_code": 200
+              }
+            ],
+            "service": "misty-step",
+            "state": "up",
+            "tls_expires_at": "2026-08-28T04:16:15Z",
+            "url": "https://www.mistystep.io/api/health"
+          }
+        ],
+        "truncated": true
+      }
+    },
+    {
+      "type": "http",
+      "name": "timeline_readback",
+      "method": "GET",
+      "path": "/api/v1/timeline?service=canary-write-path-20260612-live-rust-write-path-final&window=1h&limit=10",
+      "status": 200,
+      "response": {
+        "summary": "Returned 5 timeline events for canary-write-path-20260612-live-rust-write-path-final in the last 1h.",
+        "returned_count": 5,
+        "window": "1h",
+        "service": "canary-write-path-20260612-live-rust-write-path-final",
+        "events": [
+          {
+            "id": "EVT-jz858aha416v",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "event": "incident.opened",
+            "entity_type": "incident",
+            "entity_ref": "INC-nt9suim7lmbm",
+            "severity": "medium",
+            "summary": "canary-write-path-20260612-live-rust-write-path-final: incident opened",
+            "payload": {
+              "event": "incident.opened",
+              "incident": {
+                "id": "INC-nt9suim7lmbm",
+                "opened_at": "2026-06-12T21:20:21.263064114Z",
+                "resolved_at": null,
+                "service": "canary-write-path-20260612-live-rust-write-path-final",
+                "severity": "medium",
+                "signals": [
+                  {
+                    "attached_at": "2026-06-12T21:20:21.263064114Z",
+                    "resolved_at": null,
+                    "signal_ref": "<redacted-hash>",
+                    "signal_type": "error_group"
+                  }
+                ],
+                "state": "investigating",
+                "title": "canary-write-path-20260612-live-rust-write-path-final incident"
+              },
+              "timestamp": "2026-06-12T21:20:21.263064114Z"
+            },
+            "created_at": "2026-06-12T21:20:21.263064114Z"
+          },
+          {
+            "id": "EVT-fs7rv7xqq5r8",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "event": "error.new_class",
+            "entity_type": "error_group",
+            "entity_ref": "<redacted-hash>",
+            "severity": "error",
+            "summary": "canary-write-path-20260612-live-rust-write-path-final: new CanaryWritePathRehearsal",
+            "payload": {
+              "error": {
+                "error_class": "CanaryWritePathRehearsal",
+                "group_hash": "<redacted-hash>",
+                "id": "ERR-kc7o7ryv121g",
+                "message": "canary write path rehearsal 20260612-live-rust-write-path-final",
+                "service": "canary-write-path-20260612-live-rust-write-path-final",
+                "severity": "error"
+              },
+              "event": "error.new_class",
+              "timestamp": "2026-06-12T21:20:21.261615333Z"
+            },
+            "created_at": "2026-06-12T21:20:21.261615333Z"
+          },
+          {
+            "id": "EVT-q5dvrqv8wel6",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "event": "health_check.recovered",
+            "entity_type": "monitor",
+            "entity_ref": "MON-k2843ev95yz9",
+            "severity": "info",
+            "summary": "canary-write-path-20260612-live-rust-write-path-final: canary-write-path-20260612-live-rust-write-path-final-monitor up",
+            "payload": {
+              "deadline_at": "2026-06-12T21:32:18.208144995Z",
+              "event": "health_check.recovered",
+              "last_check_in_at": "2026-06-12T21:20:18.208144995Z",
+              "last_check_in_status": "alive",
+              "monitor": {
+                "expected_every_ms": 600000,
+                "grace_ms": 120000,
+                "mode": "ttl",
+                "name": "canary-write-path-20260612-live-rust-write-path-final-monitor",
+                "service": "canary-write-path-20260612-live-rust-write-path-final"
+              },
+              "previous_state": "unknown",
+              "sequence": 1,
+              "state": "up",
+              "timestamp": "2026-06-12T21:20:18.208144995Z"
+            },
+            "created_at": "2026-06-12T21:20:18.208144995Z"
+          },
+          {
+            "id": "EVT-grzmfyr8azl6",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "event": "health_check.recovered",
+            "entity_type": "target",
+            "entity_ref": "TGT-2cr0ze6iwcfx",
+            "severity": "info",
+            "summary": "canary-write-path-20260612-live-rust-write-path-final: canary-write-path-20260612-live-rust-write-path-final-target up",
+            "payload": {
+              "consecutive_failures": 0,
+              "event": "health_check.recovered",
+              "last_success_at": "2026-06-12T21:20:17.137223325Z",
+              "previous_state": "unknown",
+              "sequence": 2,
+              "state": "up",
+              "target": {
+                "name": "canary-write-path-20260612-live-rust-write-path-final-target",
+                "service": "canary-write-path-20260612-live-rust-write-path-final",
+                "url": "https://canary-obs.fly.dev/healthz"
+              },
+              "timestamp": "2026-06-12T21:20:17.137223325Z"
+            },
+            "created_at": "2026-06-12T21:20:17.137223325Z"
+          },
+          {
+            "id": "EVT-qki9q94q8pxe",
+            "service": "canary-write-path-20260612-live-rust-write-path-final",
+            "event": "health_check.recovered",
+            "entity_type": "target",
+            "entity_ref": "TGT-2cr0ze6iwcfx",
+            "severity": "info",
+            "summary": "canary-write-path-20260612-live-rust-write-path-final: canary-write-path-20260612-live-rust-write-path-final-target up",
+            "payload": {
+              "consecutive_failures": 0,
+              "event": "health_check.recovered",
+              "last_success_at": "2026-06-12T21:20:15.015795318Z",
+              "previous_state": "unknown",
+              "sequence": 1,
+              "state": "up",
+              "target": {
+                "name": "canary-write-path-20260612-live-rust-write-path-final-target",
+                "service": "canary-write-path-20260612-live-rust-write-path-final",
+                "url": "https://canary-obs.fly.dev/healthz"
+              },
+              "timestamp": "2026-06-12T21:20:15.015795318Z"
+            },
+            "created_at": "2026-06-12T21:20:15.015795318Z"
+          }
+        ],
+        "cursor": null
+      }
+    },
+    {
+      "type": "http",
+      "name": "error_detail_readback",
+      "method": "GET",
+      "path": "/api/v1/errors/ERR-kc7o7ryv121g",
+      "status": 200,
+      "response": {
+        "summary": "CanaryWritePathRehearsal in canary-write-path-20260612-live-rust-write-path-final. Seen 1 times since 2026-06-12T21:20:21.261615333Z. Last occurrence: 2026-06-12T21:20:21.261615333Z.",
+        "id": "ERR-kc7o7ryv121g",
+        "service": "canary-write-path-20260612-live-rust-write-path-final",
+        "error_class": "CanaryWritePathRehearsal",
+        "message": "canary write path rehearsal 20260612-live-rust-write-path-final",
+        "message_template": "canary write path rehearsal <int>-live-rust-write-path-final",
+        "stack_trace": null,
+        "context": {
+          "rehearsal_prefix": "20260612-live-rust-write-path-final"
+        },
+        "severity": "error",
+        "environment": "production",
+        "group_hash": "<redacted-hash>",
+        "created_at": "2026-06-12T21:20:21.261615333Z",
+        "group": {
+          "total_count": 1,
+          "first_seen_at": "2026-06-12T21:20:21.261615333Z",
+          "last_seen_at": "2026-06-12T21:20:21.261615333Z",
+          "status": "active"
+        },
+        "incident_ids": [
+          "INC-nt9suim7lmbm"
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "webhook_delivery_poll",
+      "method": "GET",
+      "path": "/api/v1/webhook-deliveries?webhook_id=WHK-opehar1c54yt&event=error.new_class&limit=5",
+      "status": 200,
+      "response": {
+        "returned_count": 1,
+        "cursor": null,
+        "deliveries": [
+          {
+            "delivery_id": "DLV-stwp8h56qgxd",
+            "webhook_id": "WHK-opehar1c54yt",
+            "event": "error.new_class",
+            "status": "delivered",
+            "attempt_count": 1,
+            "reason": null,
+            "first_attempt_at": "2026-06-12T21:20:22.612764237Z",
+            "last_attempt_at": "2026-06-12T21:20:22.612764237Z",
+            "delivered_at": "2026-06-12T21:20:22.692544432Z",
+            "discarded_at": null,
+            "completed_at": "2026-06-12T21:20:22.692544432Z",
+            "created_at": "2026-06-12T21:20:21.264400255Z",
+            "updated_at": "2026-06-12T21:20:22.692544432Z"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "webhook_delivery_lookup",
+      "method": "GET",
+      "path": "/api/v1/webhook-deliveries/DLV-stwp8h56qgxd",
+      "status": 200,
+      "response": {
+        "delivery_id": "DLV-stwp8h56qgxd",
+        "webhook_id": "WHK-opehar1c54yt",
+        "event": "error.new_class",
+        "status": "delivered",
+        "attempt_count": 1,
+        "reason": null,
+        "first_attempt_at": "2026-06-12T21:20:22.612764237Z",
+        "last_attempt_at": "2026-06-12T21:20:22.612764237Z",
+        "delivered_at": "2026-06-12T21:20:22.692544432Z",
+        "discarded_at": null,
+        "completed_at": "2026-06-12T21:20:22.692544432Z",
+        "created_at": "2026-06-12T21:20:21.264400255Z",
+        "updated_at": "2026-06-12T21:20:22.692544432Z"
+      }
+    },
+    {
+      "type": "shell",
+      "name": "dr_status",
+      "command": "NO_COLOR=1 bin/dr-status --app canary-obs",
+      "status": 0,
+      "output": "Connecting to fdaa:45:6cb6:a7b:40a:a6a6:fd3f:2...\ndatabase         status  local txid        wal size\n/data/canary.db  ok      0000000000089857  5.5 MB"
+    },
+    {
+      "type": "http",
+      "name": "target_delete",
+      "method": "DELETE",
+      "path": "/api/v1/targets/TGT-2cr0ze6iwcfx",
+      "status": 204,
+      "response": null
+    },
+    {
+      "type": "http",
+      "name": "monitor_delete",
+      "method": "DELETE",
+      "path": "/api/v1/monitors/MON-k2843ev95yz9",
+      "status": 204,
+      "response": null
+    },
+    {
+      "type": "http",
+      "name": "webhook_delete",
+      "method": "DELETE",
+      "path": "/api/v1/webhooks/WHK-opehar1c54yt",
+      "status": 204,
+      "response": null
+    },
+    {
+      "type": "http",
+      "name": "api_key_revoke_ingest",
+      "method": "POST",
+      "path": "/api/v1/keys/KEY-vy07y1z3576z/revoke",
+      "status": 200,
+      "response": {
+        "status": "revoked"
+      }
+    },
+    {
+      "type": "http",
+      "name": "revoked_ingest_key_rejects_check_in",
+      "method": "POST",
+      "path": "/api/v1/check-ins",
+      "status": 401,
+      "response": {
+        "type": "https://canary.dev/problems/invalid-api-key",
+        "title": "Invalid API Key",
+        "status": 401,
+        "detail": "Invalid or revoked API key.",
+        "code": "invalid_api_key",
+        "request_id": null
+      }
+    },
+    {
+      "type": "http",
+      "name": "post_cleanup_targets",
+      "method": "GET",
+      "path": "/api/v1/targets",
+      "status": 200,
+      "response": {
+        "targets": [
+          {
+            "active": true,
+            "created_at": "2026-03-14T23:03:28.424961Z",
+            "expected_status": "200",
+            "id": "TGT-5gowpivgtuvw",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "canary-self",
+            "service": "canary-self",
+            "timeout_ms": 5000,
+            "url": "https://canary-obs.fly.dev/healthz"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:36:59.551650Z",
+            "expected_status": "200",
+            "id": "TGT-cjjw9uyj0k41",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "chrondle",
+            "service": "chrondle",
+            "timeout_ms": 10000,
+            "url": "https://www.chrondle.app/api/health"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:37:00.059891Z",
+            "expected_status": "200",
+            "id": "TGT-l1uqvd03m5tz",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "linejam",
+            "service": "linejam",
+            "timeout_ms": 10000,
+            "url": "https://www.linejam.app/api/health"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-12T02:15:08.789422938Z",
+            "expected_status": "200",
+            "id": "TGT-ifbre1aplmka",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "misty-step",
+            "service": "misty-step",
+            "timeout_ms": 10000,
+            "url": "https://www.mistystep.io/api/health"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:37:00.472023Z",
+            "expected_status": "200",
+            "id": "TGT-72csit0gquvr",
+            "interval_ms": 60000,
+            "method": "GET",
+            "name": "vulcan",
+            "service": "vulcan",
+            "timeout_ms": 10000,
+            "url": "https://adminifi-vulcan-orchestrator.fly.dev/health"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "post_cleanup_monitors",
+      "method": "GET",
+      "path": "/api/v1/monitors",
+      "status": 200,
+      "response": {
+        "monitors": [
+          {
+            "created_at": "2026-06-12T00:48:07.869103074Z",
+            "expected_every_ms": 600000,
+            "grace_ms": 120000,
+            "id": "MON-5csw7imodfcq",
+            "mode": "ttl",
+            "name": "canary-watchman",
+            "service": "canary"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "post_cleanup_webhooks",
+      "method": "GET",
+      "path": "/api/v1/webhooks",
+      "status": 200,
+      "response": {
+        "webhooks": [
+          {
+            "active": true,
+            "created_at": "2026-04-09T01:51:10.814543Z",
+            "events": [
+              "error.new_class",
+              "error.regression",
+              "incident.opened",
+              "incident.updated",
+              "incident.resolved",
+              "health_check.down",
+              "health_check.degraded",
+              "health_check.recovered",
+              "health_check.tls_expiring"
+            ],
+            "id": "WHK-78ro85gmubzy",
+            "url": "https://linejam-canary-responder.fly.dev/canary/webhook"
+          }
+        ]
+      }
+    },
+    {
+      "type": "http",
+      "name": "post_cleanup_keys",
+      "method": "GET",
+      "path": "/api/v1/keys",
+      "status": 200,
+      "response": {
+        "keys": [
+          {
+            "active": false,
+            "created_at": "2026-06-12T21:20:13.781976835Z",
+            "id": "KEY-vy07y1z3576z",
+            "key_prefix": "<redacted>",
+            "name": "canary-write-path-20260612-live-rust-write-path-final-ingest",
+            "revoked_at": "2026-06-12T21:20:31.673994618Z",
+            "scope": "ingest-only"
+          },
+          {
+            "active": false,
+            "created_at": "2026-06-12T20:41:07.849869486Z",
+            "id": "KEY-kjqobspbx0yo",
+            "key_prefix": "<redacted>",
+            "name": "canary-write-path-20260612-live-rust-write-path-ingest",
+            "revoked_at": "2026-06-12T20:41:23.183799183Z",
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-12T02:15:08.789422938Z",
+            "id": "KEY-ru54cr7zg3lb",
+            "key_prefix": "<redacted>",
+            "name": "misty-step-ingest",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:44:42.836918744Z",
+            "id": "KEY-o3cn7j1rvswi",
+            "key_prefix": "<redacted>",
+            "name": "linejam-ingest-3",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:44:27.290789492Z",
+            "id": "KEY-i788wzx41qkz",
+            "key_prefix": "<redacted>",
+            "name": "linejam-ingest-2",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:44:23.624863041Z",
+            "id": "KEY-7m8fdfsll3zc",
+            "key_prefix": "<redacted>",
+            "name": "chrondle-ingest-2",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:44:11.900314666Z",
+            "id": "KEY-qm3k2tjer27k",
+            "key_prefix": "<redacted>",
+            "name": "linejam-ingest",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:44:07.644887554Z",
+            "id": "KEY-qn436id373vr",
+            "key_prefix": "<redacted>",
+            "name": "chrondle-ingest",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:44:03.146120169Z",
+            "id": "KEY-nsjbzl0ovfpk",
+            "key_prefix": "<redacted>",
+            "name": "ops-read",
+            "revoked_at": null,
+            "scope": "read-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-06-10T15:43:53.175599276Z",
+            "id": "KEY-eo0fsa0ait09",
+            "key_prefix": "<redacted>",
+            "name": "sploot-web-ingest",
+            "revoked_at": null,
+            "scope": "ingest-only"
+          },
+          {
+            "active": true,
+            "created_at": "2026-04-09T14:01:27.246219Z",
+            "id": "KEY-8dv27qy4yph2",
+            "key_prefix": "<redacted>",
+            "name": "bb-tansy-20260409-090124",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-04-09T14:01:06.095842Z",
+            "id": "KEY-k93i7gwhslva",
+            "key_prefix": "<redacted>",
+            "name": "bb-tansy-test",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-04-09T01:37:37.852270Z",
+            "id": "KEY-6u1ea8sf8ayp",
+            "key_prefix": "<redacted>",
+            "name": "linejam-prod",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-04-06T15:39:58.007028Z",
+            "id": "KEY-29c19q1r0fay",
+            "key_prefix": "<redacted>",
+            "name": "scry-vercel-browser",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-04-06T15:39:22.904906Z",
+            "id": "KEY-xndxnztxpvlg",
+            "key_prefix": "<redacted>",
+            "name": "scry-vercel",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": false,
+            "created_at": "2026-03-27T01:31:11.332486Z",
+            "id": "KEY-pmhakkcnqdbf",
+            "key_prefix": "<redacted>",
+            "name": "deploy-2026-03-26",
+            "revoked_at": "2026-03-27T01:37:58.087976Z",
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-27T01:29:59.144517Z",
+            "id": "KEY-jrh8y1axznrn",
+            "key_prefix": "<redacted>",
+            "name": "multi-deploy-2026-03-26",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-25T15:07:12.440690Z",
+            "id": "KEY-36mpkoreql6c",
+            "key_prefix": "<redacted>",
+            "name": "vulcan-prod",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": false,
+            "created_at": "2026-03-25T14:57:39.716980Z",
+            "id": "KEY-1bgs6md9oqce",
+            "key_prefix": "<redacted>",
+            "name": "vulcan-pr70-smoke-2",
+            "revoked_at": "2026-03-25T15:00:05.764071Z",
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-25T14:57:24.477607Z",
+            "id": "KEY-ropyby059tya",
+            "key_prefix": "<redacted>",
+            "name": "vulcan-pr70-smoke",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-25T14:52:23.988241Z",
+            "id": "KEY-cy1xu2bh0h9e",
+            "key_prefix": "<redacted>",
+            "name": "vulcan-prod",
+            "revoked_at": null,
+            "scope": "admin"
+          },
+          {
+            "active": true,
+            "created_at": "2026-03-14T23:03:11.307102Z",
+            "id": "KEY-89jcjamy1mv7",
+            "key_prefix": "<redacted>",
+            "name": "bootstrap",
+            "revoked_at": null,
+            "scope": "admin"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/bin/canary_write_path_rehearsal_test.sh
+++ b/test/bin/canary_write_path_rehearsal_test.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/bin/canary-write-path-rehearsal"
+ORIGINAL_PATH="$PATH"
+BASH_BIN="$(command -v bash)"
+PASS=0
+FAIL=0
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+setup_stubs() {
+  rm -rf "$TMPDIR_TEST/bin" "$TMPDIR_TEST/state"
+  mkdir -p "$TMPDIR_TEST/bin" "$TMPDIR_TEST/state"
+  export PATH="$TMPDIR_TEST/bin:$ORIGINAL_PATH"
+  export CURL_LOG="$TMPDIR_TEST/curl.log"
+  export CURL_STATE="$TMPDIR_TEST/state"
+  : > "$CURL_LOG"
+
+  cat > "$TMPDIR_TEST/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+method="GET"
+output=""
+status_format=""
+body=""
+url=""
+auth=""
+
+while (($#)); do
+  case "$1" in
+    -X)
+      method="$2"
+      shift 2
+      ;;
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -w)
+      status_format="$2"
+      shift 2
+      ;;
+    -H)
+      if [[ "$2" == Authorization:* ]]; then
+        auth="${2#Authorization: Bearer }"
+      fi
+      shift 2
+      ;;
+    --data)
+      body="$2"
+      shift 2
+      ;;
+    -s|-S|-sS)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+path="${url#http://canary.test}"
+printf '%s %s\n' "$method" "$path" >> "${CURL_LOG:?}"
+
+write_response() {
+  local status="$1"
+  local response="$2"
+  printf '%s' "$response" > "$output"
+  if [[ "$status_format" == "%{http_code}" ]]; then
+    printf '%s' "$status"
+  fi
+}
+
+case "$method $path" in
+  "POST /api/v1/keys")
+    touch "$CURL_STATE/key-active"
+    raw_key="sk_${CURL_KEY_SCOPE_WORD:-live}_TEST"
+    key_prefix="${raw_key%ST}"
+    write_response "${CURL_KEY_CREATE_STATUS:-201}" "$(
+      jq -cn \
+        --arg key "$raw_key" \
+        --arg key_prefix "$key_prefix" \
+        '{
+          id: "KEY-test",
+          name: "canary-write-path-test-ingest",
+          scope: "ingest-only",
+          key: $key,
+          key_prefix: $key_prefix,
+          detail: ("echoed raw key " + $key),
+          created_at: "2026-06-12T20:00:00Z",
+          warning: "Store this key securely. It will not be shown again."
+        }'
+    )"
+    ;;
+  "GET /api/v1/keys")
+    raw_key="sk_${CURL_KEY_SCOPE_WORD:-live}_TEST"
+    key_prefix="${raw_key%ST}"
+    if [[ -f "$CURL_STATE/key-active" ]]; then
+      active=true
+      revoked_at=null
+    else
+      active=false
+      revoked_at='"2026-06-12T20:01:00Z"'
+    fi
+    write_response 200 "$(
+      jq -cn \
+        --arg key_prefix "$key_prefix" \
+        --argjson active "$active" \
+        --argjson revoked_at "$revoked_at" \
+        '{
+          keys: [{
+            id: "KEY-test",
+            name: "canary-write-path-test-ingest",
+            scope: "ingest-only",
+            key_prefix: $key_prefix,
+            active: $active,
+            created_at: "2026-06-12T20:00:00Z",
+            revoked_at: $revoked_at
+          }]
+        }'
+    )"
+    ;;
+  "POST /api/v1/keys/KEY-test/revoke")
+    rm -f "$CURL_STATE/key-active"
+    write_response 200 '{"status":"revoked"}'
+    ;;
+  "POST /api/v1/targets")
+    touch "$CURL_STATE/target-active"
+    write_response 201 '{"id":"TGT-test","name":"canary-write-path-test-target","service":"canary-write-path-test","url":"http://canary.test/healthz","method":"GET","interval_ms":60000,"timeout_ms":5000,"expected_status":"200","active":true,"created_at":"2026-06-12T20:00:00Z"}'
+    ;;
+  "GET /api/v1/targets")
+    if [[ "$auth" == sk_* ]]; then
+      write_response 403 '{"type":"https://canary.local/problems/insufficient_scope","title":"Insufficient Scope","status":403,"detail":"API key scope `ingest-only` cannot access this read endpoint.","code":"insufficient_scope","scope":"ingest-only"}'
+      exit 0
+    fi
+    if [[ -f "$CURL_STATE/target-active" ]]; then
+      write_response 200 '{"targets":[{"id":"TGT-test","name":"canary-write-path-test-target","service":"canary-write-path-test","url":"http://canary.test/healthz","active":true}]}'
+    else
+      write_response 200 '{"targets":[]}'
+    fi
+    ;;
+  "POST /api/v1/targets/TGT-test/pause")
+    write_response 200 '{"status":"paused"}'
+    ;;
+  "POST /api/v1/targets/TGT-test/resume")
+    write_response 200 '{"status":"resumed"}'
+    ;;
+  "DELETE /api/v1/targets/TGT-test")
+    rm -f "$CURL_STATE/target-active"
+    write_response 204 ''
+    ;;
+  "POST /api/v1/monitors")
+    touch "$CURL_STATE/monitor-active"
+    write_response 201 '{"id":"MON-test","name":"canary-write-path-test-monitor","service":"canary-write-path-test","mode":"ttl","expected_every_ms":600000,"grace_ms":120000,"created_at":"2026-06-12T20:00:00Z"}'
+    ;;
+  "GET /api/v1/monitors")
+    if [[ -f "$CURL_STATE/monitor-active" ]]; then
+      write_response 200 '{"monitors":[{"id":"MON-test","name":"canary-write-path-test-monitor","service":"canary-write-path-test","mode":"ttl","expected_every_ms":600000,"grace_ms":120000}]}'
+    else
+      write_response 200 '{"monitors":[]}'
+    fi
+    ;;
+  "POST /api/v1/check-ins")
+    if [[ "$auth" == sk_* && ! -f "$CURL_STATE/key-active" ]]; then
+      write_response 401 '{"type":"https://canary.local/problems/invalid_api_key","title":"Invalid API Key","status":401,"detail":"Invalid API key.","code":"invalid_api_key"}'
+      exit 0
+    fi
+    write_response 201 '{"monitor_id":"MON-test","check_in_id":"CHK-test","state":"up","observed_at":"2026-06-12T20:00:01Z","sequence":1}'
+    ;;
+  "DELETE /api/v1/monitors/MON-test")
+    rm -f "$CURL_STATE/monitor-active"
+    write_response 204 ''
+    ;;
+  "POST /api/v1/webhooks")
+    touch "$CURL_STATE/webhook-active"
+    webhook_secret="canary-webhook-""redaction-token"
+    write_response 201 "$(
+      jq -cn \
+        --arg secret "$webhook_secret" \
+        '{
+          id: "WHK-test",
+          url: "https://example.com/hook?canary_rehearsal=test",
+          events: ["canary.ping", "error.new_class"],
+          secret: $secret,
+          message: ("echoed webhook secret " + $secret),
+          created_at: "2026-06-12T20:00:00Z"
+        }'
+    )"
+    ;;
+  "GET /api/v1/webhooks")
+    if [[ -f "$CURL_STATE/webhook-active" ]]; then
+      write_response 200 '{"webhooks":[{"id":"WHK-test","url":"https://example.com/hook?canary_rehearsal=test","events":["canary.ping","error.new_class"],"active":true,"created_at":"2026-06-12T20:00:00Z"}]}'
+    else
+      write_response 200 '{"webhooks":[]}'
+    fi
+    ;;
+  "POST /api/v1/webhooks/WHK-test/test")
+    write_response 200 '{"status":"delivered"}'
+    ;;
+  "DELETE /api/v1/webhooks/WHK-test")
+    rm -f "$CURL_STATE/webhook-active"
+    write_response 204 ''
+    ;;
+  "POST /api/v1/errors")
+    touch "$CURL_STATE/error-created"
+    write_response 201 '{"id":"ERR-test","group_hash":"grp-test","is_new_class":true}'
+    ;;
+  "GET /api/v1/query?service=canary-write-path-test&window=1h")
+    write_response 200 '{"summary":"1 error for canary-write-path-test","service":"canary-write-path-test","window":"1h","total_errors":1,"groups":[{"group_hash":"grp-test","service":"canary-write-path-test","error_class":"CanaryWritePathRehearsal","count":1}],"cursor":null}'
+    ;;
+  "GET /api/v1/report?window=1h&q=test&limit=5")
+    write_response 200 '{"status":"healthy","summary":"ok","targets":[],"monitors":[],"error_groups":[{"group_hash":"grp-test","service":"canary-write-path-test","error_class":"CanaryWritePathRehearsal","count":1}],"search_results":[{"id":"ERR-test","service":"canary-write-path-test","error_class":"CanaryWritePathRehearsal","message":"canary write path rehearsal test","group_hash":"grp-test"}],"incidents":[],"recent_transitions":[],"truncated":false,"cursor":null}'
+    ;;
+  "GET /api/v1/timeline?service=canary-write-path-test&window=1h&limit=10")
+    write_response 200 '{"summary":"Returned 1 timeline events for canary-write-path-test in the last 1h.","returned_count":1,"window":"1h","service":"canary-write-path-test","events":[{"id":"EVT-test","service":"canary-write-path-test","event":"error.new_class","entity_type":"error_group","entity_ref":"grp-test","summary":"new error"}],"cursor":null}'
+    ;;
+  "GET /api/v1/errors/ERR-test")
+    write_response 200 '{"id":"ERR-test","service":"canary-write-path-test","error_class":"CanaryWritePathRehearsal","message":"canary write path rehearsal test","group":{"group_hash":"grp-test"}}'
+    ;;
+  "GET /api/v1/webhook-deliveries?webhook_id=WHK-test&event=error.new_class&limit=5")
+    delivery_status="${CURL_DELIVERY_STATUS:-delivered}"
+    write_response 200 "{\"returned_count\":1,\"cursor\":null,\"deliveries\":[{\"delivery_id\":\"DLV-test\",\"webhook_id\":\"WHK-test\",\"event\":\"error.new_class\",\"status\":\"$delivery_status\",\"attempt_count\":1,\"delivered_at\":\"2026-06-12T20:00:02Z\",\"completed_at\":\"2026-06-12T20:00:02Z\"}]}"
+    ;;
+  "GET /api/v1/webhook-deliveries/DLV-test")
+    delivery_status="${CURL_DELIVERY_STATUS:-delivered}"
+    write_response 200 "{\"delivery_id\":\"DLV-test\",\"webhook_id\":\"WHK-test\",\"event\":\"error.new_class\",\"status\":\"$delivery_status\",\"attempt_count\":1,\"delivered_at\":\"2026-06-12T20:00:02Z\",\"completed_at\":\"2026-06-12T20:00:02Z\"}"
+    ;;
+  *)
+    write_response 500 "{\"unexpected\":\"$method $path\"}"
+    ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/bin/curl"
+
+  cat > "$TMPDIR_TEST/bin/flyctl" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "status" ]]; then
+  jq -cn '{
+    Name: "canary-test",
+    Status: "deployed",
+    Hostname: "canary-test.fly.dev",
+    Version: 77,
+    Machines: [{
+      id: "machine-test",
+      name: "test-machine",
+      state: "started",
+      region: "iad",
+      image_ref: {
+        registry: "registry.fly.io",
+        repository: "canary-test",
+        tag: "deployment-test",
+        digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        labels: {
+          GH_SHA: "8066373b55108f662bf08158dfd74c25561a9fd4",
+          GH_REPO: "misty-step/canary",
+          GH_EVENT_NAME: "workflow_run"
+        }
+      },
+      config: {
+        image: "registry.fly.io/canary-test:deployment-test",
+        metadata: {
+          fly_release_id: "rel_test",
+          fly_release_version: "77"
+        }
+      },
+      checks: [{
+        name: "servicecheck-00-http-4000",
+        status: "passing",
+        updated_at: "2026-06-12T20:00:00Z"
+      }]
+    }]
+  }'
+  exit 0
+fi
+printf 'replica /data/canary.db ok\n'
+STUB
+  chmod +x "$TMPDIR_TEST/bin/flyctl"
+}
+
+run_and_capture() {
+  "$@" 2>&1
+}
+
+run_failure() {
+  local output
+
+  set +e
+  output="$("$@" 2>&1)"
+  local rc=$?
+  set -e
+
+  printf '%s\n%s' "$rc" "$output"
+}
+
+assert_contains() {
+  local output="$1" expected="$2" test_name="$3"
+  if grep -qF -- "$expected" <<<"$output"; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected to contain: $expected"
+    echo "    Got: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+redact_test_output() {
+  local output="$1"
+  local raw_key="sk_""live_TEST"
+  local raw_key_prefix="${raw_key%ST}"
+  local webhook_secret="canary-webhook-""redaction-token"
+
+  output="${output//$raw_key/<redacted-api-key>}"
+  output="${output//$raw_key_prefix/<redacted-api-key-prefix>}"
+  output="${output//$webhook_secret/<redacted-webhook-secret>}"
+  printf '%s' "$output"
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" test_name="$3" label="${4:-<redacted-forbidden-value>}"
+  if grep -qF -- "$unexpected" <<<"$output"; then
+    echo "  FAIL: $test_name"
+    echo "    Did not expect to contain: $label"
+    echo "    Got: $(redact_test_output "$output")"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_file_contains() {
+  local path="$1" expected="$2" test_name="$3"
+  if grep -qF "$expected" "$path"; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected $path to contain: $expected"
+    echo "    Got:"
+    sed 's/^/      /' "$path"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_jq() {
+  local json="$1" filter="$2" test_name="$3"
+  if jq -e "$filter" >/dev/null <<<"$json"; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    jq filter failed: $filter"
+    echo "    JSON: $json"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_exit_code() {
+  local actual="$1" expected="$2" test_name="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected exit code: $expected"
+    echo "    Got: $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "Test 1: help"
+OUTPUT=$(run_and_capture "$SCRIPT" --help)
+assert_contains "$OUTPUT" "Usage: bin/canary-write-path-rehearsal" "shows usage"
+
+echo "Test 2: missing endpoint fails clearly"
+setup_stubs
+OUTPUT=$(run_failure env -u CANARY_ENDPOINT -u CANARY_API_KEY PATH="$PATH" "$SCRIPT" --api-key admin)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "missing endpoint exits non-zero"
+assert_contains "$BODY" "Missing Canary endpoint" "missing endpoint names fix"
+
+echo "Test 3: missing curl fails clearly"
+NO_CURL_PATH="$TMPDIR_TEST/no-curl-path"
+rm -rf "$NO_CURL_PATH"
+mkdir -p "$NO_CURL_PATH"
+OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin PATH="$NO_CURL_PATH" "$BASH_BIN" "$SCRIPT" --json)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "missing curl exits non-zero"
+assert_contains "$BODY" "Missing required command: curl" "missing curl names dependency"
+
+echo "Test 4: stubbed rehearsal emits sanitized JSON receipt"
+setup_stubs
+OUTPUT=$(env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin "$SCRIPT" --prefix test --webhook-url https://example.com/hook --app canary-test --json)
+assert_jq "$OUTPUT" '.status == "ok"' "receipt status ok"
+assert_jq "$OUTPUT" '.resources.cleaned_target_id == "TGT-test"' "records target id"
+assert_jq "$OUTPUT" '.resources.revoked_key_id == "KEY-test"' "records revoked key id"
+assert_jq "$OUTPUT" '.resources.immutable_webhook_delivery_id == "DLV-test"' "records delivery id"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "dr_status" and .status == 0)] | length == 1' "records dr-status success"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "post_cleanup_targets")][0].response.targets == []' "post-cleanup targets empty"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "post_cleanup_monitors")][0].response.monitors == []' "post-cleanup monitors empty"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "post_cleanup_webhooks")][0].response.webhooks == []' "post-cleanup webhooks empty"
+assert_jq "$OUTPUT" '.deploy_identity.machines[0].id == "machine-test"' "records Fly machine id"
+assert_jq "$OUTPUT" '.deploy_identity.machines[0].image_ref.digest == "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"' "records Fly image digest"
+assert_jq "$OUTPUT" '.deploy_identity.machines[0].image_ref.commit == "8066373b55108f662bf08158dfd74c25561a9fd4"' "records Fly image commit"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "ingest_key_cannot_read_targets" and .status == 403)] | length == 1' "proves ingest key cannot read admin target list"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "revoked_ingest_key_rejects_check_in" and .status == 401)] | length == 1' "proves revoked ingest key rejects check-in"
+RAW_TEST_KEY="sk_""live_TEST"
+RAW_TEST_KEY_PREFIX="${RAW_TEST_KEY%ST}"
+RAW_WEBHOOK_SECRET="canary-webhook-""redaction-token"
+assert_not_contains "$OUTPUT" "$RAW_TEST_KEY" "raw API key is redacted" "<raw API key>"
+assert_not_contains "$OUTPUT" "$RAW_TEST_KEY_PREFIX" "API key prefix is redacted" "<API key prefix>"
+assert_not_contains "$OUTPUT" "$RAW_WEBHOOK_SECRET" "webhook secret is redacted" "<webhook secret>"
+assert_not_contains "$OUTPUT" '"grp-test"' "group hash is redacted from receipt" "<group hash>"
+
+assert_file_contains "$CURL_LOG" "POST /api/v1/errors" "ingests an error"
+assert_file_contains "$CURL_LOG" "POST /api/v1/check-ins" "sends monitor check-in"
+assert_file_contains "$CURL_LOG" "GET /api/v1/webhook-deliveries?webhook_id=WHK-test&event=error.new_class&limit=5" "queries webhook deliveries"
+assert_file_contains "$CURL_LOG" "DELETE /api/v1/targets/TGT-test" "deletes target"
+assert_file_contains "$CURL_LOG" "DELETE /api/v1/monitors/MON-test" "deletes monitor"
+assert_file_contains "$CURL_LOG" "DELETE /api/v1/webhooks/WHK-test" "deletes webhook"
+assert_file_contains "$CURL_LOG" "POST /api/v1/keys/KEY-test/revoke" "revokes key"
+
+echo "Test 5: non-delivered webhook rows fail and clean up"
+setup_stubs
+OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin CURL_DELIVERY_STATUS=pending "$SCRIPT" --prefix test --webhook-url https://example.com/hook --app canary-test --poll-attempts 1 --poll-sleep 0 --json)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "pending webhook delivery exits non-zero"
+assert_contains "$BODY" "timed out waiting for delivered webhook delivery for WHK-test" "pending delivery explains failure"
+assert_file_contains "$CURL_LOG" "DELETE /api/v1/targets/TGT-test" "pending failure deletes target"
+assert_file_contains "$CURL_LOG" "DELETE /api/v1/monitors/MON-test" "pending failure deletes monitor"
+assert_file_contains "$CURL_LOG" "DELETE /api/v1/webhooks/WHK-test" "pending failure deletes webhook"
+assert_file_contains "$CURL_LOG" "POST /api/v1/keys/KEY-test/revoke" "pending failure revokes key"
+
+echo "Test 6: unexpected credential-bearing mutation status redacts and cleans up"
+setup_stubs
+OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin CURL_KEY_CREATE_STATUS=500 "$SCRIPT" --prefix test --webhook-url https://example.com/hook --app canary-test --json)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "unexpected key-create status exits non-zero"
+assert_contains "$BODY" "api_key_create_ingest expected HTTP 201" "unexpected key-create status explains failure"
+RAW_TEST_KEY="sk_""live_TEST"
+RAW_TEST_KEY_PREFIX="${RAW_TEST_KEY%ST}"
+assert_not_contains "$BODY" "$RAW_TEST_KEY" "unexpected key-create failure redacts raw key" "<raw API key>"
+assert_not_contains "$BODY" "$RAW_TEST_KEY_PREFIX" "unexpected key-create failure redacts key prefix" "<API key prefix>"
+assert_file_contains "$CURL_LOG" "POST /api/v1/keys/KEY-test/revoke" "unexpected key-create failure revokes key"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Add `bin/canary-write-path-rehearsal` to exercise Canary production write paths end to end with temporary target, monitor, webhook, ingest key, readback checks, cleanup, and redacted JSON evidence.
- Archive backlog #032 with the final 2026-06-12 live receipt and update the Rust cutover evidence docs.
- Keep strict advisory gates green by overriding the TypeScript SDK audit blockers: `esbuild` -> `0.28.1`, `postcss` -> `8.5.15`.

## Live evidence
- Final rehearsal command: `bin/canary-write-path-rehearsal --prefix 20260612-live-rust-write-path-final --json | tee /tmp/canary-write-path-rehearsal-2026-06-12-final.json | jq ...`
- Receipt: `docs/architecture/rust-write-path-receipt-2026-06-12.json`
- Production deploy identity observed during rehearsal: machine `78407d7f515008`, commit `8066373b55108f662bf08158dfd74c25561a9fd4`, digest `sha256:bf4d29b374f423cdd93e926ea6d2d0a5a8a2c49bfbf2d726bd2c357e9c1c2c65`.
- Temporary resources created and cleaned: target `TGT-2cr0ze6iwcfx`, monitor `MON-k2843ev95yz9`, webhook `WHK-opehar1c54yt`, key `KEY-vy07y1z3576z`; webhook delivery `DLV-stwp8h56qgxd`.

## Verification
- `bash -n bin/canary-write-path-rehearsal`
- `bash -n test/bin/canary_write_path_rehearsal_test.sh`
- `bash test/bin/canary_write_path_rehearsal_test.sh` -> 40 passed, 0 failed
- `npm audit --audit-level high` in `clients/typescript` -> found 0 vulnerabilities
- `npm run typecheck`, `npm run test:ci`, `npm run build` in `clients/typescript`
- `./bin/validate`
- `./bin/validate --strict` -> `Ci.strict DONE [14m31s]`
- pre-commit `Ci.fast` during amend -> `Ci.fast DONE [44.2s]`
- pre-push `Ci.strict` during push -> `Ci.strict DONE [7m9s]`
- Fresh security and QA critics re-reviewed the final diff with no blockers.

## Residual risk
- Webhook proof uses a 2xx sink and Canary delivery ledger readback; it does not verify downstream receiver signature handling.
- Retention, TLS scan, and long-running worker production evidence remain scoped to backlog #034.
