### PR TITLE
fix(witness): allow route-ready worker pressure

### DIFF
--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -234,7 +234,7 @@ ready_ok="$(jq -r 'try (
   and ([.response.checks.workers[].name] | sort) == ["monitor_overdue", "retention_prune", "target_probe", "tls_scan", "webhook_delivery"]
   and all(.response.checks.workers[];
     .state == "started"
-    and .health == "ok"
+    and (.health == "ok" or .health == "pressured")
     and .failure_count == 0
     and .consecutive_failures == 0
     and (.last_success_at | type) == "string"

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -20,7 +20,7 @@ is checking.
 | Signal | Route | Healthy expectation |
 |---|---|---|
 | Liveness | `GET /healthz` | HTTP 200 and `{"status":"ok"}` |
-| Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, database and supervisor `ok`, and all five worker lifecycle snapshots started with zero failures |
+| Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, database and supervisor `ok`, and all five worker lifecycle snapshots started with zero failures. Worker `health` may be `ok` or `pressured`; stale, failing, and stopped workers are unhealthy. |
 | Error readback | `GET /api/v1/query?service=canary&window=1h` | HTTP 200, service `canary`, and numeric `total_errors` |
 
 When all three signals are healthy, the witness sends an ingest check-in:
@@ -86,10 +86,11 @@ worker readiness line as a stale inspection surface or a runtime pressure
 signal, not as a healthy witness result.
 
 The witness itself now requires each `/readyz` worker to report `state:
-started`, `health: ok`, zero cumulative and consecutive failures, a string
-`last_success_at`, numeric pressure counters, and a boolean
-`backoff_or_circuit_open`. A worker thread that is alive but stale, repeatedly
-failing, or pressured is therefore an unhealthy witness result.
+started`, `health: ok` or `health: pressured`, zero cumulative and consecutive
+failures, a string `last_success_at`, numeric pressure counters, and a boolean
+`backoff_or_circuit_open`. A pressured worker is still route-ready evidence; a
+worker thread that is stale, repeatedly failing, stopped, or in backoff/circuit
+open remains an unhealthy witness result.
 
 `doctor` also prints a `dr:` line. That line reflects the operator
 `bin/dr-status --app canary-obs` Litestream check when available and points to

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -58,6 +58,7 @@ write_response() {
 }
 
 READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
+PRESSURED_READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 
 case "${STUB_SCENARIO:?}:$method:$url" in
   healthy:GET:https://canary.example/healthz)
@@ -70,6 +71,23 @@ case "${STUB_SCENARIO:?}:$method:$url" in
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
     ;;
   healthy:POST:https://canary.example/api/v1/check-ins)
+    if ! jq -e '.monitor == "canary-watchman" and .status == "alive"' <<<"$data" >/dev/null; then
+      printf 'invalid check-in payload: %s\n' "$data" >&2
+      exit 95
+    fi
+    write_response 201 0.040 '{"monitor":"canary-watchman","status":"alive"}'
+    ;;
+
+  pressured:GET:https://canary.example/healthz)
+    write_response 200 0.010 '{"status":"ok"}'
+    ;;
+  pressured:GET:https://canary.example/readyz)
+    write_response 200 0.020 "$PRESSURED_READY_BODY"
+    ;;
+  pressured:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
+    write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
+    ;;
+  pressured:POST:https://canary.example/api/v1/check-ins)
     if ! jq -e '.monitor == "canary-watchman" and .status == "alive"' <<<"$data" >/dev/null; then
       printf 'invalid check-in payload: %s\n' "$data" >&2
       exit 95
@@ -180,6 +198,19 @@ assert_json_equals "$receipt" '.probes.healthz.response.status' 'ok' "healthy re
 assert_json_equals "$receipt" '.probes.readyz.response.status' 'ready' "healthy records readyz"
 assert_json_equals "$receipt" '.probes.canary_query.response.total_errors' '0' "healthy records canary query"
 assert_json_equals "$receipt" '.check_in.http_status' '201' "healthy sends check-in"
+
+receipt="$TMPDIR_TEST/pressured.json"
+STUB_SCENARIO=pressured run_success "pressured ready witness exits zero" \
+  "$WITNESS" \
+    --endpoint https://canary.example \
+    --read-api-key read-key \
+    --ingest-api-key ingest-key \
+    --receipt "$receipt" \
+    --require-check-in \
+    --json
+assert_json_equals "$receipt" '.status' 'healthy' "pressured ready receipt status"
+assert_json_equals "$receipt" '.probes.readyz.response.checks.workers[] | select(.name == "monitor_overdue") | .health' 'pressured' "pressured ready records worker pressure"
+assert_json_equals "$receipt" '.check_in.http_status' '201' "pressured ready sends check-in"
 
 receipt="$TMPDIR_TEST/degraded.json"
 STUB_SCENARIO=degraded run_failure "degraded witness exits nonzero" \


### PR DESCRIPTION
## Summary
- align `bin/canary-witness` with `/readyz` readiness semantics by accepting started workers with health `ok` or `pressured`
- add a regression for the stale `canary-watchman` deadlock where `monitor_overdue` pressure previously skipped the external check-in
- update the witness docs to clarify pressured workers are route-ready while stale/failing/stopped workers remain unhealthy

## Root cause
The witness required every `/readyz` worker to report `health=ok`. Production `/readyz` intentionally remains ready for pressured-but-started workers with zero failures. When `canary-watchman` became stale, `monitor_overdue` was pressured; the witness then skipped the check-in that would clear that pressure.

## Verification
- `bash test/bin/canary_witness_test.sh`
- `bash -n bin/canary-witness`
- `git diff --check`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH ./bin/validate --fast`
- patched live witness run against `https://canary-obs.fly.dev` exited 0 and posted `CHK-51d1ahr00ucj` for `MON-5csw7imodfcq`
- `/readyz` pressure cleared and report showed `canary-watchman` state `up` with `last_check_in_at=2026-06-15T15:51:00Z`

## Local strict note
Pre-push strict reached production image smoke/advisory lanes but was interrupted after the global local Dagger engine was repeatedly switched between v0.20.5 and v0.21.6 by concurrent repo work. This PR should use the hosted CI control plane as the strict gate oracle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canary witness now accepts both "ok" and "pressured" worker health statuses as healthy indicators, allowing for greater flexibility in health assessment.

* **Documentation**
  * Updated canary-witness documentation to clarify health state expectations, worker lifecycle snapshots, and required worker field reporting for accurate health monitoring.

* **Tests**
  * Added test coverage for the new pressured health state scenario, validating check-in behavior and overall witness status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->