### PR TITLE
chore(ci): opt workflows into node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   dagger:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request_target:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   core:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -9,6 +9,9 @@ concurrency:
   group: canary-witness
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   witness:
     runs-on: ubuntu-latest
@@ -56,9 +59,11 @@ jobs:
 
           STATUS=$(jq -r '.status // "unknown"' "$RUNNER_TEMP/canary-witness-receipt.json")
           OBSERVED_AT=$(jq -r '.observed_at // "unknown"' "$RUNNER_TEMP/canary-witness-receipt.json")
-          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          echo "observed_at=$OBSERVED_AT" >> "$GITHUB_OUTPUT"
+          {
+            echo "exit_code=$EXIT_CODE"
+            echo "status=$STATUS"
+            echo "observed_at=$OBSERVED_AT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload witness receipt
         if: always()
@@ -149,4 +154,9 @@ jobs:
       - name: Fail workflow if witness failed
         if: steps.check.outputs.exit_code != '0'
         run: |
-          exit "${{ steps.check.outputs.exit_code }}"
+          exit_code="${{ steps.check.outputs.exit_code }}"
+          if [ "$exit_code" -lt 0 ] || [ "$exit_code" -gt 255 ]; then
+            echo "Invalid witness exit code: $exit_code" >&2
+            exit 1
+          fi
+          exit "$exit_code"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ User-ratified composition: **`/settle → /refactor → /code-review → merge`.
 
 ## Self-monitoring
 
-Canary reports its own errors through the Rust runtime direct-ingest path, no HTTP loopback. Query Canary itself (`GET /api/v1/query?service=canary&window=5m`) for post-deploy signal.
+Canary reports its own errors through the Rust runtime direct-ingest path, no HTTP loopback. Query Canary itself (`GET /api/v1/query?service=canary&window=1h`) for post-deploy signal.
 
 ## Deploy (operational crib)
 


### PR DESCRIPTION
## Summary
- opt CI, deploy, and Canary Witness workflows into the GitHub Actions Node 24 runtime at the workflow boundary
- update the Canary self-monitoring crib to use the supported `window=1h`
- clean up existing Canary Witness shell lint in the touched workflow

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/deploy.yml .github/workflows/uptime-monitor.yml`
- `git diff --check`
- `curl -fsS -H "Authorization: Bearer $CANARY_API_KEY" 'https://canary-obs.fly.dev/api/v1/query?service=canary&window=1h' | jq -e '.service == "canary" and .window == "1h" and (.total_errors | type == "number")'`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH ./bin/validate --fast`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH git push -u origin chore/actions-node24-and-query-window` (pre-push `./bin/validate --strict`)
