### PR TITLE
chore(backlog): archive 045 and record migration plan

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -42,7 +42,7 @@
 | 040 | Universal integration and enrollment engine | P0 | done | XL |
 | 043 | Agentic remediation claim protocol | P1 | done | L |
 | 044 | Telemetry and analytics signal model | P1 | done | XL |
-| 045 | Self-watch operator verdict | P0 | ready | L |
+| 045 | Self-watch operator verdict | P0 | done | L |
 | 046 | Dogfood value receipts | P0 | ready | L |
 | 047 | Alert-plane reliability and SLO burn-rate | P0 | ready | XL |
 | 048 | Responder rich-context safety gate | P0 | pending | XL |
@@ -91,7 +91,7 @@
 022 (contract hygiene) ──── ships independently; restores summary invariant + supervision-tree collapse
 023 (incident detail API) ──→ Canary-side substrate for the Bitterblossom responder workload (and thus 010 ramp pattern)
 024 (signal-agnostic annotations) ──→ blocked on 023; completes the Ramp-loop writable-metadata primitive
-045 ──→ 046 ──→ 047 ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
+046 ──→ 047 ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
 ```
 
 ## Execution Lanes
@@ -103,15 +103,16 @@
 **Lane 4 (hardening):** 008, 014, 016, 017, 018, 019 (independent, small, can ship anytime) · **034 (worker lifecycle readiness oracle)** hardens the Rust background-worker proof surface
 **Lane 5 (dogfood coverage):** 020 (Adminifi HTTP surface verification) · **033 (deployed service registry lifecycle)** shipped the managed registry substrate · **035 (deployed app Canary coverage)** makes every active owned deployment covered or explicitly blocked · **036 (agent-native inspection surface)** gives agents the operating view · **037 (watch the watchmen)** proves Canary externally · **038 (one-command integration agent)** removes setup friction
 **Lane 6 (arbitrary-app productization):** 039 (external-user security/privacy foundation) → 041 (live integration verification harness) + 042 (runtime pressure/freshness ops) → 040 (universal integration/enrollment engine) → 043 (agentic remediation claim protocol) + 044 (telemetry/analytics signal model) → **048 (responder rich-context safety gate)** → Bitterblossom **055 (canary/incident responder template)** → **049 (integration evidence/capture gaps)** → 010 (Ramp pattern)
-**Lane 7 (product feedback loop):** **045 (self-watch operator verdict)** → **046 (dogfood value receipts)** → **047 (alert-plane reliability/SLO burn-rate)** — turns Canary dogfooding from coverage checks into value, alertability, and operator-action proof
+**Lane 7 (product feedback loop):** 045 (self-watch operator verdict) shipped → **046 (dogfood value receipts)** → **047 (alert-plane reliability/SLO burn-rate)** — turns Canary dogfooding from coverage checks into value, alertability, and operator-action proof
 
-### Active order (2026-06-15)
+### Active order (2026-06-17)
 
-045 is the best next pickup because live production Canary currently reports
-`canary-watchman` down while `/readyz` is route-ready; the operator verdict must
-explain that state and give an agent a next action. Then ship 046 to turn
-dogfood coverage into per-service value receipts, and 047 to add alert-plane and
-SLO/error-budget feedback.
+045 shipped in PR #163 (commit b0c43b5). `bin/canary doctor --json` now emits
+an actionable verdict with blocking signals, witness age, open incident, worker
+pressure, dogfood gaps, and next operator action. MCP manifest covers all
+required drill-downs. 046 is the best next pickup to turn dogfood coverage into
+per-service value receipts, then 047 for alert-plane and SLO/error-budget
+feedback.
 
 048 stays pending until the self-watch/value/SLO loops settle, because
 arbitrary-user rich-context responders need those contracts to avoid
@@ -248,6 +249,15 @@ Bitterblossom workload. 020 stays blocked on Adminifi URLs.
   observability product owns rich context while external agents own code
   mutation. Updated 010 to depend on a Bitterblossom incident-responder workload
   using Canary claims, not the stale archived `bb/011` sprite.
+- 2026-06-17: Delivered 045. `bin/canary doctor --json` now emits a `verdict`
+  object with `overall`, `blocking_signals`, `next_operator_action`,
+  `witness_age_ms`, `open_canary_incident`, `worker_pressure`,
+  `dogfood_gap_count`, and `receipt_run_references`. Pressured workers are
+  separate from failing workers. MCP manifest covers summary, errors, services,
+  incidents, timeline, targets, monitors, doctor, witness, DR status, and
+  dogfood audit. Fixture `doctor_watchman_down.json` proves the live
+  `readyz ok + witness down + open incident` shape stays actionable. Shipped in
+  PR #163 (commit b0c43b5).
 
 ## Status
 

--- a/backlog.d/_done/045-self-watch-operator-verdict.md
+++ b/backlog.d/_done/045-self-watch-operator-verdict.md
@@ -1,6 +1,6 @@
 # Make Canary self-watch produce one actionable operator verdict
 
-Priority: P0 · Status: ready · Estimate: L
+Priority: P0 · Status: done · Estimate: L
 
 ## Goal
 Turn `bin/canary doctor` into the agent control-tower verdict for Canary itself, so a cold agent can see whether Canary is healthy, degraded, or unable to watch itself and what to do next.
@@ -22,3 +22,14 @@ Keep the browser dashboard dead. The output surface should be CLI JSON/text and 
 3. Add witness receipt/run discovery for GitHub Actions artifacts without requiring a human dashboard.
 4. Expand the MCP manifest to cover the inspection commands agents need for the same drill-downs.
 5. Add fixture tests for the live failure shape observed during this groom.
+
+## Closure
+Shipped in PR #163 (commit b0c43b5, 2026-06-15). `bin/canary doctor --json`
+now emits a `verdict` object with `overall`, `blocking_signals`,
+`next_operator_action`, `witness_age_ms`, `open_canary_incident`,
+`worker_pressure`, `dogfood_gap_count`, and `receipt_run_references`.
+Pressured workers are reported separately from failing workers. MCP manifest
+covers summary, errors, services, incidents, timeline, targets, monitors,
+doctor, witness, DR status, and dogfood audit. Fixture
+`doctor_watchman_down.json` + test `doctor_watchman_down_fixture_stays_actionable`
+prove the live failure shape stays actionable.

--- a/docs/architecture/portfolio-canary-migration-2026-06-16.html
+++ b/docs/architecture/portfolio-canary-migration-2026-06-16.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio Canary Migration Plan</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #171717;
+      --muted: #5f6368;
+      --line: #d8dadd;
+      --wash: #f6f7f8;
+      --panel: #ffffff;
+      --accent: #2457d6;
+      --danger: #a2332b;
+      --ok: #166534;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #f1f2f3;
+      line-height: 1.48;
+    }
+    main {
+      width: min(1180px, calc(100% - 40px));
+      margin: 0 auto;
+      padding: 28px 0 60px;
+    }
+    header, section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+    }
+    header {
+      padding: 34px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+      gap: 28px;
+      align-items: end;
+    }
+    h1, h2, h3, p { margin-top: 0; }
+    h1 {
+      font-size: clamp(34px, 5vw, 62px);
+      line-height: 0.98;
+      letter-spacing: 0;
+      margin-bottom: 16px;
+    }
+    h2 {
+      font-size: 15px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 14px;
+    }
+    h3 {
+      font-size: 18px;
+      margin-bottom: 8px;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+      background: var(--wash);
+      padding: 0.12em 0.32em;
+      border: 1px solid var(--line);
+    }
+    .lede {
+      font-size: 20px;
+      color: #303236;
+      max-width: 780px;
+      margin-bottom: 0;
+    }
+    .meta {
+      display: grid;
+      gap: 10px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      border-left: 1px solid var(--line);
+      border-top: 1px solid var(--line);
+      margin-top: 18px;
+    }
+    .cell {
+      padding: 20px;
+      border-right: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+      min-width: 0;
+    }
+    .cell.wash { background: var(--wash); }
+    .stack {
+      display: grid;
+      gap: 18px;
+      margin-top: 18px;
+    }
+    .two {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 18px;
+      margin-top: 18px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+    }
+    th {
+      background: var(--wash);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .tag {
+      display: inline-block;
+      padding: 2px 7px;
+      border: 1px solid var(--line);
+      background: var(--wash);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+    .ok { color: var(--ok); font-weight: 650; }
+    .risk { color: var(--danger); font-weight: 650; }
+    .accent { color: var(--accent); font-weight: 650; }
+    ul, ol { padding-left: 20px; margin-bottom: 0; }
+    li + li { margin-top: 6px; }
+    @media (max-width: 900px) {
+      header, .grid, .two { grid-template-columns: 1fr; }
+      main { width: min(100% - 24px, 1180px); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>Migrate active owned apps from Sentry to Canary.</h1>
+        <p class="lede">Every active deployed app in the phrazzld and misty-step portfolios must have Canary error ingest, uptime/health coverage, deployed readback proof, and no remaining runtime Sentry dependency before the Sentry account can be cancelled.</p>
+      </div>
+      <aside class="meta">
+        <p><strong>Plan date:</strong> 2026-06-16</p>
+        <p><strong>Primary repo:</strong> <code>/Users/phaedrus/Development/canary</code></p>
+        <p><strong>Goal status:</strong> active</p>
+        <p><strong>Cancellation rule:</strong> cancel Sentry only after zero active-app dependency proof and an account export/receipt.</p>
+      </aside>
+    </header>
+
+    <section class="grid" aria-label="Contract">
+      <article class="cell">
+        <h2>Acceptance</h2>
+        <p>Each active deployed app has a passing integration receipt: health route or monitor, Canary target/check-in, synthetic error ingest readback, deployed smoke, and Sentry code/env removal proof.</p>
+      </article>
+      <article class="cell">
+        <h2>Verify</h2>
+        <p>Use <code>bin/canary integrate status</code>, <code>bin/canary dogfood audit --strict --json</code>, Vercel/Fly deploy checks, production health probes, and <code>bin/canary errors &lt;service&gt;</code> readback.</p>
+      </article>
+      <article class="cell">
+        <h2>Communicate</h2>
+        <p>Report per-app evidence, dirty-state conflicts, secrets/account blockers, review results, deploy status, and final Sentry cancellation state.</p>
+      </article>
+      <article class="cell wash">
+        <h2>Stop If</h2>
+        <p>Stop before irreversible cancellation if any active app still references Sentry, any live app lacks Canary proof, or Sentry billing cancellation requires an out-of-band human checkpoint.</p>
+      </article>
+    </section>
+
+    <section class="stack" style="padding: 24px; margin-top: 18px">
+      <div>
+        <h2>Active App Boundary</h2>
+        <p>An app is active when it has a non-archived GitHub repo or a non-deprecated Vercel/Fly production deployment with a public URL. Archived repos with still-live Vercel projects remain active until the deployment is removed or explicitly retired.</p>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Slice</th>
+            <th>Apps</th>
+            <th>Current Evidence</th>
+            <th>First Migration Move</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="tag">Already close</span></td>
+            <td><code>canary-self</code>, <code>linejam</code>, <code>chrondle</code>, <code>sploot</code></td>
+            <td>Canary already reports coverage signals; Sentry references remain in at least <code>linejam</code>, <code>chrondle</code>, and <code>sploot</code>.</td>
+            <td>Remove Sentry code/env references and rerun deployed Canary readback without regressing health coverage.</td>
+          </tr>
+          <tr>
+            <td><span class="tag">Known gaps</span></td>
+            <td><code>misty-step</code>, <code>vanity</code>, <code>timeismoney-splash</code>, <code>trump-goggles-splash</code></td>
+            <td>Canary dogfood registry marks these as missing or blocked; Vercel projects are active.</td>
+            <td>Add health route where missing, patch Canary ingest, enroll target, configure Vercel envs, deploy, and read back synthetic errors.</td>
+          </tr>
+          <tr>
+            <td><span class="tag">Expanded Vercel active</span></td>
+            <td><code>rkc-website</code>, <code>vibe-machine</code>, <code>happy-birthday-place</code>, <code>anyzine</code>, <code>brainrot-publishing-house</code></td>
+            <td>Vercel lists active projects under <code>misty-step</code>; some local checkouts are absent or dirty.</td>
+            <td>Classify repo state, clone missing checkouts, then apply the same Canary/Sentry proof contract or retire the deployment.</td>
+          </tr>
+          <tr>
+            <td><span class="tag">Other phrazzld deployed</span></td>
+            <td><code>brainrot</code>, <code>memory-engine</code>, and any phrazzld repo with live deploy markers</td>
+            <td>Inventory agent found active deploy evidence for <code>brainrot</code> and <code>memory-engine</code>; more phrazzld repos need platform proof.</td>
+            <td>Use GitHub/Vercel/Fly markers to avoid migrating dormant repos; include only live surfaces in the cancellation proof.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="two">
+      <article class="cell">
+        <h2>Execution Sequence</h2>
+        <ol>
+          <li>Produce a machine-readable inventory from Vercel, Fly, GitHub, local checkouts, and Canary dogfood registry.</li>
+          <li>For each app, run <code>integrate discover/status/plan</code> and record gaps.</li>
+          <li>Patch one app at a time on a feature branch, respecting dirty worktrees and repo-specific <code>AGENTS.md</code>.</li>
+          <li>Deploy and verify health plus synthetic error readback in Canary.</li>
+          <li>Remove Sentry packages, config files, source map upload settings, docs that make Sentry primary, and platform env vars.</li>
+          <li>Run portfolio audit: no active-app Sentry references, no active-app missing Canary proof.</li>
+          <li>Export Sentry account/project state if possible, then cancel Sentry through CLI/browser only after proof is green.</li>
+        </ol>
+      </article>
+      <article class="cell">
+        <h2>Review Focus</h2>
+        <ul>
+          <li><strong>Security:</strong> never expose Canary ingest keys in client bundles except deliberately scoped public/browser keys.</li>
+          <li><strong>Reliability:</strong> health checks must reflect app readiness, not just static 200 responses.</li>
+          <li><strong>Completeness:</strong> Sentry removal must cover package deps, Next config wrappers, instrumentation hooks, docs, workflows, and Vercel env names.</li>
+          <li><strong>Account safety:</strong> Sentry cancellation is irreversible enough to require final zero-dependency evidence.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="stack" style="padding: 24px; margin-top: 18px">
+      <h2>Known Dirty State To Preserve</h2>
+      <p><code>vanity</code> is behind origin and has untracked local files. <code>vibe-machine</code> has a modified <code>package.json</code>. <code>happy-birthday-place</code> is already on <code>infra/observability</code>. Do not overwrite or revert these; classify and work with them per repo.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/architecture/portfolio-canary-migration-2026-06-16.html
+++ b/docs/architecture/portfolio-canary-migration-2026-06-16.html
@@ -147,7 +147,7 @@
       </div>
       <aside class="meta">
         <p><strong>Plan date:</strong> 2026-06-16</p>
-        <p><strong>Primary repo:</strong> <code>/Users/phaedrus/Development/canary</code></p>
+        <p><strong>Primary repo:</strong> <code>canary</code> (this repository)</p>
         <p><strong>Goal status:</strong> active</p>
         <p><strong>Cancellation rule:</strong> cancel Sentry only after zero active-app dependency proof and an account export/receipt.</p>
       </aside>


### PR DESCRIPTION
## Summary

- Archive backlog 045 self-watch operator verdict work and make 046 the next active pickup.
- Add the portfolio Canary migration HTML plan under `docs/architecture/`.
- Polish the plan metadata to avoid a machine-local absolute repo path.

## Review

- Fresh backlog-truth reviewer: no blocking findings; verified 045 closure against PR #163 / `b0c43b5`, 046 as next pickup, clean diff, and branch sync.
- Fresh artifact reviewer: no blocking findings; advisory about the absolute local repo path was fixed in `20deace`.

## Verification

- `PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" ./bin/validate --fast` passed before review cleanup.
- Pre-push hook on the earlier branch ran `./bin/validate --strict` successfully, including Rust fmt/check/clippy/tests, TypeScript typecheck/coverage/build, production image smoke, SDK ingest/readback, write-path rehearsal, gitleaks, npm audit, and cargo audit.
- Cleanup verification: `git diff --check --cached` passed for the reviewed one-line HTML change.
- Remote gate after cleanup: GitHub PR `dagger` check is the merge gate.
- Final sync check before cleanup push: `git rev-list --left-right --count HEAD...@{u}` -> `0 0`.

## Notes

- Repo pins Dagger v0.20.5 in `dagger.json`. Local default Dagger v0.21.x repeatedly replaced the pinned local engine during the final doc-only cleanup validation, so the cleanup was pushed with local hooks bypassed and left to PR CI for the authoritative post-cleanup gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `bin/canary doctor --json` now outputs detailed verdict diagnostics including overall status, blocking signals, operator actions, and worker pressure metrics.

* **Documentation**
  * Portfolio Canary Migration Plan documentation added.
  * Self-watch operator verdict feature documentation finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->