### PR TITLE
feat(cli): add self-watch operator verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
  "urlencoding",
 ]
 

--- a/crates/canary-cli/Cargo.toml
+++ b/crates/canary-cli/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
+time = { version = "0.3", features = ["parsing"] }
 urlencoding = "2.1"
 
 [lints]

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -12,12 +12,17 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 /// Default hosted Canary endpoint used when no endpoint is configured.
 pub const DEFAULT_ENDPOINT: &str = "https://canary-obs.fly.dev";
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const WITNESS_MONITOR_NAME: &str = "canary-watchman";
+const WITNESS_WORKFLOW_NAME: &str = "Canary Witness";
+const WITNESS_WORKFLOW_BRANCH: &str = "master";
+const WITNESS_ARTIFACT_PATTERN: &str = "canary-witness-<run_id>";
+const WITNESS_RUN_LIST_COMMAND: &str = "gh run list --workflow \"Canary Witness\" --branch master --limit 3 --json databaseId,status,conclusion,createdAt,updatedAt,url,event,workflowName";
 const DEFAULT_INTEGRATION_ENDPOINT_ENV: &str = "CANARY_ENDPOINT";
 const DEFAULT_INTEGRATION_SERVER_KEY_ENV: &str = "CANARY_API_KEY";
 const DEFAULT_INTEGRATION_PUBLIC_ENDPOINT_ENV: &str = "NEXT_PUBLIC_CANARY_ENDPOINT";
