### PR TITLE
feat(ci): prove production integration smoke

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -37,7 +37,7 @@
 | 036 | Agent-native inspection surface | high | done | L |
 | 037 | Watch the watchmen | high | done | L |
 | 038 | One-command integration agent | high | done | XL |
-| 041 | Live integration verification harness | P0 | ready | L |
+| 041 | Live integration verification harness | P0 | done | L |
 | 042 | Runtime pressure and freshness operations | P0 | ready | L |
 | 040 | Universal integration and enrollment engine | P0 | ready | XL |
 | 043 | Agentic remediation claim protocol | P1 | ready | L |
@@ -72,7 +72,7 @@
 037 (watch the watchmen) — shipped; proves Canary itself from outside the Canary process, preserves receipts when Canary is unreachable, and surfaces the external witness in `bin/canary doctor`
 038 (one-command integration agent) — discovers, patches, enrolls, and verifies Canary integration for Vercel/Fly/Next apps
 039 (external-user security/privacy foundation) — must precede arbitrary-user hosted claims; adds tenant/project ownership, public-ingest constraints, privacy defaults, webhook scoping, and quotas
-041 (live integration verification harness) — makes strict prove the production-image write/readback path before integration coverage claims scale beyond dogfood
+041 (live integration verification harness) — shipped; strict now proves the production-image SDK/write/readback/webhook/doctor/MCP path before integration coverage claims scale beyond dogfood
 042 (runtime pressure/freshness ops) — hardens worker/job/readiness/backup/dogfood freshness so arbitrary-app scale fails loudly instead of silently aging
 040 (universal integration/enrollment engine) — builds on 039/041/042 to make arbitrary app onboarding state-aware, framework-neutral, and receipt-backed
 044 (telemetry/analytics signal model) — defines what analytics/log/metric/event signals Canary owns or bridges before adding broad ingest surfaces
@@ -95,12 +95,11 @@
 
 ### Active order (2026-06-13)
 
-039 is delivered. 041 and 042 are the next parallel foundations: strict must
-prove SDK to server to query/webhook/doctor behavior, and runtime readiness must
-reflect freshness/pressure rather than thread liveness. 040 follows once those
-foundations can make integration receipts trustworthy. 043 and 044 are P1
-product-shaping epics that should not block the P0 foundation, but they define
-the agentic-remediation and analytics direction.
+039 and 041 are delivered. 042 is the next P0 foundation: runtime readiness
+must reflect freshness/pressure rather than thread liveness. 040 follows once
+those foundations can make integration receipts trustworthy. 043 and 044 are
+P1 product-shaping epics that should not block the P0 foundation, but they
+define the agentic-remediation and analytics direction.
 
 020 stays blocked on Adminifi URLs; 010 stays blocked on the downstream
 bitterblossom triage sprite, but the new Lane 6 foundations now precede any
@@ -186,6 +185,11 @@ parity backlog items were retired during the Rust scorched-earth migration.
   ingest applies redaction defaults, webhook delivery uses timestamped signatures
   and scoped service authority, and durable rate limits back process-local
   buckets.
+- 2026-06-13: Delivered 041. Dagger strict now runs a production-image
+  integration harness that proves health/readiness workers, TypeScript SDK
+  ingest/readback against the Rust server, disposable target/monitor/webhook
+  write paths, webhook delivery ledger readback, doctor worker readiness, and
+  MCP manifest schema shape.
 
 ## Status
 

--- a/backlog.d/_done/041-live-integration-verification-harness.md
+++ b/backlog.d/_done/041-live-integration-verification-harness.md
@@ -1,19 +1,19 @@
 # Prove live integration behavior in the gate
 
 Priority: P0
-Status: ready
+Status: done
 Estimate: L
 
 ## Goal
 Make the canonical gate prove Canary's production-image write/readback behavior across SDK ingest, health, webhooks, CLI/doctor, MCP manifest, and integration receipts instead of only proving boot readiness.
 
 ## Oracle
-- [ ] Dagger strict runs a production-image integration harness that mints scoped keys, creates a target/monitor/webhook, ingests a synthetic error through the TypeScript SDK or generated fixture, and reads it back through query/report/timeline/error detail.
-- [ ] The harness verifies webhook delivery ledger rows, stable delivery IDs, retry/diagnostic visibility, and signed test delivery behavior.
-- [ ] The harness runs `bin/canary doctor --json`, validates worker readiness from `/readyz`, and fails if doctor reports stale placeholders for shipped readiness features.
-- [ ] The harness validates the MCP manifest schemas, not only tool names.
-- [ ] SDK/server payload contract tests exercise the real Rust ingest handler instead of only mocked `fetch` calls.
-- [ ] `bin/canary-write-path-rehearsal` remains useful for live Fly evidence, but the PR gate owns deterministic local proof.
+- [x] Dagger strict runs a production-image integration harness that mints scoped keys, creates a target/monitor/webhook, ingests a synthetic error through the TypeScript SDK or generated fixture, and reads it back through query/report/timeline/error detail.
+- [x] The harness verifies webhook delivery ledger rows, stable delivery IDs, retry/diagnostic visibility, and signed test delivery behavior.
+- [x] The harness runs `bin/canary doctor --json`, validates worker readiness from `/readyz`, and fails if doctor reports stale placeholders for shipped readiness features.
+- [x] The harness validates the MCP manifest schemas, not only tool names.
+- [x] SDK/server payload contract tests exercise the real Rust ingest handler instead of only mocked `fetch` calls.
+- [x] `bin/canary-write-path-rehearsal` remains useful for live Fly evidence, but the PR gate owns deterministic local proof.
 
 ## Children
 1. Convert the existing production-image smoke from health-only to write/readback integration proof.
