### PR TITLE
fix(witness): set explicit check-in ttl

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       CANARY_WITNESS_ENDPOINT: https://canary-obs.fly.dev
       CANARY_WITNESS_MONITOR: canary-watchman
+      CANARY_WITNESS_TTL_MS: "7200000"
       CANARY_WITNESS_READ_KEY: ${{ secrets.CANARY_WITNESS_READ_KEY }}
       CANARY_WITNESS_INGEST_KEY: ${{ secrets.CANARY_WITNESS_INGEST_KEY }}
       ISSUE_LABEL: canary-witness-failed

--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -8,6 +8,7 @@ INGEST_API_KEY="${CANARY_WITNESS_INGEST_KEY:-${CANARY_INGEST_API_KEY:-${CANARY_A
 MONITOR="${CANARY_WITNESS_MONITOR:-canary-watchman}"
 WINDOW="${CANARY_WITNESS_WINDOW:-1h}"
 RECEIPT="${CANARY_WITNESS_RECEIPT:-canary-witness-receipt.json}"
+CHECK_IN_TTL_MS="${CANARY_WITNESS_TTL_MS:-}"
 CURL_BIN="${CANARY_WITNESS_CURL:-curl}"
 TIMEOUT_SECONDS="${CANARY_WITNESS_TIMEOUT_SECONDS:-10}"
 REQUIRE_CHECK_IN=0
