### PR TITLE
chore(deploy): pin node 24 flyctl action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- pin the Fly deploy setup action to the `v1` release SHA that declares `runs.using: node24`
- remove the remaining deploy-time Node 20 action warning left after checkout/upload-artifact were upgraded

## Verification
- `actionlint .github/workflows/deploy.yml`
- GitHub action metadata: old `setup-flyctl@63da...` declares `runs.using: node20`; new `setup-flyctl@ed8ef...` declares `runs.using: node24`
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH git commit -m "chore(deploy): pin node 24 flyctl action"` (pre-commit `./bin/validate --fast`)
- `PATH=/Users/phaedrus/.local/share/canary-dagger/v0.20.5/bin:$PATH ./bin/validate --strict`