@@ -26,3 +26,4 @@ Make the canonical gate prove Canary's production-image write/readback behavior 
 ## Notes
 - Evidence: `dagger/src/index.ts` currently curls `/healthz` and `/readyz`; `test/bin/canary_write_path_rehearsal_test.sh` stubs external commands; `clients/typescript/test/client.test.ts` mocks `globalThis.fetch`; `crates/canary-cli/src/lib.rs` still reports `worker_readiness` unavailable because #034 had not landed when the doctor code was written.
 - Verification lane found #038's intent is shipped, but its broad coverage oracle is not yet owned by the gate.
+- Delivered in `docs/architecture/live-integration-verification-harness-2026-06-13.md`.

--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -222,7 +222,18 @@ request_json "readyz" "GET" "/readyz" "none" "$ready_file"
 request_json "canary-query" "GET" "/api/v1/query?service=canary&window=${encoded_window}" "read" "$query_file"
 
 health_ok="$(jq -r 'try (.curl_exit == 0 and .http_status == 200 and (.response | type == "object") and .response.status == "ok") catch false' "$health_file")"
-ready_ok="$(jq -r 'try (.curl_exit == 0 and .http_status == 200 and (.response | type == "object") and .response.status == "ready" and ([.response.checks[]?] | all(. == "ok"))) catch false' "$ready_file")"
+ready_ok="$(jq -r 'try (
+  .curl_exit == 0
+  and .http_status == 200
+  and (.response | type == "object")
+  and .response.status == "ready"
+  and .response.checks.database == "ok"
+  and .response.checks.supervisor == "ok"
+  and (.response.checks.workers | type == "array")
+  and (.response.checks.workers | length) == 5
+  and ([.response.checks.workers[].name] | sort) == ["monitor_overdue", "retention_prune", "target_probe", "tls_scan", "webhook_delivery"]
+  and all(.response.checks.workers[]; .state == "started" and .failure_count == 0 and (.last_success_at | type) == "string")
+) catch false' "$ready_file")"
 query_ok="$(jq -r 'try (.curl_exit == 0 and .http_status == 200 and (.response | type == "object") and .response.service == "canary" and (.response.total_errors | type == "number")) catch false' "$query_file")"
 transport_failures="$(jq -s '[.[] | select((.skipped // false | not) and (.curl_exit != 0))] | length' "$health_file" "$ready_file" "$query_file")"
 

--- a/bin/canary-write-path-rehearsal
+++ b/bin/canary-write-path-rehearsal
@@ -6,6 +6,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENDPOINT="${CANARY_ENDPOINT:-}"
 API_KEY="${CANARY_API_KEY:-}"
 WEBHOOK_URL="${CANARY_REHEARSAL_WEBHOOK_URL:-https://httpbingo.org/status/204}"
+TARGET_URL="${CANARY_REHEARSAL_TARGET_URL:-}"
 APP="${FLY_APP:-canary-obs}"
 PREFIX=""
 JSON_OUTPUT=0