@@ -15,7 +16,7 @@ JSON_OUTPUT=0
 
 usage() {
   cat <<'EOF'
-Usage: bin/canary-witness [--endpoint <url>] [--read-api-key <key>] [--ingest-api-key <key>] [--monitor <name>] [--window <window>] [--receipt <path>] [--require-check-in] [--json] [-h|--help]
+Usage: bin/canary-witness [--endpoint <url>] [--read-api-key <key>] [--ingest-api-key <key>] [--monitor <name>] [--window <window>] [--receipt <path>] [--ttl-ms <millis>] [--require-check-in] [--json] [-h|--help]
 
 Check Canary from outside the Fly app and preserve a receipt even when Canary is
 unreachable. The witness verifies:
@@ -50,6 +51,17 @@ now_utc() {
   date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
+validate_positive_millis() {
+  local name="$1" value="$2"
+  if [[ -z "$value" ]]; then
+    return 0
+  fi
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'canary-witness: %s must be a positive integer number of milliseconds\n' "$name" >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --endpoint)
@@ -82,6 +94,11 @@ while [[ $# -gt 0 ]]; do
       RECEIPT="$2"
       shift 2
       ;;
+    --ttl-ms)
+      [[ $# -ge 2 ]] || fail_usage
+      CHECK_IN_TTL_MS="$2"
+      shift 2
+      ;;
     --require-check-in)
       REQUIRE_CHECK_IN=1
       shift
@@ -100,6 +117,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+validate_positive_millis "ttl-ms" "$CHECK_IN_TTL_MS"
 require_command jq
 require_command "$CURL_BIN"
 
@@ -257,6 +275,7 @@ fi
 
 if [[ "$status" == "healthy" ]]; then
   total_errors="$(jq -r '.response.total_errors // 0' "$query_file")"
+  ttl_ms_json="${CHECK_IN_TTL_MS:-null}"
   context="$(
     jq -n \
       --arg endpoint "$ENDPOINT" \
@@ -278,6 +297,7 @@ if [[ "$status" == "healthy" ]]; then
       --arg monitor "$MONITOR" \
       --arg observed_at "$observed_at" \
       --arg summary "Canary witness saw healthy self-signals and ${total_errors} recent canary errors." \
+      --argjson ttl_ms "$ttl_ms_json" \
       --argjson context "$context" \
       '{
         monitor: $monitor,
@@ -285,7 +305,7 @@ if [[ "$status" == "healthy" ]]; then
         observed_at: $observed_at,
         summary: $summary,
         context: $context
-      }'
+      } + (if $ttl_ms == null then {} else {ttl_ms: $ttl_ms} end)'
   )"
   request_json "check-in" "POST" "/api/v1/check-ins" "ingest" "$check_in_file" "$check_in_payload"
 else

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -4,9 +4,10 @@ Canary monitors itself from two directions:
 
 - Inside Canary, the `canary-self` HTTP target checks
   `https://canary-obs.fly.dev/healthz`.
-- Outside Canary, the scheduled GitHub Actions witness runs
-  `bin/canary-witness` every five minutes and preserves a JSON receipt as a
-  workflow artifact.
+- Outside Canary, the scheduled GitHub Actions witness asks to run every five
+  minutes and preserves a JSON receipt as a workflow artifact. GitHub cron is
+  best-effort, so the production workflow sends a two-hour `ttl_ms` check-in
+  to avoid false witness-down incidents when scheduled runs are delayed.
 
 The external witness is intentionally a shell script rather than a Rust service
 because the production substrate is GitHub Actions cron. Avoiding a scheduled
@@ -34,7 +35,9 @@ When all three signals are healthy, the witness sends an ingest check-in:
 ```
 
 The check-in proves Canary can still ingest from an external observer. The
-receipt remains useful when the check-in cannot be delivered.
+receipt remains useful when the check-in cannot be delivered. When
+`CANARY_WITNESS_TTL_MS` or `--ttl-ms` is set, the check-in includes `ttl_ms`
+so Canary uses that TTL for the next deadline on TTL-mode monitors.
 
 ## GitHub Schedule
 
@@ -42,6 +45,11 @@ receipt remains useful when the check-in cannot be delivered.
 each run it uploads `canary-witness-receipt.json`. On failure it opens a GitHub
 issue labeled `canary-witness-failed`; on recovery it closes the issue. This
 notification path does not depend on Canary being reachable.
+
+The workflow keeps the cron expression at `*/5 * * * *` for best-effort
+freshness but sets `CANARY_WITNESS_TTL_MS=7200000` because observed GitHub
+scheduled runs can land roughly hourly or later. Tightening this TTL requires
+moving the witness to a scheduler that can meet the tighter cadence.
 
 Required repository secrets:
 

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-WITNESS="$ROOT/bin/canary-witness"
+WITNESS=(bash "$ROOT/bin/canary-witness")
 TMPDIR_TEST="$(mktemp -d)"
 PASS=0
 FAIL=0
@@ -57,6 +57,22 @@ write_response() {
   printf '%s %s' "$status" "$latency"
 }
 
+assert_check_in_payload() {
+  if ! jq -e '.monitor == "canary-watchman" and .status == "alive"' <<<"$data" >/dev/null; then
+    printf 'invalid check-in payload: %s\n' "$data" >&2
+    exit 95
+  fi
+  if [[ -n "${CHECK_IN_TTL_EXPECTED:-}" ]]; then
+    if ! jq -e --argjson ttl "$CHECK_IN_TTL_EXPECTED" '.ttl_ms == $ttl' <<<"$data" >/dev/null; then
+      printf 'invalid check-in ttl payload: %s\n' "$data" >&2
+      exit 96
+    fi
+  elif ! jq -e 'has("ttl_ms") | not' <<<"$data" >/dev/null; then
+    printf 'expected no ttl_ms in payload: %s\n' "$data" >&2
+    exit 97
+  fi
+}
+
 READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 PRESSURED_READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 
@@ -71,10 +87,7 @@ case "${STUB_SCENARIO:?}:$method:$url" in
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
     ;;
   healthy:POST:https://canary.example/api/v1/check-ins)
-    if ! jq -e '.monitor == "canary-watchman" and .status == "alive"' <<<"$data" >/dev/null; then
-      printf 'invalid check-in payload: %s\n' "$data" >&2
-      exit 95
-    fi
+    assert_check_in_payload
     write_response 201 0.040 '{"monitor":"canary-watchman","status":"alive"}'
     ;;
 
@@ -88,10 +101,7 @@ case "${STUB_SCENARIO:?}:$method:$url" in
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
     ;;
   pressured:POST:https://canary.example/api/v1/check-ins)
-    if ! jq -e '.monitor == "canary-watchman" and .status == "alive"' <<<"$data" >/dev/null; then
-      printf 'invalid check-in payload: %s\n' "$data" >&2
-      exit 95
-    fi
+    assert_check_in_payload
     write_response 201 0.040 '{"monitor":"canary-watchman","status":"alive"}'
     ;;
 
@@ -185,8 +195,10 @@ run_failure() {
 setup_fake_curl
 
 receipt="$TMPDIR_TEST/healthy.json"
-STUB_SCENARIO=healthy run_success "healthy witness exits zero" \
-  "$WITNESS" \
+run_success "healthy witness exits zero" \
+  env \
+    STUB_SCENARIO=healthy \
+    "${WITNESS[@]}" \
     --endpoint https://canary.example \
     --read-api-key read-key \
     --ingest-api-key ingest-key \
@@ -199,9 +211,27 @@ assert_json_equals "$receipt" '.probes.readyz.response.status' 'ready' "healthy 
 assert_json_equals "$receipt" '.probes.canary_query.response.total_errors' '0' "healthy records canary query"
 assert_json_equals "$receipt" '.check_in.http_status' '201' "healthy sends check-in"
 
+receipt="$TMPDIR_TEST/healthy-ttl.json"
+run_success "healthy witness sends configured ttl" \
+  env \
+    CHECK_IN_TTL_EXPECTED=7200000 \
+    STUB_SCENARIO=healthy \
+    CANARY_WITNESS_TTL_MS=7200000 \
+    "${WITNESS[@]}" \
+      --endpoint https://canary.example \
+      --read-api-key read-key \
+      --ingest-api-key ingest-key \
+      --receipt "$receipt" \
+      --require-check-in \
+      --json
+assert_json_equals "$receipt" '.status' 'healthy' "healthy ttl receipt status"
+assert_json_equals "$receipt" '.check_in.http_status' '201' "healthy ttl sends check-in"
+
 receipt="$TMPDIR_TEST/pressured.json"
-STUB_SCENARIO=pressured run_success "pressured ready witness exits zero" \
-  "$WITNESS" \
+run_success "pressured ready witness exits zero" \
+  env \
+    STUB_SCENARIO=pressured \
+    "${WITNESS[@]}" \
     --endpoint https://canary.example \
     --read-api-key read-key \
     --ingest-api-key ingest-key \
@@ -213,8 +243,10 @@ assert_json_equals "$receipt" '.probes.readyz.response.checks.workers[] | select
 assert_json_equals "$receipt" '.check_in.http_status' '201' "pressured ready sends check-in"
 
 receipt="$TMPDIR_TEST/degraded.json"
-STUB_SCENARIO=degraded run_failure "degraded witness exits nonzero" \
-  "$WITNESS" \
+run_failure "degraded witness exits nonzero" \
+  env \
+    STUB_SCENARIO=degraded \
+    "${WITNESS[@]}" \
     --endpoint https://canary.example \
     --read-api-key read-key \
     --ingest-api-key ingest-key \
@@ -224,8 +256,10 @@ assert_json_equals "$receipt" '.status' 'degraded' "degraded receipt status"
 assert_json_equals "$receipt" '.check_in.skipped' 'true' "degraded skips check-in"
 
 receipt="$TMPDIR_TEST/unreachable.json"
-STUB_SCENARIO=unreachable run_failure "unreachable witness exits nonzero" \
-  "$WITNESS" \
+run_failure "unreachable witness exits nonzero" \
+  env \
+    STUB_SCENARIO=unreachable \
+    "${WITNESS[@]}" \
     --endpoint https://canary.example \
     --read-api-key read-key \
     --ingest-api-key ingest-key \
@@ -236,8 +270,10 @@ assert_json_equals "$receipt" '.status' 'unreachable' "unreachable receipt statu
 assert_json_equals "$receipt" '.probes.healthz.curl_exit' '7' "unreachable records curl exit"
 
 receipt="$TMPDIR_TEST/malformed.json"
-STUB_SCENARIO=malformed run_failure "malformed witness exits nonzero" \
-  "$WITNESS" \
+run_failure "malformed witness exits nonzero" \
+  env \
+    STUB_SCENARIO=malformed \
+    "${WITNESS[@]}" \
     --endpoint https://canary.example \
     --read-api-key read-key \
     --ingest-api-key ingest-key \
@@ -253,7 +289,7 @@ run_failure "required missing check-in exits nonzero" \
     -u CANARY_INGEST_API_KEY \
     -u CANARY_WITNESS_INGEST_KEY \
     STUB_SCENARIO=healthy \
-    "$WITNESS" \
+    "${WITNESS[@]}" \
     --endpoint https://canary.example \
     --read-api-key read-key \
     --receipt "$receipt" \


### PR DESCRIPTION
## Summary
- add optional `ttl_ms` support to `bin/canary-witness`
- set the scheduled Canary Witness workflow to send `CANARY_WITNESS_TTL_MS=7200000`
- document GitHub cron as best-effort and cover the TTL payload in the witness shell tests

## Verification
- `timeout 60 bash test/bin/canary_witness_test.sh` (25 assertions)
- `bash -n bin/canary-witness test/bin/canary_witness_test.sh`
- `git diff --cached --check && git diff --check`
- fresh-context `codex review --uncommitted`: no blocking or important findings
- live production check-in: `CANARY_WITNESS_TTL_MS=7200000 bash bin/canary-witness --require-check-in` returned healthy, check-in HTTP 201, monitor `MON-5csw7imodfcq` state `up`, deadline `2026-06-18T23:35:49Z`
- `bin/canary doctor --json`: verdict overall `healthy`, no blocking signals

## Local gate note
- `bash ./bin/validate --fast` initially blocked because global Dagger was `v0.21.6` while `dagger.json` requires `v0.20.5`.
- Retrying with a temp `v0.20.5` binary reached the shell test lane, including cached `canary_witness_test.sh`, then wedged after the shell lane when the local Dagger engine disappeared. PR CI remains the canonical full gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Witness check-ins now support configurable time-to-live (TTL) values via a CLI option.
  * TTL-mode witness payloads include a `ttl_ms` field when a TTL is set.
  * Canary workflow configurations can set the TTL to reduce false “witness-down” alerts.

* **Documentation**
  * Updated the witness workflow description and scheduling guidance to reflect TTL-mode behavior and recommended settings.

* **Tests**
  * Expanded test coverage to validate the presence/absence of the TTL field in check-in requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->