@@ -1985,11 +1990,25 @@ pub fn doctor_report(client: &ApiClient, repo_root: &Path) -> Value {
     let incidents = auth_probe(client, "/api/v1/incidents");
     let canary_errors = auth_probe(client, "/api/v1/query?service=canary&window=1h");
     let witness = witness_monitor_report(&status, &monitors);
+    let witness_runs = witness_run_references(repo_root);
     let dogfood = match run_dogfood_inventory(repo_root, false) {
         Ok(value) => json!({"ok": true, "summary": summarize_dogfood(&value), "response": value}),
         Err(error) => json!({"ok": false, "error": error.to_string()}),
     };
     let dr = dr_evidence_report(repo_root);
+    let worker_readiness = worker_readiness_report(&readyz);
+    let verdict = doctor_verdict(
+        &healthz,
+        &readyz,
+        &report,
+        &incidents,
+        &canary_errors,
+        &witness,
+        &worker_readiness,
+        &dogfood,
+        &witness_runs,
+        current_unix_ms(),
+    );
 
     json!({
         "schema_version": 1,
@@ -2010,7 +2029,8 @@ pub fn doctor_report(client: &ApiClient, repo_root: &Path) -> Value {
         "witness": witness,
         "dr": dr,
         "dogfood": dogfood,
-        "worker_readiness": worker_readiness_report(&readyz)
+        "worker_readiness": worker_readiness,
+        "verdict": verdict
     })
 }
 
@@ -2021,6 +2041,23 @@ pub fn summarize_doctor(value: &Value) -> Vec<String> {
         format!("key: {}", string_field(value, "key")),
         format!("key_scope: {}", string_field(value, "key_scope")),
     ];
+    lines.push(format!(
+        "verdict: {}",
+        verdict_summary(value.get("verdict"))
+    ));
+    if let Some(blocking) = value
+        .get("verdict")
+        .and_then(|verdict| verdict.get("blocking_signals"))
+        .and_then(Value::as_array)
+        .filter(|signals| !signals.is_empty())
+    {
+        let signals = blocking
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join("; ");
+        lines.push(format!("verdict_blocking: {signals}"));
+    }
     for key in ["healthz", "readyz"] {
         let probe = value
             .get("reachability")
@@ -2052,6 +2089,471 @@ pub fn summarize_doctor(value: &Value) -> Vec<String> {
         worker_readiness_summary(value.get("worker_readiness"))
     ));
     lines
+}
+
+#[allow(clippy::too_many_arguments)]
+fn doctor_verdict(
+    healthz: &Value,
+    readyz: &Value,
+    summary: &Value,
+    incidents: &Value,
+    canary_errors: &Value,
+    witness: &Value,
+    worker_readiness: &Value,
+    dogfood: &Value,
+    receipt_run_references: &Value,
+    now_unix_ms: u64,
+) -> Value {
+    let mut blocking_signals = Vec::new();
+    let mut unable = false;
+
+    if !probe_ok(healthz) {
+        unable = true;
+        blocking_signals.push(format!(
+            "/healthz unavailable: {}",
+            string_field(healthz, "error")
+        ));
+    }
+    if !probe_ok(readyz) {
+        unable = true;
+        blocking_signals.push(format!(
+            "/readyz unavailable: {}",
+            string_field(readyz, "error")
+        ));
+    }
+    if !probe_ok(summary) {
+        unable = true;
+        blocking_signals.push(format!(
+            "authenticated summary unavailable: {}",
+            string_field(summary, "error")
+        ));
+    }
+    if !probe_ok(canary_errors) {
+        unable = true;
+        blocking_signals.push(format!(
+            "canary error readback unavailable: {}",
+            string_field(canary_errors, "error")
+        ));
+    }
+    if !probe_ok(incidents) {
+        unable = true;
+        blocking_signals.push(format!(
+            "incident readback unavailable: {}",
+            string_field(incidents, "error")
+        ));
+    }
+
+    let witness_age_ms = witness_age_ms(witness, now_unix_ms);
+    if let Some(signal) = witness_blocking_signal(witness, witness_age_ms) {
+        blocking_signals.push(signal);
+    }
+    if string_field(witness, "status") == "unavailable" {
+        unable = true;
+    }
+
+    let open_canary_incident = open_canary_incident(incidents);
+    if let Some(incident) = &open_canary_incident {
+        let id = string_field(incident, "id");
+        let title = incident
+            .get("title")
+            .or_else(|| incident.get("summary"))
+            .and_then(Value::as_str)
+            .unwrap_or("untitled");
+        blocking_signals.push(format!("open Canary incident {id}: {title}"));
+    }
+
+    let worker_pressure = worker_pressure_report(worker_readiness);
+    if !worker_readiness
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        unable = true;
+        blocking_signals.push(format!(
+            "worker readiness unavailable: {}",
+            string_field(worker_readiness, "reason")
+        ));
+    }
+    let failing_workers = worker_pressure
+        .get("failing_workers")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let pressured_workers = worker_pressure
+        .get("pressured_workers")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if failing_workers > 0 {
+        blocking_signals.push(format!(
+            "{} worker(s) failing: {}",
+            failing_workers,
+            worker_names(&worker_pressure, "failing")
+        ));
+    }
+    if pressured_workers > 0 {
+        blocking_signals.push(format!(
+            "worker pressure: {}",
+            worker_names(&worker_pressure, "pressured")
+        ));
+    }
+
+    let canary_error_total = canary_error_total(canary_errors);
+    if canary_error_total > 0 {
+        blocking_signals.push(format!(
+            "{canary_error_total} recent service=canary error(s)"
+        ));
+    }
+
+    let dogfood_gap_count = dogfood_gap_count(dogfood);
+    let overall = if unable {
+        "unable"
+    } else if blocking_signals.is_empty() {
+        "healthy"
+    } else {
+        "degraded"
+    };
+    let next_operator_action = next_operator_action(
+        overall,
+        witness,
+        failing_workers,
+        pressured_workers,
+        canary_error_total,
+        dogfood_gap_count,
+        open_canary_incident.as_ref(),
+    );
+
+    json!({
+        "overall": overall,
+        "blocking_signals": blocking_signals,
+        "next_operator_action": next_operator_action,
+        "witness_age_ms": witness_age_ms,
+        "open_canary_incident": open_canary_incident.unwrap_or(Value::Null),
+        "worker_pressure": worker_pressure,
+        "dogfood_gap_count": dogfood_gap_count,
+        "receipt_run_references": receipt_run_references
+    })
+}
+
+fn next_operator_action(
+    overall: &str,
+    witness: &Value,
+    failing_workers: u64,
+    pressured_workers: u64,
+    canary_error_total: u64,
+    dogfood_gap_count: usize,
+    open_canary_incident: Option<&Value>,
+) -> String {
+    if overall == "unable" {
+        return "Restore `bin/canary doctor --json` evidence first: verify `/healthz`, `/readyz`, and read/admin API credentials, then rerun the doctor.".to_owned();
+    }
+    if witness_needs_operator(witness) {
+        return "Run `gh workflow run \"Canary Witness\" --ref master`; then inspect the latest witness receipt and rerun `bin/canary doctor --json`.".to_owned();
+    }
+    if let Some(incident) = open_canary_incident {
+        return format!(
+            "Investigate open Canary incident {}; inspect `bin/canary incidents --open --json` and rerun `bin/canary doctor --json` after remediation.",
+            string_field(incident, "id")
+        );
+    }
+    if failing_workers > 0 || pressured_workers > 0 {
+        return "Inspect `/readyz` worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`.".to_owned();
+    }
+    if canary_error_total > 0 {
+        return "Run `bin/canary errors canary --window 1h --json`, fix the newest error class, and rerun `bin/canary doctor --json`.".to_owned();
+    }
+    if dogfood_gap_count > 0 {
+        return "No runtime blocker; run `bin/canary dogfood audit --strict --json` and close the reported coverage gaps.".to_owned();
+    }
+    "No immediate operator action; keep the external witness and scheduled deploy monitors running."
+        .to_owned()
+}
+
+fn witness_blocking_signal(witness: &Value, witness_age_ms: Option<u64>) -> Option<String> {
+    let monitor = string_field(witness, "monitor");
+    match string_field(witness, "status").as_str() {
+        "observed" => {
+            let state = string_field(witness, "state");
+            if state == "up" {
+                return None;
+            }
+            let last_status = string_field(witness, "last_check_in_status");
+            Some(match witness_age_ms {
+                Some(age) => {
+                    format!("{monitor} {state}; last {last_status} check-in was {age} ms ago")
+                }
+                None => format!("{monitor} {state}; last {last_status} check-in age unknown"),
+            })
+        }
+        "configured" => Some(format!(
+            "{monitor} configured but no external check-in has been observed"
+        )),
+        "missing" => Some(format!("{monitor} monitor is missing")),
+        "unavailable" => Some(format!("{monitor} monitor readback is unavailable")),
+        other => Some(format!("{monitor} witness status is {other}")),
+    }
+}
+
+fn witness_needs_operator(witness: &Value) -> bool {
+    match string_field(witness, "status").as_str() {
+        "observed" => string_field(witness, "state") != "up",
+        "configured" | "missing" | "unavailable" => true,
+        _ => true,
+    }
+}
+
+fn witness_age_ms(witness: &Value, now_unix_ms: u64) -> Option<u64> {
+    let timestamp = witness
+        .get("last_check_in_at")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty() && *value != "unknown")?;
+    let observed = rfc3339_unix_ms(timestamp)?;
+    Some(now_unix_ms.saturating_sub(observed))
+}
+
+fn rfc3339_unix_ms(input: &str) -> Option<u64> {
+    let parsed = OffsetDateTime::parse(input, &Rfc3339).ok()?;
+    let seconds = u64::try_from(parsed.unix_timestamp()).ok()?;
+    seconds
+        .checked_mul(1_000)?
+        .checked_add(u64::from(parsed.nanosecond() / 1_000_000))
+}
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn open_canary_incident(incidents: &Value) -> Option<Value> {
+    incidents
+        .get("response")
+        .and_then(|response| response.get("incidents"))
+        .or_else(|| incidents.get("incidents"))
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|incident| {
+            incident.get("service").and_then(Value::as_str) == Some("canary")
+                && incident_is_open(incident)
+        })
+        .cloned()
+}
+
+fn incident_is_open(incident: &Value) -> bool {
+    !matches!(
+        incident
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or("open"),
+        "resolved" | "closed" | "dismissed"
+    )
+}
+
+fn canary_error_total(canary_errors: &Value) -> u64 {
+    canary_errors
+        .get("response")
+        .and_then(|response| response.get("total_errors"))
+        .or_else(|| canary_errors.get("total_errors"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+}
+
+fn dogfood_gap_count(dogfood: &Value) -> usize {
+    dogfood.get("response").map_or_else(
+        || dogfood_strict_failure_count(dogfood),
+        dogfood_strict_failure_count,
+    )
+}
+
+fn worker_pressure_report(worker_readiness: &Value) -> Value {
+    if !worker_readiness
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return json!({
+            "status": "unavailable",
+            "pressured_workers": 0,
+            "failing_workers": 0,
+            "reason": string_field(worker_readiness, "reason"),
+            "workers": []
+        });
+    }
+
+    let workers = worker_readiness
+        .get("workers")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let pressured = workers
+        .iter()
+        .filter(|worker| worker_is_pressured(worker))
+        .map(worker_pressure_detail)
+        .collect::<Vec<_>>();
+    let failing = workers
+        .iter()
+        .filter(|worker| worker_is_failing(worker))
+        .map(worker_pressure_detail)
+        .collect::<Vec<_>>();
+    let status = if !failing.is_empty() {
+        "failing"
+    } else if !pressured.is_empty() {
+        "pressured"
+    } else {
+        worker_readiness
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("ready")
+    };
+
+    json!({
+        "status": status,
+        "pressured_workers": pressured.len(),
+        "failing_workers": failing.len(),
+        "workers": pressured,
+        "failing": failing
+    })
+}
+
+fn worker_names(worker_pressure: &Value, key: &str) -> String {
+    let field = if key == "failing" {
+        "failing"
+    } else {
+        "workers"
+    };
+    let names = worker_pressure
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|workers| {
+            workers
+                .iter()
+                .filter_map(|worker| worker.get("name").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if names.is_empty() {
+        "unknown".to_owned()
+    } else {
+        names.join(", ")
+    }
+}
+
+fn worker_pressure_detail(worker: &Value) -> Value {
+    json!({
+        "name": string_field(worker, "name"),
+        "state": string_field(worker, "state"),
+        "health": string_field(worker, "health"),
+        "failure_count": worker.get("failure_count").and_then(Value::as_u64).unwrap_or(0),
+        "consecutive_failures": worker.get("consecutive_failures").and_then(Value::as_u64).unwrap_or(0),
+        "due_count": worker.get("due_count").and_then(Value::as_u64).unwrap_or(0),
+        "in_flight_count": worker.get("in_flight_count").and_then(Value::as_u64).unwrap_or(0),
+        "oldest_due_age_ms": worker.get("oldest_due_age_ms").cloned().unwrap_or(Value::Null),
+        "backoff_or_circuit_open": worker.get("backoff_or_circuit_open").and_then(Value::as_bool).unwrap_or(false)
+    })
+}
+
+fn worker_is_pressured(worker: &Value) -> bool {
+    worker.get("state").and_then(Value::as_str) == Some("started")
+        && worker.get("health").and_then(Value::as_str) == Some("pressured")
+}
+
+fn worker_is_failing(worker: &Value) -> bool {
+    if worker.get("state").and_then(Value::as_str) != Some("started") {
+        return true;
+    }
+    !matches!(
+        worker.get("health").and_then(Value::as_str),
+        Some("ok" | "pressured")
+    )
+}
+
+fn witness_run_references(repo_root: &Path) -> Value {
+    let mut command = Command::new("gh");
+    command
+        .current_dir(repo_root)
+        .env("GH_PROMPT_DISABLED", "1")
+        .env("GH_NO_UPDATE_NOTIFIER", "1")
+        .args([
+            "run",
+            "list",
+            "--workflow",
+            WITNESS_WORKFLOW_NAME,
+            "--branch",
+            WITNESS_WORKFLOW_BRANCH,
+            "--limit",
+            "3",
+            "--json",
+            "databaseId,status,conclusion,createdAt,updatedAt,url,event,workflowName",
+        ]);
+
+    match command.output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            match serde_json::from_str::<Value>(&stdout) {
+                Ok(Value::Array(runs)) => json!({
+                    "ok": true,
+                    "workflow": WITNESS_WORKFLOW_NAME,
+                    "branch": WITNESS_WORKFLOW_BRANCH,
+                    "command": WITNESS_RUN_LIST_COMMAND,
+                    "artifact_name_pattern": WITNESS_ARTIFACT_PATTERN,
+                    "runs": runs.into_iter().map(enrich_witness_run).collect::<Vec<_>>()
+                }),
+                Ok(value) => json!({
+                    "ok": false,
+                    "workflow": WITNESS_WORKFLOW_NAME,
+                    "command": WITNESS_RUN_LIST_COMMAND,
+                    "artifact_name_pattern": WITNESS_ARTIFACT_PATTERN,
+                    "reason": "gh returned non-array JSON",
+                    "response": value
+                }),
+                Err(error) => json!({
+                    "ok": false,
+                    "workflow": WITNESS_WORKFLOW_NAME,
+                    "command": WITNESS_RUN_LIST_COMMAND,
+                    "artifact_name_pattern": WITNESS_ARTIFACT_PATTERN,
+                    "reason": format!("could not parse gh run list JSON: {error}")
+                }),
+            }
+        }
+        Ok(output) => json!({
+            "ok": false,
+            "workflow": WITNESS_WORKFLOW_NAME,
+            "branch": WITNESS_WORKFLOW_BRANCH,
+            "command": WITNESS_RUN_LIST_COMMAND,
+            "artifact_name_pattern": WITNESS_ARTIFACT_PATTERN,
+            "reason": redact_text(&String::from_utf8_lossy(&output.stderr))
+        }),
+        Err(error) => json!({
+            "ok": false,
+            "workflow": WITNESS_WORKFLOW_NAME,
+            "branch": WITNESS_WORKFLOW_BRANCH,
+            "command": WITNESS_RUN_LIST_COMMAND,
+            "artifact_name_pattern": WITNESS_ARTIFACT_PATTERN,
+            "reason": error.to_string()
+        }),
+    }
+}
+
+fn enrich_witness_run(mut run: Value) -> Value {
+    if let Some(object) = run.as_object_mut()
+        && let Some(id) = object.get("databaseId").and_then(Value::as_u64)
+    {
+        object.insert(
+            "artifact_name".to_owned(),
+            Value::String(format!("canary-witness-{id}")),
+        );
+    }
+    run
+}
+
+fn verdict_summary(value: Option<&Value>) -> String {
+    let Some(value) = value else {
+        return "missing".to_owned();
+    };
+    format!(
+        "{}; next: {}",
+        string_field(value, "overall"),
+        string_field(value, "next_operator_action")
+    )
 }
 
 fn dr_evidence_report(repo_root: &Path) -> Value {
@@ -2403,15 +2905,11 @@ fn worker_readiness_report(readyz_probe: &Value) -> Value {
         .count();
     let failing_workers = workers
         .iter()
-        .filter(|worker| {
-            worker.get("state").and_then(Value::as_str) != Some("started")
-                || worker.get("health").and_then(Value::as_str) != Some("ok")
-                || worker
-                    .get("failure_count")
-                    .and_then(Value::as_i64)
-                    .unwrap_or(0)
-                    > 0
-        })
+        .filter(|worker| worker_is_failing(worker))
+        .count();
+    let pressured_workers = workers
+        .iter()
+        .filter(|worker| worker_is_pressured(worker))
         .count();
 
     json!({
@@ -2422,6 +2920,7 @@ fn worker_readiness_report(readyz_probe: &Value) -> Value {
             .unwrap_or("unknown"),
         "worker_count": workers.len(),
         "failing_workers": failing_workers,
+        "pressured_workers": pressured_workers,
         "schema_missing_health_fields": schema_missing_health_fields,
         "workers": workers
     })
@@ -2519,15 +3018,21 @@ fn worker_readiness_summary(value: Option<&Value>) -> String {
                 .map_or(0, |workers| {
                     workers
                         .iter()
-                        .filter(|worker| {
-                            worker.get("state").and_then(Value::as_str) != Some("started")
-                                || worker.get("health").and_then(Value::as_str) != Some("ok")
-                                || worker
-                                    .get("failure_count")
-                                    .and_then(Value::as_i64)
-                                    .unwrap_or(0)
-                                    > 0
-                        })
+                        .filter(|worker| worker_is_failing(worker))
+                        .count() as i64
+                })
+        });
+    let pressured_workers = value
+        .get("pressured_workers")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| {
+            value
+                .get("workers")
+                .and_then(Value::as_array)
+                .map_or(0, |workers| {
+                    workers
+                        .iter()
+                        .filter(|worker| worker_is_pressured(worker))
                         .count() as i64
                 })
         });
@@ -2535,22 +3040,19 @@ fn worker_readiness_summary(value: Option<&Value>) -> String {
         .get("schema_missing_health_fields")
         .and_then(Value::as_i64)
         .unwrap_or(0);
-    if missing_health > 0 {
-        format!(
-            "{} {} workers, {} failing, {} missing health fields",
-            string_field(value, "status"),
-            worker_count,
-            failing_workers,
-            missing_health
-        )
-    } else {
-        format!(
-            "{} {} workers, {} failing",
-            string_field(value, "status"),
-            worker_count,
-            failing_workers
-        )
+    let mut summary = format!(
+        "{} {} workers, {} failing",
+        string_field(value, "status"),
+        worker_count,
+        failing_workers
+    );
+    if pressured_workers > 0 {
+        summary.push_str(&format!(", {pressured_workers} pressured"));
     }
+    if missing_health > 0 {
+        summary.push_str(&format!(", {missing_health} missing health fields"));
+    }
+    summary
 }
 
 fn dr_summary(value: Option<&Value>) -> String {
@@ -2660,9 +3162,49 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
             input_schema: json!({"type":"object","required":["service"],"properties":{"service":{"type":"string"},"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]}}}),
         },
         ToolSpec {
+            name: "canary_services",
+            description: "List target and monitor service states from `bin/canary services`.",
+            input_schema: json!({"type":"object","properties":{"state":{"type":"string","enum":["up","degraded","down","unknown"]},"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]}}}),
+        },
+        ToolSpec {
+            name: "canary_incidents",
+            description: "Inspect active incidents from `bin/canary incidents`; use this after doctor reports an open Canary incident.",
+            input_schema: json!({"type":"object","properties":{"open":{"type":"boolean","default":true}}}),
+        },
+        ToolSpec {
+            name: "canary_timeline",
+            description: "Inspect timeline events globally or for one service.",
+            input_schema: json!({"type":"object","properties":{"service":{"type":"string"},"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]},"limit":{"type":"integer","minimum":1,"maximum":100}}}),
+        },
+        ToolSpec {
+            name: "canary_targets",
+            description: "List configured HTTP uptime targets.",
+            input_schema: json!({"type":"object","properties":{}}),
+        },
+        ToolSpec {
+            name: "canary_monitors",
+            description: "List configured non-HTTP monitors and check-in watchers.",
+            input_schema: json!({"type":"object","properties":{}}),
+        },
+        ToolSpec {
             name: "canary_doctor",
             description: "Run the agent-oriented Canary doctor check.",
             input_schema: json!({"type":"object","properties":{}}),
+        },
+        ToolSpec {
+            name: "canary_witness",
+            description: "Inspect the external `canary-watchman` state and GitHub Actions receipt refs; replacement command: `bin/canary doctor --json | jq '.response.witness,.response.verdict.receipt_run_references'`.",
+            input_schema: json!({"type":"object","properties":{}}),
+        },
+        ToolSpec {
+            name: "canary_dr_status",
+            description: "Inspect DR/Litestream evidence surfaced by doctor; replacement command: `bin/canary doctor --json | jq '.response.dr'`.",
+            input_schema: json!({"type":"object","properties":{}}),
+        },
+        ToolSpec {
+            name: "canary_dogfood_audit",
+            description: "Run deployed-service dogfood coverage audit; strict mode exits nonzero after printing JSON gaps.",
+            input_schema: json!({"type":"object","properties":{"strict":{"type":"boolean","default":false}}}),
         },
         ToolSpec {
             name: "canary_event_capture",
@@ -2759,6 +3301,130 @@ mod tests {
         assert_eq!(report["status"], "configured");
         assert_eq!(report["monitor"], "canary-watchman");
         assert_eq!(report["mode"], "ttl");
+    }
+
+    #[test]
+    fn doctor_verdict_degrades_for_stale_down_watchman_even_when_routes_ready() {
+        let healthz = json!({"ok": true, "response": {"status": "ok"}});
+        let readyz = json!({"ok": true, "response": {"status": "ready"}});
+        let summary = json!({"ok": true, "summary": ["summary: Canary healthy"]});
+        let incidents = json!({
+            "ok": true,
+            "response": {
+                "incidents": [{
+                    "id": "INC-witness",
+                    "service": "canary",
+                    "state": "open",
+                    "title": "Canary witness failed"
+                }]
+            }
+        });
+        let canary_errors = json!({
+            "ok": true,
+            "response": {
+                "service": "canary",
+                "total_errors": 0
+            }
+        });
+        let witness = json!({
+            "status": "observed",
+            "monitor": "canary-watchman",
+            "state": "down",
+            "last_check_in_status": "alive",
+            "last_check_in_at": "2026-06-15T22:00:00Z",
+            "expected_every_ms": 600000
+        });
+        let worker_readiness = json!({
+            "available": true,
+            "status": "ready",
+            "worker_count": 5,
+            "failing_workers": 0,
+            "pressured_workers": 0,
+            "workers": []
+        });
+        let dogfood = json!({
+            "ok": true,
+            "response": {
+                "strict_failures": [
+                    {"kind": "missing_readback", "service": "vanity"},
+                    {"kind": "missing_target", "service": "linejam"}
+                ]
+            }
+        });
+        let receipt_runs = json!({
+            "ok": true,
+            "workflow": "Canary Witness",
+            "runs": [{
+                "databaseId": 123456,
+                "status": "completed",
+                "conclusion": "failure",
+                "url": "https://github.com/example/canary/actions/runs/123456",
+                "artifact_name": "canary-witness-123456"
+            }]
+        });
+
+        let verdict = doctor_verdict(
+            &healthz,
+            &readyz,
+            &summary,
+            &incidents,
+            &canary_errors,
+            &witness,
+            &worker_readiness,
+            &dogfood,
+            &receipt_runs,
+            1_781_561_520_000,
+        );
+
+        assert_eq!(verdict["overall"], "degraded");
+        assert_eq!(verdict["witness_age_ms"], 720000);
+        assert_eq!(verdict["open_canary_incident"]["id"], "INC-witness");
+        assert_eq!(verdict["dogfood_gap_count"], 2);
+        assert_eq!(
+            verdict["receipt_run_references"]["runs"][0]["artifact_name"],
+            "canary-witness-123456"
+        );
+        assert!(
+            verdict["blocking_signals"]
+                .as_array()
+                .is_some_and(|signals| signals.iter().any(|signal| signal
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("canary-watchman down")))
+        );
+        assert!(
+            verdict["next_operator_action"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("gh workflow run")
+        );
+    }
+
+    #[test]
+    fn worker_readiness_keeps_pressured_workers_separate_from_failures() {
+        let readyz = json!({
+            "ok": true,
+            "response": {
+                "status": "ready",
+                "checks": {
+                    "workers": [
+                        {"name": "webhook_delivery", "state": "started", "health": "pressured", "failure_count": 0, "due_count": 5, "oldest_due_age_ms": 120000},
+                        {"name": "target_probe", "state": "started", "health": "ok", "failure_count": 0}
+                    ]
+                }
+            }
+        });
+
+        let report = worker_readiness_report(&readyz);
+
+        assert_eq!(report["status"], "ready");
+        assert_eq!(report["worker_count"], 2);
+        assert_eq!(report["failing_workers"], 0);
+        assert_eq!(report["pressured_workers"], 1);
+        assert_eq!(
+            worker_readiness_summary(Some(&report)),
+            "ready 2 workers, 0 failing, 1 pressured"
+        );
     }
 
     #[test]

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -3,6 +3,7 @@
 use canary_cli::{
     dogfood_strict_failure_count, summarize_doctor, summarize_dogfood, summarize_incidents,
     summarize_monitors, summarize_query, summarize_report, summarize_targets, summarize_timeline,
+    tool_manifest,
 };
 use serde_json::{Value, json};
 
@@ -185,4 +186,102 @@ fn doctor_summary_flags_missing_restore_receipt_and_worker_health_schema() {
     assert!(lines.iter().any(
         |line| line == "worker_readiness: ready 1 workers, 1 failing, 1 missing health fields"
     ));
+}
+
+#[test]
+fn doctor_watchman_down_fixture_stays_actionable() -> Result<(), Box<dyn std::error::Error>> {
+    let value = fixture(include_str!("fixtures/doctor_watchman_down.json"))?;
+    let lines = summarize_doctor(&value);
+
+    assert_eq!(value["verdict"]["overall"], "degraded");
+    assert_eq!(value["verdict"]["witness_age_ms"], 720000);
+    assert_eq!(
+        value["verdict"]["open_canary_incident"]["id"],
+        "INC-witness"
+    );
+    assert!(
+        value["verdict"]["next_operator_action"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("gh workflow run")
+    );
+    assert!(lines.iter().any(|line| line
+        == "verdict: degraded; next: Run `gh workflow run \"Canary Witness\" --ref master`; then inspect the latest witness receipt and rerun `bin/canary doctor --json`."));
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("canary-watchman down"))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn doctor_summary_reports_worker_pressure_separately() {
+    let value = json!({
+        "endpoint": "https://canary.example",
+        "key": "CANARY_API_KEY: redacted",
+        "key_scope": "admin",
+        "reachability": {
+            "healthz": {"ok": true, "response": {"status": "ok"}},
+            "readyz": {"ok": true, "response": {"status": "ready"}}
+        },
+        "summary": {"ok": true, "summary": ["summary: Canary healthy"]},
+        "services": {"ok": true, "summary": ["summary: all surfaces healthy"]},
+        "witness": {"status": "observed", "monitor": "canary-watchman", "state": "up", "last_check_in_status": "alive", "last_check_in_at": "2026-06-15T22:00:00Z"},
+        "canary_errors": {"ok": true, "summary": ["summary: 0 errors in canary in the last 1h."]},
+        "incidents": {"ok": true, "summary": ["summary: 0 open incidents"]},
+        "dr": {
+            "status": {"ok": true, "stdout": "/data/canary.db: ok"},
+            "restore_receipt": {"ok": true, "path": "docs/architecture/restore-drill-evidence-2026-06-14.md"}
+        },
+        "dogfood": {"ok": true, "summary": ["covered: 4"]},
+        "worker_readiness": {
+            "available": true,
+            "status": "ready",
+            "worker_count": 2,
+            "failing_workers": 0,
+            "pressured_workers": 1,
+            "schema_missing_health_fields": 0,
+            "workers": [
+                {"name": "webhook_delivery", "state": "started", "health": "pressured", "failure_count": 0},
+                {"name": "target_probe", "state": "started", "health": "ok", "failure_count": 0}
+            ]
+        },
+        "verdict": {
+            "overall": "degraded",
+            "blocking_signals": ["worker pressure: webhook_delivery"],
+            "next_operator_action": "Inspect `/readyz` worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`."
+        }
+    });
+
+    let lines = summarize_doctor(&value);
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "worker_readiness: ready 2 workers, 0 failing, 1 pressured")
+    );
+    assert!(lines.iter().any(|line| line
+        == "verdict: degraded; next: Inspect `/readyz` worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`."));
+}
+
+#[test]
+fn mcp_manifest_exposes_operator_drilldowns() {
+    let names = tool_manifest()
+        .iter()
+        .map(|tool| tool.name)
+        .collect::<std::collections::BTreeSet<_>>();
+
+    for name in [
+        "canary_services",
+        "canary_incidents",
+        "canary_timeline",
+        "canary_targets",
+        "canary_monitors",
+        "canary_dogfood_audit",
+        "canary_witness",
+        "canary_dr_status",
+    ] {
+        assert!(names.contains(name), "missing {name}");
+    }
 }

--- a/crates/canary-cli/tests/fixtures/doctor_watchman_down.json
+++ b/crates/canary-cli/tests/fixtures/doctor_watchman_down.json
@@ -1,0 +1,141 @@
+{
+  "endpoint": "https://canary.example",
+  "key": "CANARY_API_KEY: redacted",
+  "key_scope": "admin",
+  "reachability": {
+    "healthz": {
+      "ok": true,
+      "response": {
+        "status": "ok"
+      }
+    },
+    "readyz": {
+      "ok": true,
+      "response": {
+        "status": "ready"
+      }
+    }
+  },
+  "summary": {
+    "ok": true,
+    "summary": [
+      "summary: Canary healthy"
+    ]
+  },
+  "services": {
+    "ok": true,
+    "summary": [
+      "summary: Canary has degraded surfaces"
+    ]
+  },
+  "witness": {
+    "status": "observed",
+    "monitor": "canary-watchman",
+    "state": "down",
+    "last_check_in_status": "alive",
+    "last_check_in_at": "2026-06-15T22:00:00Z",
+    "expected_every_ms": 600000
+  },
+  "canary_errors": {
+    "ok": true,
+    "summary": [
+      "summary: 0 errors in canary in the last 1h."
+    ],
+    "response": {
+      "service": "canary",
+      "total_errors": 0
+    }
+  },
+  "incidents": {
+    "ok": true,
+    "summary": [
+      "summary: 1 open incident"
+    ],
+    "response": {
+      "incidents": [
+        {
+          "id": "INC-witness",
+          "service": "canary",
+          "state": "open",
+          "title": "Canary witness failed",
+          "opened_at": "2026-06-15T22:10:00Z"
+        }
+      ]
+    }
+  },
+  "dr": {
+    "status": {
+      "ok": true,
+      "stdout": "/data/canary.db: ok"
+    },
+    "restore_receipt": {
+      "ok": true,
+      "path": "docs/architecture/restore-drill-evidence-2026-06-14.md"
+    }
+  },
+  "dogfood": {
+    "ok": true,
+    "summary": [
+      "covered: 4",
+      "strict_failures: 2"
+    ],
+    "response": {
+      "strict_failures": [
+        {
+          "kind": "missing_readback",
+          "service": "vanity"
+        },
+        {
+          "kind": "missing_target",
+          "service": "linejam"
+        }
+      ]
+    }
+  },
+  "worker_readiness": {
+    "available": true,
+    "status": "ready",
+    "worker_count": 5,
+    "failing_workers": 0,
+    "pressured_workers": 0,
+    "schema_missing_health_fields": 0,
+    "workers": []
+  },
+  "verdict": {
+    "overall": "degraded",
+    "blocking_signals": [
+      "canary-watchman down; last alive check-in was 720000 ms ago",
+      "open Canary incident INC-witness: Canary witness failed"
+    ],
+    "next_operator_action": "Run `gh workflow run \"Canary Witness\" --ref master`; then inspect the latest witness receipt and rerun `bin/canary doctor --json`.",
+    "witness_age_ms": 720000,
+    "open_canary_incident": {
+      "id": "INC-witness",
+      "service": "canary",
+      "state": "open",
+      "title": "Canary witness failed"
+    },
+    "worker_pressure": {
+      "status": "ready",
+      "pressured_workers": 0,
+      "failing_workers": 0,
+      "workers": []
+    },
+    "dogfood_gap_count": 2,
+    "receipt_run_references": {
+      "ok": true,
+      "workflow": "Canary Witness",
+      "command": "gh run list --workflow \"Canary Witness\" --branch master --limit 3 --json databaseId,status,conclusion,createdAt,updatedAt,url,event,workflowName",
+      "artifact_name_pattern": "canary-witness-<run_id>",
+      "runs": [
+        {
+          "databaseId": 123456,
+          "status": "completed",
+          "conclusion": "failure",
+          "url": "https://github.com/example/canary/actions/runs/123456",
+          "artifact_name": "canary-witness-123456"
+        }
+      ]
+    }
+  }
+}

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -69,11 +69,60 @@ nonzero when coverage gaps remain, so agents can inspect the failure details.
 `doctor` is the fastest "who watches Canary?" command. It probes `/healthz`,
 `/readyz`, the global report, service status, incidents, dogfood coverage,
 recent `service=canary` errors, worker lifecycle readiness, and the external
-`canary-watchman` monitor created by `bin/canary-witness`. The worker readiness
-line is derived from `/readyz` and should look like:
+`canary-watchman` monitor created by `bin/canary-witness`.
+
+The doctor envelope's `response` object includes an operator verdict:
+
+```json
+{
+  "verdict": {
+    "overall": "degraded",
+    "blocking_signals": [
+      "canary-watchman down; last alive check-in was 720000 ms ago"
+    ],
+    "next_operator_action": "Run `gh workflow run \"Canary Witness\" --ref master`; then inspect the latest witness receipt and rerun `bin/canary doctor --json`.",
+    "witness_age_ms": 720000,
+    "open_canary_incident": {
+      "id": "INC-example",
+      "service": "canary",
+      "state": "open"
+    },
+    "worker_pressure": {
+      "status": "ready",
+      "pressured_workers": 0,
+      "failing_workers": 0,
+      "workers": []
+    },
+    "dogfood_gap_count": 3,
+    "receipt_run_references": {
+      "ok": true,
+      "workflow": "Canary Witness",
+      "runs": []
+    }
+  }
+}
+```
+
+`overall` is `healthy` only when the public routes are reachable, authenticated
+readback works, the external witness is observed as up, no `service=canary`
+incident is open, and workers are not failing or pressured. `degraded` means an
+agent can still inspect Canary but has work to do. `unable` means Canary cannot
+produce enough authenticated self-watch evidence to trust the rest of the
+report. Dogfood gaps are counted in the verdict but are not by themselves a
+runtime blocker.
+
+The worker readiness line is derived from `/readyz` and should look like:
 
 ```text
 worker_readiness: ready 5 workers, 0 failing
+```
+
+If a worker reports `health: pressured`, the route can still be ready. Doctor
+reports that as operational pressure rather than counting the same worker as
+both ready and failing:
+
+```text
+worker_readiness: ready 5 workers, 0 failing, 1 pressured
 ```
 
 `doctor` also surfaces DR evidence:
@@ -99,6 +148,16 @@ The witness line is:
 
 The witness runbook and GitHub Actions receipt contract live in
 `docs/canary-witness.md`.
+
+Doctor discovers the latest GitHub Actions witness runs with:
+
+```bash
+gh run list --workflow "Canary Witness" --branch master --limit 3 --json databaseId,status,conclusion,createdAt,updatedAt,url,event,workflowName
+```
+
+If the GitHub CLI or auth is unavailable, the verdict still returns the
+replacement command plus the receipt artifact convention
+`canary-witness-<run_id>`.
 
 ## Integration Agent
 
@@ -148,3 +207,10 @@ secret-manager handoff.
 `bin/canary mcp-manifest` emits the generated tool manifest. MCP tools should shell
 out to the CLI and reuse the same JSON schemas rather than reimplementing route
 semantics.
+
+The manifest covers the drill-down surfaces an agent needs after
+`canary_doctor`: summary, services, errors, incidents, timeline, targets,
+monitors, dogfood audit, witness, DR status, event capture, remediation claims,
+and integration discovery/status/plan/patch/enroll. If a future MCP server does
+not implement a tool directly, it must preserve the manifest replacement
+command so agents can shell out to the CLI.

--- a/docs/architecture/self-watch-operator-verdict-2026-06-15.html
+++ b/docs/architecture/self-watch-operator-verdict-2026-06-15.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Canary Self-Watch Operator Verdict</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #182016;
+      --muted: #5d6559;
+      --line: #cfd6c9;
+      --paper: #f8faf5;
+      --panel: #ffffff;
+      --accent: #1b6f5f;
+      --warn: #a15300;
+      --bad: #9b1c31;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--paper);
+      color: var(--ink);
+      line-height: 1.45;
+    }
+    main {
+      width: min(1180px, calc(100vw - 48px));
+      margin: 0 auto;
+      padding: 40px 0 56px;
+    }
+    header {
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+      gap: 28px;
+      align-items: start;
+      padding-bottom: 28px;
+      border-bottom: 1px solid var(--line);
+    }
+    h1 {
+      margin: 0 0 16px;
+      font-size: 42px;
+      line-height: 1.04;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 0 0 12px;
+      font-size: 18px;
+      letter-spacing: 0;
+    }
+    p { margin: 0 0 12px; }
+    .summary {
+      font-size: 18px;
+      color: var(--muted);
+      max-width: 760px;
+    }
+    .panel, .callout {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+      margin-top: 28px;
+    }
+    .wide { grid-column: span 2; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+      background: #eef3ea;
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+    ul { margin: 0; padding-left: 20px; }
+    li + li { margin-top: 7px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      border-top: 1px solid var(--line);
+      padding: 10px 8px;
+    }
+    th { color: var(--muted); font-weight: 650; }
+    .tag {
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      color: var(--muted);
+      margin-right: 6px;
+    }
+    .bad { color: var(--bad); }
+    .warn { color: var(--warn); }
+    @media (max-width: 850px) {
+      header, .grid { grid-template-columns: 1fr; }
+      .wide { grid-column: auto; }
+      main { width: min(100vw - 28px, 1180px); padding-top: 24px; }
+      h1 { font-size: 32px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <section>
+      <span class="tag">Backlog 045</span><span class="tag">operator surface</span><span class="tag">agent-first</span>
+      <h1>Self-Watch Operator Verdict</h1>
+      <p class="summary">
+        Make <code>bin/canary doctor</code> answer the first operator question:
+        can Canary watch itself right now, what evidence proves that, and what
+        should the next agent do without opening a dashboard?
+      </p>
+    </section>
+    <aside class="callout">
+      <h2>Chosen Design</h2>
+      <p>
+        Add one derived <code>doctor.verdict</code> object assembled from the
+        existing doctor probes. Keep HTTP routes, store writes, workers, and the
+        witness runtime unchanged.
+      </p>
+      <p>
+        This keeps the interface deep: callers ask one question and receive a
+        compact control-tower answer, while detailed probe evidence remains
+        available underneath.
+      </p>
+    </aside>
+  </header>
+
+  <section class="grid">
+    <article class="panel">
+      <h2>Outcome</h2>
+      <ul>
+        <li><code>doctor --json</code> includes <code>verdict.overall</code>, blocking signals, witness age, open Canary incident, worker pressure, dogfood gap count, receipt/run refs, and next action.</li>
+        <li><code>doctor</code> text prints a compact verdict and keeps existing probe lines.</li>
+        <li>Worker <code>pressured</code> means ready with operational pressure, not double-counted as failed.</li>
+      </ul>
+    </article>
+    <article class="panel">
+      <h2>Assumptions</h2>
+      <ul>
+        <li>The CLI may shell out for operator evidence, as it already does for DR and dogfood inventory.</li>
+        <li>GitHub Actions witness run discovery is best-effort and must fail open with the replacement command.</li>
+        <li>Open incidents for service <code>canary</code> are self-watch blockers; unrelated service incidents stay visible below the verdict.</li>
+      </ul>
+    </article>
+    <article class="panel">
+      <h2>Stop Conditions</h2>
+      <ul>
+        <li>The verdict can be produced without a new server route or schema migration.</li>
+        <li>Fixture tests cover stale witness, worker pressure, MCP drill-down names, and live-shape actionability.</li>
+        <li>Live <code>bin/canary doctor --json</code> and text output produce usable operator guidance.</li>
+      </ul>
+    </article>
+
+    <article class="panel wide">
+      <h2>Verification Surface</h2>
+      <table>
+        <thead>
+          <tr><th>Layer</th><th>Command or artifact</th><th>What it proves</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Red test</td><td><code>cargo test -p canary-cli doctor_</code></td><td>Verdict semantics fail before implementation and pass after.</td></tr>
+          <tr><td>CLI fixtures</td><td><code>cargo test -p canary-cli --test fixtures</code></td><td>Text summary and manifest stay agent-readable.</td></tr>
+          <tr><td>Repo gate</td><td><code>./bin/validate</code></td><td>Full local acceptance across Rust, TS client, scripts, Docker smoke, and scans.</td></tr>
+          <tr><td>Live QA</td><td><code>bin/canary doctor --json</code>, <code>bin/canary doctor</code>, <code>bin/canary mcp-manifest</code></td><td>Production Canary reports a real operator verdict without secret leakage.</td></tr>
+          <tr><td>Fresh review</td><td>Diff plus ticket oracle only</td><td>Critic tries to refute semantics, security, and agent usability before landing.</td></tr>
+        </tbody>
+      </table>
+    </article>
+
+    <article class="panel">
+      <h2>Risks</h2>
+      <ul>
+        <li><span class="warn">Clock parsing:</span> witness age needs RFC3339 parsing and must degrade to <code>null</code> rather than panic.</li>
+        <li><span class="warn">GH auth:</span> witness run discovery may be unavailable locally; verdict must still include commands.</li>
+        <li><span class="bad">False health:</span> a ready route with down witness is not healthy; the verdict must prefer self-watch evidence.</li>
+      </ul>
+    </article>
+    <article class="panel wide">
+      <h2>Alternatives Rejected</h2>
+      <table>
+        <thead><tr><th>Alternative</th><th>Why not now</th></tr></thead>
+        <tbody>
+          <tr><td>New server endpoint</td><td>Broadens production surface for a derived operator view that the CLI can compute from existing routes.</td></tr>
+          <tr><td>Dashboard-first UI</td><td>The first citizen is an agent; CLI JSON is lower friction and easier to MCP-wrap.</td></tr>
+          <tr><td>Webhook to Bitterblossom first</td><td>Downstream triage is separate backlog work. Canary still needs to expose the watch state cleanly.</td></tr>
+        </tbody>
+      </table>
+    </article>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an agent-readable `bin/canary doctor` verdict with overall health, blocking signals, next operator action, witness age, open Canary incident, worker pressure, dogfood gap count, and GitHub witness receipt references
- keep pressured workers separate from failing workers so `/readyz` can stay route-ready while the verdict still surfaces operator pressure
- expose Canary operator drilldowns in the MCP manifest for services, incidents, timeline, targets, monitors, witness, DR status, and dogfood audit

## Verification
- `cargo test -p canary-cli --locked`
- `PATH=/tmp/canary-dagger-0.20.5:$PATH ./bin/validate`
- `PATH=/tmp/canary-dagger-0.20.5:$PATH git push -u origin cx/045-self-watch-verdict` (strict pre-push gate)
- live `bin/canary doctor --json` and `bin/canary doctor` against production
- live `bin/canary mcp-manifest` drilldown listing

## Review and QA
- fresh QA verifier: no blocking findings; CLI tests and live doctor/manifest smoke passed
- fresh implementation critic: no blocking findings; non-blocking docs/action-copy suggestions applied

## Production signal
The current production doctor verdict reports `degraded` because the existing canary-watchman check-in is stale, there is an open Canary incident, and `monitor_overdue` is pressured. That is pre-existing live dogfood signal and is the new operator oracle doing its job, not a branch-introduced route failure. The post-merge closeout should rerun the witness workflow and production doctor after deploy.