@@ -33,7 +34,7 @@ WEBHOOK_RUN_URL=""
 
 usage() {
   cat <<'EOF'
-Usage: bin/canary-write-path-rehearsal [--endpoint <url>] [--api-key <key>] [--webhook-url <url>] [--prefix <prefix>] [--app <fly-app>] [--poll-attempts <n>] [--poll-sleep <seconds>] [--no-dr-status] [--json] [-h|--help]
+Usage: bin/canary-write-path-rehearsal [--endpoint <url>] [--api-key <key>] [--webhook-url <url>] [--target-url <url>] [--prefix <prefix>] [--app <fly-app>] [--poll-attempts <n>] [--poll-sleep <seconds>] [--no-dr-status] [--json] [-h|--help]
 
 Exercise Canary's live write paths with uniquely named disposable resources.
 
@@ -575,6 +576,11 @@ while (($#)); do
       WEBHOOK_URL="$2"
       shift 2
       ;;
+    --target-url)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      TARGET_URL="$2"
+      shift 2
+      ;;
     --prefix)
       (($# >= 2)) || { usage >&2; exit 1; }
       PREFIX="$2"
@@ -639,7 +645,9 @@ SERVICE="canary-write-path-$PREFIX"
 KEY_NAME="$SERVICE-ingest"
 TARGET_NAME="$SERVICE-target"
 MONITOR_NAME="$SERVICE-monitor"
-TARGET_URL="${ENDPOINT%/}/healthz"
+if [[ -z "$TARGET_URL" ]]; then
+  TARGET_URL="${ENDPOINT%/}/healthz"
+fi
 WEBHOOK_RUN_URL="$(append_rehearsal_query "$WEBHOOK_URL")"
 remember_sensitive_literal "$WEBHOOK_RUN_URL"
 

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -1194,10 +1194,7 @@ pub fn doctor_report(client: &ApiClient, repo_root: &Path) -> Value {
         "canary_errors": canary_errors,
         "witness": witness,
         "dogfood": dogfood,
-        "worker_readiness": {
-            "available": false,
-            "reason": "backlog item #034 has not landed"
-        }
+        "worker_readiness": worker_readiness_report(&readyz)
     })
 }
 
@@ -1233,7 +1230,10 @@ pub fn summarize_doctor(value: &Value) -> Vec<String> {
         probe_summary(value.get("incidents"))
     ));
     lines.push(format!("dogfood: {}", probe_summary(value.get("dogfood"))));
-    lines.push("worker_readiness: unavailable until #034 lands".to_owned());
+    lines.push(format!(
+        "worker_readiness: {}",
+        worker_readiness_summary(value.get("worker_readiness"))
+    ));
     lines
 }
 
@@ -1469,6 +1469,55 @@ fn witness_monitor_report(status_probe: &Value, monitors_probe: &Value) -> Value
     }
 }
 
+fn worker_readiness_report(readyz_probe: &Value) -> Value {
+    if !probe_ok(readyz_probe) {
+        return json!({
+            "available": false,
+            "reason": string_field(readyz_probe, "error")
+        });
+    }
+
+    let Some(response) = readyz_probe.get("response") else {
+        return json!({
+            "available": false,
+            "reason": "readyz response missing"
+        });
+    };
+    let Some(workers) = response
+        .get("checks")
+        .and_then(|checks| checks.get("workers"))
+        .and_then(Value::as_array)
+    else {
+        return json!({
+            "available": false,
+            "reason": "readyz worker checks missing"
+        });
+    };
+
+    let failing_workers = workers
+        .iter()
+        .filter(|worker| {
+            worker.get("state").and_then(Value::as_str) != Some("started")
+                || worker
+                    .get("failure_count")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0)
+                    > 0
+        })
+        .count();
+
+    json!({
+        "available": true,
+        "status": response
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        "worker_count": workers.len(),
+        "failing_workers": failing_workers,
+        "workers": workers
+    })
+}
+
 fn find_witness_monitor(probe: &Value) -> Option<&Value> {
     probe
         .get("response")
@@ -1529,6 +1578,55 @@ fn witness_summary(value: Option<&Value>) -> String {
         "unavailable" => format!("{} unavailable", string_field(value, "monitor")),
         other => other.to_owned(),
     }
+}
+
+fn worker_readiness_summary(value: Option<&Value>) -> String {
+    let Some(value) = value else {
+        return "missing".to_owned();
+    };
+    if !value
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return format!("unavailable: {}", string_field(value, "reason"));
+    }
+    let worker_count = value
+        .get("worker_count")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| {
+            value
+                .get("workers")
+                .and_then(Value::as_array)
+                .map_or(0, |workers| workers.len() as i64)
+        });
+    let failing_workers = value
+        .get("failing_workers")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| {
+            value
+                .get("workers")
+                .and_then(Value::as_array)
+                .map_or(0, |workers| {
+                    workers
+                        .iter()
+                        .filter(|worker| {
+                            worker.get("state").and_then(Value::as_str) != Some("started")
+                                || worker
+                                    .get("failure_count")
+                                    .and_then(Value::as_i64)
+                                    .unwrap_or(0)
+                                    > 0
+                        })
+                        .count() as i64
+                })
+        });
+    format!(
+        "{} {} workers, {} failing",
+        string_field(value, "status"),
+        worker_count,
+        failing_workers
+    )
 }
 
 fn probe_status(value: &Value) -> String {
@@ -1904,8 +2002,9 @@ mod tests {
 
     #[test]
     fn mcp_manifest_exposes_integration_tools() {
-        let names = tool_manifest()
-            .into_iter()
+        let manifest = tool_manifest();
+        let names = manifest
+            .iter()
             .map(|tool| tool.name)
             .collect::<BTreeSet<_>>();
 
@@ -1913,6 +2012,18 @@ mod tests {
         assert!(names.contains("canary_integrate_plan"));
         assert!(names.contains("canary_integrate_patch"));
         assert!(names.contains("canary_integrate_enroll"));
+        for tool in manifest {
+            assert_eq!(
+                tool.input_schema["type"], "object",
+                "{} should declare an object input schema",
+                tool.name
+            );
+            assert!(
+                tool.input_schema.get("properties").is_some(),
+                "{} should declare properties for agents",
+                tool.name
+            );
+        }
     }
 
     fn temp_project(name: &str) -> std::result::Result<PathBuf, Box<dyn std::error::Error>> {

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -78,7 +78,20 @@ fn doctor_summary_includes_watchman_and_self_errors() {
         "key_scope": "admin",
         "reachability": {
             "healthz": {"ok": true, "response": {"status": "ok"}},
-            "readyz": {"ok": true, "response": {"status": "ready"}}
+            "readyz": {"ok": true, "response": {
+                "status": "ready",
+                "checks": {
+                    "database": "ok",
+                    "supervisor": "ok",
+                    "workers": [
+                        {"name": "webhook_delivery", "state": "started", "last_success_at": "2026-06-14T02:07:53Z", "failure_count": 0, "last_error_class": null},
+                        {"name": "target_probe", "state": "started", "last_success_at": "2026-06-14T02:07:55Z", "failure_count": 0, "last_error_class": null},
+                        {"name": "monitor_overdue", "state": "started", "last_success_at": "2026-06-14T02:07:55Z", "failure_count": 0, "last_error_class": null},
+                        {"name": "retention_prune", "state": "started", "last_success_at": "2026-06-14T02:07:23Z", "failure_count": 0, "last_error_class": null},
+                        {"name": "tls_scan", "state": "started", "last_success_at": "2026-06-14T02:07:23Z", "failure_count": 0, "last_error_class": null}
+                    ]
+                }
+            }}
         },
         "summary": {"ok": true, "summary": ["summary: Canary healthy"]},
         "services": {"ok": true, "summary": ["summary: all surfaces healthy"]},
@@ -92,7 +105,17 @@ fn doctor_summary_includes_watchman_and_self_errors() {
         "canary_errors": {"ok": true, "summary": ["summary: 0 errors in canary in the last 1h."]},
         "incidents": {"ok": true, "summary": ["summary: 0 open incidents"]},
         "dogfood": {"ok": true, "summary": ["covered: 4"]},
-        "worker_readiness": {"available": false}
+        "worker_readiness": {
+            "available": true,
+            "status": "ready",
+            "workers": [
+                {"name": "webhook_delivery", "state": "started", "failure_count": 0},
+                {"name": "target_probe", "state": "started", "failure_count": 0},
+                {"name": "monitor_overdue", "state": "started", "failure_count": 0},
+                {"name": "retention_prune", "state": "started", "failure_count": 0},
+                {"name": "tls_scan", "state": "started", "failure_count": 0}
+            ]
+        }
     });
 
     let lines = summarize_doctor(&value);
@@ -104,5 +127,10 @@ fn doctor_summary_includes_watchman_and_self_errors() {
         lines
             .iter()
             .any(|line| line == "canary_errors: summary: 0 errors in canary in the last 1h.")
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "worker_readiness: ready 5 workers, 0 failing")
     );
 }

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -8,6 +8,8 @@ import {
   dag,
   Container,
   Directory,
+  Secret,
+  Service,
   object,
   func,
   check,
@@ -267,42 +269,198 @@ export class Ci {
     return source.dockerBuild()
   }
 
-  private productionImageSmokeContainer(source: Directory): Container {
-    const service = this.productionImageContainer(source)
+  private async productionImageService(
+    source: Directory,
+  ): Promise<{ service: Service; adminKey: Secret }> {
+    const prepared = this.productionImageContainer(source)
       .withEnvVariable("CANARY_DB_PATH", "/tmp/canary-smoke.db")
       .withEnvVariable("PORT", "4000")
       .withEnvVariable("CANARY_DISCLOSE_BOOTSTRAP_KEY", "false")
-      .withExposedPort(4000)
-      .asService()
-
-    return dag
-      .container()
-      .from(RUST_IMAGE)
-      .withExec(["apt-get", "update", "-q"])
-      .withExec(["apt-get", "install", "-yq", "--no-install-recommends", "curl", "jq"])
-      .withServiceBinding("canary", service)
+      .withEnvVariable("ALLOW_PRIVATE_TARGETS", "true")
       .withExec([
         "bash",
         "-ceu",
-        [
-          "for _ in {1..60}; do",
-          "  if curl --fail --silent --show-error http://canary:4000/healthz >/tmp/healthz.json &&",
-          "     curl --fail --silent --show-error http://canary:4000/readyz >/tmp/readyz.json &&",
-          "     grep -F '\"status\":\"ok\"' /tmp/healthz.json &&",
-          "     grep -F '\"status\":\"ready\"' /tmp/readyz.json &&",
-          "     jq -e '",
-          "      (.checks.workers | length) == 5 and",
-          "      ([.checks.workers[].name] | sort) == [\"monitor_overdue\", \"retention_prune\", \"target_probe\", \"tls_scan\", \"webhook_delivery\"] and",
-          "      all(.checks.workers[]; .state == \"started\" and .failure_count == 0 and (.last_success_at | type) == \"string\")",
-          "    ' /tmp/readyz.json; then",
-          "    exit 0",
-          "  fi",
-          "  sleep 1",
-          "done",
-          "cat /tmp/healthz.json /tmp/readyz.json 2>/dev/null || true",
-          "exit 1",
-        ].join("\n"),
+        "/app/bin/canary-server mint-key --scope admin --name production-smoke-admin >/tmp/canary-admin-key 2>/tmp/canary-mint-key.log",
       ])
+
+    const rawKey = (await prepared.file("/tmp/canary-admin-key").contents()).trim()
+    const adminKey = dag.setSecret("canary-smoke-admin-key", rawKey)
+    const service = prepared
+      .withExposedPort(4000)
+      .asService()
+
+    return { service, adminKey }
+  }
+
+  private readinessProbeScript(): string {
+    return [
+      "for _ in {1..60}; do",
+      "  if curl --fail --silent --show-error http://canary:4000/healthz >/tmp/healthz.json &&",
+      "     curl --fail --silent --show-error http://canary:4000/readyz >/tmp/readyz.json &&",
+      "     grep -F '\"status\":\"ok\"' /tmp/healthz.json &&",
+      "     grep -F '\"status\":\"ready\"' /tmp/readyz.json &&",
+      "     jq -e '",
+      "      .checks.database == \"ok\" and",
+      "      .checks.supervisor == \"ok\" and",
+      "      (.checks.workers | length) == 5 and",
+      "      ([.checks.workers[].name] | sort) == [\"monitor_overdue\", \"retention_prune\", \"target_probe\", \"tls_scan\", \"webhook_delivery\"] and",
+      "      all(.checks.workers[]; .state == \"started\" and .failure_count == 0 and (.last_success_at | type) == \"string\")",
+      "    ' /tmp/readyz.json; then",
+      "    exit 0",
+      "  fi",
+      "  sleep 1",
+      "done",
+      "cat /tmp/healthz.json /tmp/readyz.json 2>/dev/null || true",
+      "exit 1",
+    ].join("\n")
+  }
+
+  private sdkSmokeScript(): string {
+    return `
+import { initCanary, captureException } from "./clients/typescript/dist/index.js";
+
+const endpoint = process.env.CANARY_ENDPOINT;
+const apiKey = process.env.CANARY_API_KEY;
+const service = \`canary-sdk-smoke-\${Date.now()}-\${process.pid}\`;
+
+if (!endpoint || !apiKey) {
+  throw new Error("missing Canary smoke endpoint or API key");
+}
+
+initCanary({
+  endpoint,
+  apiKey,
+  service,
+  environment: "ci",
+});
+
+const result = await captureException(new Error(\`Canary SDK production smoke \${service}\`), {
+  fingerprint: ["canary-sdk-production-smoke", service],
+  context: { source: "dagger-production-image-smoke" },
+});
+
+if (!result?.id || !result.group_hash) {
+  throw new Error(\`SDK ingest did not return an error id and group hash: \${JSON.stringify(result)}\`);
+}
+
+const query = await fetch(
+  \`\${endpoint}/api/v1/query?service=\${encodeURIComponent(service)}&window=1h\`,
+  { headers: { Authorization: \`Bearer \${apiKey}\` } },
+);
+if (!query.ok) {
+  throw new Error(\`SDK readback query failed with HTTP \${query.status}\`);
+}
+const body = await query.json();
+if (
+  body.service !== service ||
+  body.total_errors < 1 ||
+  !body.groups?.some((group) => group.group_hash === result.group_hash && group.service === service)
+) {
+  throw new Error(\`SDK readback did not include group \${result.group_hash}: \${JSON.stringify(body)}\`);
+}
+`
+  }
+
+  private writePathSmokeScript(): string {
+    return `
+prefix="dagger-prod-$(date -u +%Y%m%d%H%M%S)-$$"
+receipt="$(
+  CANARY_REHEARSAL_POLL_ATTEMPTS=20 \
+  CANARY_REHEARSAL_POLL_SLEEP=1 \
+  bin/canary-write-path-rehearsal \
+    --endpoint "$CANARY_ENDPOINT" \
+    --webhook-url https://httpbingo.org/status/204 \
+    --target-url http://127.0.0.1:4000/healthz \
+    --prefix "$prefix" \
+    --no-dr-status \
+    --json
+)"
+printf '%s' "$receipt" >/tmp/canary-write-path-rehearsal.json
+jq -e '
+  .status == "ok"
+  and (.resources.immutable_error_id | startswith("ERR-"))
+  and (.resources.immutable_webhook_delivery_id | startswith("DLV-"))
+  and ([.steps[].name] | index("api_key_create_ingest"))
+  and ([.steps[].name] | index("webhook_test"))
+  and ([.steps[].name] | index("error_ingest"))
+  and ([.steps[].name] | index("error_query_readback"))
+  and ([.steps[].name] | index("report_readback"))
+  and ([.steps[].name] | index("timeline_readback"))
+  and ([.steps[].name] | index("error_detail_readback"))
+  and ([.steps[].name] | index("webhook_delivery_lookup"))
+  and ([.steps[].name] | index("post_cleanup_targets"))
+  and ([.steps[].name] | index("post_cleanup_monitors"))
+  and ([.steps[].name] | index("post_cleanup_webhooks"))
+' /tmp/canary-write-path-rehearsal.json
+`
+  }
+
+  private doctorAndMcpSmokeScript(): string {
+    return `
+bin/canary doctor --json >/tmp/canary-doctor.json
+jq -e '
+  .response.worker_readiness.available == true
+  and .response.worker_readiness.status == "ready"
+  and .response.worker_readiness.worker_count == 5
+  and .response.worker_readiness.failing_workers == 0
+  and (.response.reachability.readyz.response.checks.workers | length) == 5
+' /tmp/canary-doctor.json
+
+bin/canary mcp-manifest >/tmp/canary-mcp-manifest.json
+jq -e '
+  .schema_version == 1
+  and (.tools | type == "array")
+  and (.tools | length) >= 4
+  and all(.tools[]; (.name | type == "string") and (.description | type == "string") and .input_schema.type == "object" and (.input_schema.properties | type == "object"))
+' /tmp/canary-mcp-manifest.json
+`
+  }
+
+  private async productionImageNodeSmokeContainer(
+    source: Directory,
+    service: Service,
+    adminKey: Secret,
+  ): Promise<Container> {
+    return (
+      await nodeContainer(
+        source,
+        "clients/typescript",
+        "clients/typescript/package-lock.json",
+        "canary-typescript",
+      )
+    )
+      .withWorkdir("/work")
+      .withExec(["apt-get", "update", "-q"])
+      .withExec(["apt-get", "install", "-yq", "--no-install-recommends", "curl", "jq"])
+      .withServiceBinding("canary", service)
+      .withSecretVariable("CANARY_API_KEY", adminKey)
+      .withEnvVariable("CANARY_ENDPOINT", "http://canary:4000")
+      .withExec(["bash", "-ceu", this.readinessProbeScript()])
+      .withExec(["npm", "--prefix", "clients/typescript", "run", "build"])
+      .withExec(["node", "--input-type=module", "-e", this.sdkSmokeScript()])
+      .withExec(["bash", "-ceu", this.writePathSmokeScript()])
+  }
+
+  private async productionImageDoctorSmokeContainer(
+    source: Directory,
+    service: Service,
+    adminKey: Secret,
+  ): Promise<Container> {
+    return (await rustContainer(source))
+      .withExec(["apt-get", "update", "-q"])
+      .withExec(["apt-get", "install", "-yq", "--no-install-recommends", "curl", "jq"])
+      .withServiceBinding("canary", service)
+      .withSecretVariable("CANARY_API_KEY", adminKey)
+      .withEnvVariable("CANARY_ENDPOINT", "http://canary:4000")
+      .withExec(["bash", "-ceu", this.readinessProbeScript()])
+      .withExec(["bash", "-ceu", this.doctorAndMcpSmokeScript()])
+  }
+
+  private async productionImageIntegration(source: Directory): Promise<void> {
+    const { service, adminKey } = await this.productionImageService(source)
+
+    await (await this.productionImageNodeSmokeContainer(source, service, adminKey)).sync()
+    await (await this.productionImageDoctorSmokeContainer(source, service, adminKey)).sync()
   }
 
   @func()
@@ -535,7 +693,7 @@ export class Ci {
     })
     source?: Directory,
   ): Promise<void> {
-    await this.productionImageSmokeContainer(source!).sync()
+    await this.productionImageIntegration(source!)
   }
 
   @func()

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -68,8 +68,15 @@ nonzero when coverage gaps remain, so agents can inspect the failure details.
 
 `doctor` is the fastest "who watches Canary?" command. It probes `/healthz`,
 `/readyz`, the global report, service status, incidents, dogfood coverage,
-recent `service=canary` errors, and the external `canary-watchman` monitor
-created by `bin/canary-witness`. The witness line is:
+recent `service=canary` errors, worker lifecycle readiness, and the external
+`canary-watchman` monitor created by `bin/canary-witness`. The worker readiness
+line is derived from `/readyz` and should look like:
+
+```text
+worker_readiness: ready 5 workers, 0 failing
+```
+
+The witness line is:
 
 - `observed`: the scheduled witness has checked in; the line includes the last
   check-in status and timestamp.

--- a/docs/architecture/live-integration-verification-harness-2026-06-13.md
+++ b/docs/architecture/live-integration-verification-harness-2026-06-13.md
@@ -1,0 +1,46 @@
+# Live Integration Verification Harness
+
+Date: 2026-06-13
+Backlog: #041
+
+## Goal
+
+Make the canonical Dagger gate prove Canary's production-image integration
+surface, not only container boot readiness.
+
+## Gate Command
+
+```bash
+PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH \
+  ./bin/dagger call production-image-smoke
+```
+
+`production-image-smoke` is called by the checked deterministic lane, so it runs
+under `strict` through `deterministic`.
+
+## Proven Path
+
+The harness builds and starts the production Docker image, mints an admin key in
+the image, and verifies:
+
+- `/healthz` returns `{"status":"ok"}`.
+- `/readyz` returns `{"status":"ready"}`, database `ok`, supervisor `ok`, and
+  the five workers `webhook_delivery`, `target_probe`, `monitor_overdue`,
+  `retention_prune`, and `tls_scan` started with zero failures.
+- The TypeScript SDK builds, ingests an exception through the production Rust
+  server, and reads the resulting group back through `/api/v1/query`.
+- `bin/canary-write-path-rehearsal` creates disposable admin resources,
+  verifies ingest-only key boundaries, creates target/monitor/webhook resources,
+  sends a monitor check-in, ingests an error, reads it back through query,
+  report, timeline, and error-detail routes, verifies a delivered webhook
+  ledger row, and cleans up disposable resources.
+- `bin/canary doctor --json` reports worker readiness from `/readyz`.
+- `bin/canary mcp-manifest` emits object-shaped input schemas with properties
+  for all tools.
+
+## Notes
+
+The Dagger harness uses the Canary service alias for API clients and an explicit
+loopback target URL for the target registered inside Canary. Webhook URLs remain
+public by design; the smoke uses `https://httpbingo.org/status/204` rather than
+weakening webhook egress validation for private CI service aliases.

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -20,7 +20,7 @@ is checking.
 | Signal | Route | Healthy expectation |
 |---|---|---|
 | Liveness | `GET /healthz` | HTTP 200 and `{"status":"ok"}` |
-| Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, and every dependency check is `ok` |
+| Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, database and supervisor `ok`, and all five worker lifecycle snapshots started with zero failures |
 | Error readback | `GET /api/v1/query?service=canary&window=1h` | HTTP 200, service `canary`, and numeric `total_errors` |
 
 When all three signals are healthy, the witness sends an ingest check-in:
@@ -80,5 +80,7 @@ secrets. If it is `configured` but not `observed`, inspect the latest GitHub
 Actions receipt. If it is `observed`, the check-in state and timestamp are the
 current external witness evidence.
 
-Worker lifecycle readiness remains separate until backlog item #034 lands;
-`doctor` continues to report that state explicitly.
+`doctor` also summarizes worker lifecycle readiness from `/readyz`, for example
+`worker_readiness: ready 5 workers, 0 failing`. Treat a missing or failing
+worker readiness line as a stale inspection surface or a runtime pressure
+signal, not as a healthy witness result.

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -62,7 +62,7 @@ case "${STUB_SCENARIO:?}:$method:$url" in
     write_response 200 0.010 '{"status":"ok"}'
     ;;
   healthy:GET:https://canary.example/readyz)
-    write_response 200 0.020 '{"status":"ready","checks":{"database":"ok","supervisor":"ok"}}'
+    write_response 200 0.020 '{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","last_success_at":"2026-06-14T02:07:53Z","failure_count":0,"last_error_class":null},{"name":"target_probe","state":"started","last_success_at":"2026-06-14T02:07:55Z","failure_count":0,"last_error_class":null},{"name":"monitor_overdue","state":"started","last_success_at":"2026-06-14T02:07:55Z","failure_count":0,"last_error_class":null},{"name":"retention_prune","state":"started","last_success_at":"2026-06-14T02:07:23Z","failure_count":0,"last_error_class":null},{"name":"tls_scan","state":"started","last_success_at":"2026-06-14T02:07:23Z","failure_count":0,"last_error_class":null}]}}'
     ;;
   healthy:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
@@ -91,7 +91,7 @@ case "${STUB_SCENARIO:?}:$method:$url" in
     exit 7
     ;;
   unreachable:GET:https://canary.example/readyz)
-    write_response 200 0.020 '{"status":"ready","checks":{"database":"ok","supervisor":"ok"}}'
+    write_response 200 0.020 '{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","last_success_at":"2026-06-14T02:07:53Z","failure_count":0,"last_error_class":null},{"name":"target_probe","state":"started","last_success_at":"2026-06-14T02:07:55Z","failure_count":0,"last_error_class":null},{"name":"monitor_overdue","state":"started","last_success_at":"2026-06-14T02:07:55Z","failure_count":0,"last_error_class":null},{"name":"retention_prune","state":"started","last_success_at":"2026-06-14T02:07:23Z","failure_count":0,"last_error_class":null},{"name":"tls_scan","state":"started","last_success_at":"2026-06-14T02:07:23Z","failure_count":0,"last_error_class":null}]}}'
     ;;
   unreachable:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'

--- a/test/bin/canary_write_path_rehearsal_test.sh
+++ b/test/bin/canary_write_path_rehearsal_test.sh
@@ -129,8 +129,14 @@ case "$method $path" in
     write_response 200 '{"status":"revoked"}'
     ;;
   "POST /api/v1/targets")
+    expected_target_url="${EXPECT_TARGET_URL:-http://canary.test/healthz}"
+    actual_target_url="$(jq -r '.url // ""' <<<"$body")"
+    if [[ "$actual_target_url" != "$expected_target_url" ]]; then
+      write_response 422 "{\"detail\":\"unexpected target url $actual_target_url\"}"
+      exit 0
+    fi
     touch "$CURL_STATE/target-active"
-    write_response 201 '{"id":"TGT-test","name":"canary-write-path-test-target","service":"canary-write-path-test","url":"http://canary.test/healthz","method":"GET","interval_ms":60000,"timeout_ms":5000,"expected_status":"200","active":true,"created_at":"2026-06-12T20:00:00Z"}'
+    write_response 201 "$(jq -cn --arg url "$actual_target_url" '{id:"TGT-test",name:"canary-write-path-test-target",service:"canary-write-path-test",url:$url,method:"GET",interval_ms:60000,timeout_ms:5000,expected_status:"200",active:true,created_at:"2026-06-12T20:00:00Z"}')"
     ;;
   "GET /api/v1/targets")
     if [[ "$auth" == sk_* ]]; then
@@ -398,9 +404,10 @@ assert_contains "$BODY" "Missing required command: curl" "missing curl names dep
 
 echo "Test 4: stubbed rehearsal emits sanitized JSON receipt"
 setup_stubs
-OUTPUT=$(env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin "$SCRIPT" --prefix test --webhook-url https://example.com/hook --app canary-test --json)
+OUTPUT=$(env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin EXPECT_TARGET_URL=http://127.0.0.1:4000/healthz "$SCRIPT" --prefix test --webhook-url https://example.com/hook --target-url http://127.0.0.1:4000/healthz --app canary-test --json)
 assert_jq "$OUTPUT" '.status == "ok"' "receipt status ok"
 assert_jq "$OUTPUT" '.resources.cleaned_target_id == "TGT-test"' "records target id"
+assert_jq "$OUTPUT" '[.steps[] | select(.name == "target_create")][0].response.url == "http://127.0.0.1:4000/healthz"' "uses custom target URL"
 assert_jq "$OUTPUT" '.resources.revoked_key_id == "KEY-test"' "records revoked key id"
 assert_jq "$OUTPUT" '.resources.immutable_webhook_delivery_id == "DLV-test"' "records delivery id"
 assert_jq "$OUTPUT" '[.steps[] | select(.name == "dr_status" and .status == 0)] | length == 1' "records dr-status success"


### PR DESCRIPTION
## Summary
- upgrades the Dagger production-image smoke from health-only to an integration harness covering SDK ingest/readback, disposable write paths, webhook delivery readback, doctor, and MCP manifest schema shape
- makes `bin/canary doctor` report worker lifecycle readiness from `/readyz` now that worker readiness has shipped
- archives backlog #041 with an evidence note under `docs/architecture/live-integration-verification-harness-2026-06-13.md`

## Verification
- `bash test/bin/canary_witness_test.sh`
- `bash test/bin/canary_write_path_rehearsal_test.sh`
- `cargo fmt --all --check`
- `cargo test -p canary-cli --locked`
- `cd dagger && npx tsc --noEmit`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH ./bin/dagger call production-image-smoke`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH ./bin/validate --fast`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH ./bin/validate --strict`
- Fresh critic lane: no blockers; reran `git diff --check`, production-image smoke, changed shell tests, and targeted CLI tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced readiness validation to strictly verify worker states and health across production services.
  * Added configurable target URL option for integration rehearsal scripts.
  * Live worker readiness status now reported in diagnostic output instead of placeholders.

* **Documentation**
  * Added comprehensive runbook for live integration verification harness testing.
  * Updated diagnostic tool guidance with strengthened readiness requirements.
  * Clarified worker lifecycle monitoring expectations.

* **Chores**
  * Marked Live Integration Verification Harness backlog item as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->