### PR TITLE
feat(ops): separate alert-plane health from readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Existing tools (Sentry, Uptime Robot) are designed around humans staring at dash
 - **Generic webhooks** — consumers define their own behavior
 - **Self-hosted** on Fly.io with SQLite + Litestream + Fly Tigris backup
 
+Read the product direction in [`VISION.md`](VISION.md). The agent UX laws and
+coordination philosophy live in
+[`docs/agent-first-identity.md`](docs/agent-first-identity.md).
+
 ## Quick Start
 
 ```bash

--- a/VISION.md
+++ b/VISION.md
@@ -1,49 +1,174 @@
-# Vision
+# Canary Vision
+
+Canary is the agent command center for production health.
+
+It is a small, self-hosted service that records errors, probes uptime, watches
+check-ins, correlates incidents, keeps a durable timeline, and gives agents the
+bounded context they need to respond without opening a human dashboard.
 
 ## The Problem
 
-Observability tooling was built for humans. Dashboards, alert fatigue, click-through workflows, context-switching between Sentry and Uptime Robot and PagerDuty. The primary consumer of production health data is increasingly AI agents — and they need something fundamentally different.
+Production health tooling was built around humans staring at dashboards:
+Sentry for application errors, UptimeRobot for uptime, PagerDuty or incident.io
+for response, Datadog or Grafana for broad telemetry, and ad hoc glue between
+them. That stack works for human teams with time to click, filter, and infer.
+It is a poor default for autonomous agents.
 
-Agents don't need pretty graphs. They need structured, bounded, pre-aggregated data they can reason over in a single context window. They need natural-language summaries they can include in reports. They need webhook events they can act on autonomously.
+Agents need a different surface:
+
+- a compact answer to "what is happening now?"
+- a durable event log they can replay after wake-up, crash, or handoff
+- a conflict primitive so duplicate agents do not work the same incident
+- scoped write-back for evidence, decisions, and ownership
+- deterministic summaries that fit in transcripts and context windows
+- setup and verification loops that prove a deployed app is actually covered
+
+The missing product is not another dashboard. It is a coordination substrate
+for agents watching production.
 
 ## The Bet
 
-The agent-infrastructure feedback loop is the next platform shift:
+The next reliability loop is agent-operated:
 
-1. Agent detects anomaly (via Canary webhook or periodic query)
-2. Agent queries for context (error groups, check history, stack traces)
-3. Agent diagnoses and either fixes automatically or files a structured report
-4. Agent verifies the fix landed (query again, check health status)
+1. Canary records a production signal: error, health transition, missed
+   check-in, operational event, or incident correlation.
+2. Canary sends a signed webhook as a wake-up hint, or an agent polls the
+   report and timeline.
+3. The agent claims the durable subject before acting.
+4. The agent queries bounded context: report, incident detail, error group,
+   target or monitor state, annotations, delivery diagnostics, and timeline.
+5. The agent fixes, files, escalates, or deliberately dismisses outside Canary.
+6. The agent writes back annotations, claim transitions, links, and evidence.
+7. Another agent can replay the same timeline and see what happened.
 
-This loop doesn't need a dashboard. It needs an API that speaks the agent's language.
+Canary wins when that loop is boring, deterministic, and hard to misuse.
 
 ## What Canary Is
 
-A single, self-hosted service that replaces the core of Sentry (error capture) and Uptime Robot (health monitoring) with an API designed for AI agents.
+**A hyper-simple production health service.** One Rust service, one Docker
+image, one SQLite database, one deployment target, and a small set of explicit
+operator scripts. Complexity has to earn its way in.
 
-**One service.** One Docker image, one SQLite file, one config. No microservices, no message queues, no external dependencies.
+**Agent-first observability.** API, CLI, SDK, and MCP-shaped tools are the
+product surfaces. Humans use the same surfaces agents use. A browser dashboard
+is not the product.
 
-**Agent-first.** Every response includes a `summary` field. Responses are bounded and pre-aggregated. Error classes are grouped automatically. Health state is a finite state machine with clear semantics.
+**An event and incident ledger.** The timeline is the durable source of truth.
+Webhooks wake agents up; timeline replay tells them what is true.
 
-**Broadcast, don't prescribe.** Generic webhooks with HMAC signing. Consumers define their own behavior. No opinionated integrations with GitHub, Slack, Discord, or anything else.
+**A coordination primitive.** Remediation claims let agents reserve a subject,
+avoid duplicate work, transition ownership state, and release or verify the
+work with evidence.
+
+**A bounded context engine.** Reports, incident details, query rows, value
+receipts, and summaries are deliberately compact. Canary should answer the
+first question without forcing an agent through a raw data lake.
+
+**A verification loop.** Integration is not complete because code was patched
+or env vars exist. It is complete when deployed readback proves health,
+ingest, query, webhook or monitor state, and a receipt.
 
 ## What Canary Is Not
 
-- Not a replacement for distributed tracing, APM, or log aggregation
-- Not a dashboard (agents are the UI)
-- Not multi-tenant (internal tool, single-org)
-- Not an MCP server (API + CLI + skill files are sufficient)
+- Not a general APM, tracing, logging, or metrics platform.
+- Not an LLM trace/eval tool.
+- Not an incident-command suite for human war rooms.
+- Not a repo mutation, issue creation, or autonomous fix engine.
+- Not a dashboard. Agents are the UI; operators inspect the same API and CLI.
+- Not a semantic workflow engine hidden behind provider-specific agents.
+- Not multi-tenant SaaS by default. External-user productization must be
+  explicit, scoped, and security-reviewed.
 
-## Where It's Going
+Canary may expose MCP tools, SDKs, and CLIs, but those are adapters over the
+same contract. They must not become parallel semantic APIs.
 
-### Near Term (v1 — current)
-Single-region health checking, error ingestion, query API, webhook broadcasting. Proves the concept with our own infrastructure.
+## Competitive Position
 
-### Medium Term (v2)
-- Multi-region health probing (Fly.io workers in multiple regions, consensus-based down detection)
-- Push-based monitoring (heartbeat endpoint for cron jobs)
-- Postgres migration (Ecto makes this a config change)
-- Logger backend (automatic capture with noise filtering)
+Canary does not try to out-feature the incumbents.
 
-### Long Term
-Canary becomes the canonical interface between AI agents and production infrastructure. Not by adding features, but by being the simplest correct answer to: "what's happening in production right now?"
+Use **Sentry** when the primary job is rich developer error monitoring,
+source maps, release health, performance tracing, session replay, and mature
+ecosystem integrations.
+
+Use **UptimeRobot** when the primary job is cheap hosted uptime checks, status
+pages, SSL/domain checks, and simple alerting without owning infrastructure.
+
+Use **Better Stack** when the primary job is a hosted bundle of uptime, logs,
+incident management, status pages, on-call, and AI-assisted operations.
+
+Use **Datadog, New Relic, Grafana Cloud, Honeycomb, or OpenTelemetry stacks**
+when the primary job is full-stack telemetry, distributed tracing, metrics,
+high-cardinality exploration, dashboards, fleet analytics, or enterprise
+observability governance.
+
+Use **PagerDuty or incident.io** when the primary job is human on-call,
+escalation policies, incident rooms, customer communications, and enterprise
+incident process.
+
+Use **Langfuse, LangSmith, or similar tools** when the primary job is LLM and
+agent execution observability: prompts, traces, token cost, evaluations, and
+human review of model behavior.
+
+Use **Canary** when the primary job is smaller and sharper: give agents a
+simple, self-hosted, production-health ledger they can read, replay, claim,
+annotate, and respond to without a dashboard or a heavyweight observability
+program.
+
+## Current Product Truth
+
+Canary is already past the "can it ingest and query?" stage. The active
+contract includes:
+
+- error ingest and grouped query readback
+- HTTP targets and non-HTTP check-in monitors
+- health, status, report, incident, error detail, and timeline read models
+- signed webhooks plus a delivery ledger and diagnostics
+- annotations on durable subjects
+- remediation claims for agent ownership
+- bounded operational events
+- a Rust CLI with JSON envelopes for agent transcripts
+- MCP manifest generation over the CLI surface
+- TypeScript SDK instrumentation
+- one-command integration discovery, patch planning, patching, and enrollment
+- dogfood registry, audit, self-watch, and value receipt loops
+
+The remaining gap is not raw capability. The gap is trust and usefulness:
+alert reliability, stale evidence cleanup, responder safety, fewer
+overclaimed integrations, and a cleaner agent handoff from signal to action.
+
+## Product Principles
+
+1. **Timeline before notification.** A webhook is only a wake-up hint. Durable
+   replay is the correctness path.
+2. **Claim before work.** Agents create a remediation claim before triage or
+   repair so duplicate responders do not collide.
+3. **Bound the first answer.** Every high-level read should fit in an agent
+   transcript and carry a deterministic summary plus the next drill-down link.
+4. **Write back evidence, not commands.** Annotations and claims record what
+   happened. Downstream responders decide how to mutate repos, tickets, or
+   infrastructure.
+5. **No LLM on the request path.** Canary can feed agents, but Canary itself
+   keeps summaries deterministic and auditable.
+6. **Coverage requires readback.** A service is not covered until live Canary
+   readback proves it.
+7. **Self-watch must be external.** Canary watches apps; an independent witness
+   watches Canary.
+8. **Small beats complete.** Prefer a deep, simple module with a stable
+   contract over broad observability surface area.
+
+## Roadmap Bias
+
+The near-term product direction is not "add every observability feature." It is:
+
+- make alert-plane reliability and SLO/error-budget feedback trustworthy
+- make responder context safe enough for arbitrary-agent consumers
+- remove stale dogfood evidence and overclaiming in integration receipts
+- make the integration loop prove deployed value faster
+- keep MCP, CLI, SDK, and HTTP aligned to one semantic contract
+
+The long-term goal is that an agent can ask one question and act:
+
+> What is unhealthy, who is already working it, what context matters, and what
+> is the next safe action?
+
+Canary should be the simplest correct answer.

--- a/backlog.d/047-alert-plane-slo-burn-rate.md
+++ b/backlog.d/047-alert-plane-slo-burn-rate.md
@@ -1,6 +1,6 @@
 # Prove alert-plane health separately from route readiness
 
-Priority: P0 · Status: ready · Estimate: XL
+Priority: P0 · Status: in_progress · Estimate: XL
 
 ## PRD Summary
 - User: agent responders and operators deciding whether Canary can be trusted to wake them up.
@@ -57,6 +57,17 @@ impairment driver that can be run in strict or as a dedicated ops gate.
 Why: the reliability lane found that `/readyz` intentionally treats `pressured` workers as route-ready, while the witness accepts `ok` or `pressured`. That can be appropriate for deploy readiness, but it is not enough for alerting health. The lane also found no SLO or burn-rate implementation and no check-in timestamp skew policy.
 
 External research supports multi-window burn-rate alerting as the mature SLO alerting shape. Start with coarse service classes and fixed defaults rather than bespoke thresholds per service.
+
+2026-06-20 slice: first alert-plane impairment proof is implemented on branch
+`docs/agent-first-vision`. `bin/canary doctor --json` now exposes
+`response.alert_plane`, the doctor verdict carries the same field, and
+`bin/canary-witness` exits nonzero with `alert_plane.status: "impaired"` when
+the induced fixture returns a route-ready `/readyz` response with a pressured
+worker. Evidence:
+`docs/architecture/canary-alert-plane-evidence-2026-06-20.md`. Remaining scope:
+future check-in timestamp skew policy, production-image induced impairment
+gate wiring beyond the shell fixture, SLO configuration, and burn-rate
+summaries.
 
 ## Children
 1. Define alert-plane health separately from route readiness.

--- a/backlog.d/047-alert-plane-slo-burn-rate.md
+++ b/backlog.d/047-alert-plane-slo-burn-rate.md
@@ -1,6 +1,32 @@
-# Add alert-plane reliability and SLO burn-rate feedback
+# Prove alert-plane health separately from route readiness
 
 Priority: P0 · Status: ready · Estimate: XL
+
+## PRD Summary
+- User: agent responders and operators deciding whether Canary can be trusted to wake them up.
+- Problem: `/readyz` can be route-ready while alert delivery, overdue monitor evaluation, or probe workers are pressured, suppressed, or stale.
+- Goal: make Canary distinguish "can serve HTTP" from "can reliably detect and route production health changes."
+- Why now: dogfood value receipts prove service health, but the next reliability risk is missing or suppressing the signal that should wake an agent.
+- UX enabled: `bin/canary doctor`, the external witness, and strict rehearsal name alert-plane impairment as a first-class reason before claiming Canary is healthy.
+- Deliverable type: working code plus production-image rehearsal evidence.
+- Success signal: an induced alert-plane impairment fails or degrades the witness/doctor even when `/readyz` remains route-ready.
+
+## Product Requirements
+- P0: alert-plane health is a separate verdict from route readiness.
+- P0: sustained worker pressure, stale due work, circuit-open suppression, and webhook fanout failure produce stable impairment reasons.
+- P0: monitor check-ins cannot use a future `observed_at` timestamp to defer overdue alerts beyond an explicit skew policy.
+- P0: the first implementation slice includes an induced impairment fixture before SLO or burn-rate math.
+- P1: expose coarse service SLO classes and multi-window burn-rate summaries after the impairment contract is proven.
+- Non-goals: replacing `/readyz`, broad distributed tracing, or adding a human dashboard.
+
+## Technical Design
+- Chosen architecture: keep `/readyz` as deploy/readiness truth, add an alert-plane verdict derived from worker lifecycle snapshots, webhook delivery reports, monitor overdue reports, target probe reports, and witness readback.
+- Files/systems touched: `crates/canary-server/src/worker_health.rs`, worker modules, `crates/canary-cli/src/lib.rs`, `bin/canary-witness`, `test/bin/canary_witness_test.sh`, Dagger production smoke, and focused server tests.
+- Data/control flow: workers emit pressure details; doctor/witness grade those into alert-plane impairment; strict or a dedicated rehearsal induces impairment and asserts the degraded verdict.
+- Build/check boundary: unit tests cover policy math and timestamp skew; shell tests cover witness status; production-image rehearsal proves the end-to-end route.
+- ADR decision: not required for the first slice because this extends the existing readiness/witness architecture; require an ADR if SLO storage introduces a persistent configuration model.
+- ADR-style invariants: route readiness stays available for deploy checks; alert-plane readiness is stricter for operational trust; no LLM participates in verdict generation.
+- Design X vs Y: do not make `/readyz` fail on every pressure case, because that would conflate deploy safety and alert reliability; instead add a separate stricter alert-plane verdict.
 
 ## Goal
 Separate deploy readiness from operational alert health by adding SLO/error-budget signals, alert-plane impairment checks, and check-in timestamp safety.
@@ -10,13 +36,22 @@ Start by defining and exposing alert-plane health separately from route
 readiness. The first slice should make sustained worker pressure, stale due
 work, circuit-open suppression, or webhook fanout failure visible to
 `bin/canary doctor`, the external witness, and a focused regression fixture
-before adding SLO configuration or burn-rate math.
+before adding SLO configuration or burn-rate math. Include an induced
+impairment driver that can be run in strict or as a dedicated ops gate.
 
 ## Oracle
 - [ ] Given webhook delivery, monitor overdue, target probe, retention, or TLS workers report sustained pressure, circuit-open suppression, stale due work, or fanout failures, when the external witness runs, then it fails or degrades with an alert-plane impairment reason even if `/readyz` is route-ready.
 - [ ] Given a monitor check-in contains a future `observed_at` beyond an allowed skew, then Canary rejects or clamps it with RFC 9457 Problem Details and a regression test proves future check-ins cannot defer overdue alerts.
 - [ ] Given configured per-service SLO objectives, when `/metrics`, `/api/v1/report`, or `bin/canary services --json` is queried, then Canary exposes windowed availability/error/latency SLIs, budget remaining, burn rate, and recommended alert severity.
 - [ ] Given an induced rehearsal creates alert-plane impairment, then a live or production-image rehearsal proves the witness and doctor catch it before declaring Canary healthy.
+
+## Verification System
+- Claim: Canary can be route-ready while still refusing to claim alert-plane health.
+- Falsifier: a fixture where `/readyz` is ready but webhook delivery is circuit-open, monitor overdue work is stale, or a worker reports sustained pressure and the witness still exits healthy.
+- Driver: focused Rust tests, `test/bin/canary_witness_test.sh`, and a production-image induced impairment rehearsal.
+- Grader: doctor/witness JSON includes stable alert-plane impairment reasons and non-healthy status; future check-in timestamps beyond allowed skew produce RFC 9457 Problem Details.
+- Evidence packet: witness receipt JSON plus Dagger or rehearsal transcript linked from the implementation PR.
+- Cadence: unit/shell tests on every gate; induced production-image rehearsal before merge and after alert-plane policy changes.
 
 ## Notes
 Why: the reliability lane found that `/readyz` intentionally treats `pressured` workers as route-ready, while the witness accepts `ok` or `pressured`. That can be appropriate for deploy readiness, but it is not enough for alerting health. The lane also found no SLO or burn-rate implementation and no check-in timestamp skew policy.
@@ -26,7 +61,7 @@ External research supports multi-window burn-rate alerting as the mature SLO ale
 ## Children
 1. Define alert-plane health separately from route readiness.
 2. Add check-in timestamp skew policy and tests.
-3. Add windowed SLI read models for targets, monitors, errors, and incidents.
-4. Add service SLO configuration with default classes.
-5. Add burn-rate summaries to report/CLI/MCP and route notification severity to page vs ticket semantics.
-6. Add an induced impairment rehearsal to strict or a dedicated ops gate.
+3. Add an induced impairment rehearsal to strict or a dedicated ops gate.
+4. Add windowed SLI read models for targets, monitors, errors, and incidents.
+5. Add service SLO configuration with default classes.
+6. Add burn-rate summaries to report/CLI/MCP and route notification severity to page vs ticket semantics.

--- a/backlog.d/048-responder-rich-context-safety-gate.md
+++ b/backlog.d/048-responder-rich-context-safety-gate.md
@@ -1,6 +1,33 @@
-# Gate rich responder context behind least privilege and audit
+# Gate external responders behind least privilege and audited context
 
 Priority: P0 · Status: pending · Estimate: XL
+
+## PRD Summary
+- User: external remediation agents that wake from Canary signals and need safe context before acting.
+- Problem: arbitrary responders currently need broad authority for claim/evidence writes, and rich context reads do not yet have enforced minimization or read-audit semantics.
+- Goal: make external responder context authorized, minimized, replayable, auditable, and safe for arbitrary-agent consumers.
+- Why now: Canary has claims, annotations, incidents, telemetry, and webhooks; before broader integrations or public/browser capture, the responder trust boundary must be explicit.
+- UX enabled: a responder can claim and annotate one service's subject with narrow authority, read a minimized context envelope, and leave an audit trail without admin-level access.
+- Deliverable type: working code, contract docs, conformance fixtures, and safety tests.
+- Success signal: a service-bound responder can complete claim/read/annotate/replay conformance while over-scoped, cross-service, unredacted, or unaudited access fails.
+
+## Product Requirements
+- P0: provide a narrow responder-write authority for claims and annotations without broad admin access.
+- P0: serialize responder context through subject-specific envelopes with service, tenant/project, retention, and privacy policy metadata.
+- P0: enforce server-side minimization/redaction for telemetry attributes, annotation metadata, evidence links, and responder context.
+- P0: add durable read-audit events for rich responder context fetches.
+- P0: define safe browser/public-ingest authority or relay semantics before any client-side capture path exposes credentials.
+- P1: ship receiver conformance fixtures for signature timestamp validation, delivery-id dedupe, and timeline replay before action.
+- Non-goals: repo mutation, issue creation, autonomous deploy rollback, or customer incident command.
+
+## Technical Design
+- Chosen architecture: add responder-specific scopes/context envelopes as adapters over existing claims, annotations, timeline, and incident read models; keep Canary as coordinator, not fixer.
+- Files/systems touched: auth scope model, claims routes, annotation routes, incident detail/read models, telemetry/context redaction, OpenAPI, CLI/MCP manifest, and webhook receiver docs/fixtures.
+- Data/control flow: webhook wakes responder; responder verifies/dedupes delivery, creates or observes claim, reads minimized context, acts outside Canary, writes annotation/claim evidence, and Canary records read/write audit events.
+- Build/check boundary: route tests prove least privilege and cross-service denial; contract tests prove OpenAPI scopes; fixture tests prove webhook receiver conformance.
+- ADR decision: required if the scope model adds new key classes beyond existing `ingest-only`, `read-only`, and `admin`.
+- ADR-style invariants: service-bound authority never escalates to all services; privacy labels are enforced before rich context leaves Canary; read-audit events do not leak redacted payloads.
+- Design X vs Y: prefer responder-specific scopes and context envelopes over handing agents admin keys plus informal docs; informal docs are not a safety boundary.
 
 ## Goal
 Make Canary safe for arbitrary-user auto-triage by ensuring external responders receive only authorized, minimized, replayable, and auditable context.
@@ -11,6 +38,16 @@ Make Canary safe for arbitrary-user auto-triage by ensuring external responders 
 - [ ] Given telemetry attributes, annotation metadata, and evidence links contain sensitive-looking data, then responder context either redacts/minimizes it server-side or excludes it by schema.
 - [ ] Given a webhook receiver is registered as an automation responder, then a conformance fixture proves timestamp validation, delivery-id dedupe, and timeline replay before action.
 - [ ] Given a responder reads rich incident detail, then Canary records a durable read-audit event with responder identity, subject, context envelope, and timestamp.
+- [ ] Given browser capture is enabled for a consuming app, then it uses a public-ingest token or relay design that cannot read, administer, claim, or expose a secret API key.
+- [ ] Given MCP or CLI tools expose responder actions, then their manifest scopes and runtime enforcement match the HTTP authority model.
+
+## Verification System
+- Claim: arbitrary external responders can act through Canary without broad authority or unminimized context.
+- Falsifier: a service-bound responder can claim or read another service, rich context returns sensitive attributes, browser capture exposes a secret key, or a rich read leaves no audit event.
+- Driver: route-level auth tests, OpenAPI scope contract tests, responder context snapshot tests, webhook receiver conformance fixtures, and CLI/MCP manifest checks.
+- Grader: unauthorized access returns RFC 9457 Problem Details; context snapshots match redaction rules; audit timeline contains non-sensitive read/write records.
+- Evidence packet: test transcripts plus a responder conformance receipt checked into `docs/architecture/` or attached to the PR.
+- Cadence: every strict gate for contract tests; conformance fixture before enabling arbitrary-user responders.
 
 ## Notes
 Why: the security lane found tenant/project/service isolation is mostly in place, but rich-context producers must never omit authority. Claims currently require admin, service-bound admin keys are rejected for mutation, telemetry privacy labels are policy-only, and there is no per-responder read receipt. That is acceptable for owned dogfood; it is not acceptable for arbitrary-user responders.
@@ -21,6 +58,8 @@ This ticket should land before promoting Canary as a general hosted substrate fo
 1. Design `responder-write` or equivalent least-privilege scope.
 2. Define responder context schemas per subject/event type.
 3. Add server-side minimization/redaction for rich context or explicitly exclude risky fields.
-4. Add webhook receiver conformance fixtures and docs.
-5. Add read-audit timeline events for rich context fetches.
-6. Update OpenAPI agent guidance with the safety contract.
+4. Define safe browser capture through public-ingest tokens or a relay boundary.
+5. Add webhook receiver conformance fixtures and docs.
+6. Add read-audit timeline events for rich context fetches.
+7. Align HTTP, CLI, and MCP responder authority metadata.
+8. Update OpenAPI agent guidance with the safety contract.

--- a/backlog.d/049-integration-evidence-closure.md
+++ b/backlog.d/049-integration-evidence-closure.md
@@ -2,6 +2,33 @@
 
 Priority: P1 · Status: pending · Estimate: XL
 
+## PRD Summary
+- User: agents integrating Canary into deployed applications and later trusting the receipt.
+- Problem: integration status can still overclaim when only partial setup exists, webhooks are global rather than service-specific, synthetic readback is missing, or browser capture would expose credentials.
+- Goal: make `canary integrate` unable to mark coverage verified until deployed service-specific evidence proves health, ingest/check-in, webhook, readback, and safe capture.
+- Why now: #040 shipped the integration loop and #046 shipped value receipts; the remaining issue is receipt truth, not basic onboarding.
+- UX enabled: an agent can run one apply/status loop and know whether a service is actually covered or exactly why it is partial.
+- Deliverable type: working code, MCP wrapper, receipts, and smoke evidence.
+- Success signal: strict integration status refuses verified coverage unless synthetic service-specific evidence is fresh and replayable.
+
+## Product Requirements
+- P0: `verified` requires synthetic ingress or check-in plus service-specific query/timeline readback.
+- P0: webhook coverage is service-specific; a webhook for another service cannot satisfy the current service.
+- P0: stale registry or stale integration receipt evidence cannot produce a verified coverage verdict.
+- P0: browser capture depends on the public-ingest or relay contract from #048 and never exposes secret API keys.
+- P1: provide `integrate apply` orchestration across patch, enroll, secret handoff, deploy smoke, synthetic signal, readback, and receipt finalization.
+- P1: ship an installable MCP wrapper over the CLI manifest with a smoke proof.
+- Non-goals: weakening manual review of code patches, writing raw secret values to logs, or making Canary mutate downstream repos through server routes.
+
+## Technical Design
+- Chosen architecture: keep the CLI as the integration orchestrator; receipts are durable local evidence, while Canary remains the server-side source for readback and service state.
+- Files/systems touched: `crates/canary-cli/src/lib.rs`, `crates/canary-cli/src/main.rs`, `bin/dogfood-inventory`, `bin/dogfood-audit`, MCP manifest artifacts, TypeScript SDK/browser capture helpers, and integration docs.
+- Data/control flow: discover local app, plan patch/enroll, apply reviewed local changes, perform approved secret handoff, create target/key/webhook/monitor resources, emit synthetic event/check-in, read query/timeline/status back for the same service, then write verified receipt.
+- Build/check boundary: unit tests catch receipt semantics; shell tests catch strict audit/dogfood behavior; MCP smoke catches wrapper install and one tool invocation.
+- ADR decision: required for the browser public-ingest/relay design if #048 has not already recorded it.
+- ADR-style invariants: receipts describe evidence, not intent; service-specific readback is mandatory; secret values never appear in receipt output.
+- Design X vs Y: do not treat target/key creation as verification; target/key creation is setup, while deployed synthetic readback is proof.
+
 ## Goal
 Close the residual evidence gaps after `040` by making `canary integrate` unable
 to overclaim verification: apply patches, enroll resources, deploy-smoke,
@@ -12,9 +39,19 @@ relay/public-ingest design.
 - [ ] Given `canary integrate apply --project <path> --service <name> --production-url <url> --platform vercel|fly --receipt <path>` runs in a supported app, then it patches code, creates target/key/monitor/webhook resources as requested, writes platform env through an approved secret handoff, runs a deployed smoke, sends a synthetic event or check-in, confirms service-specific query readback, and writes a verified receipt only after all required evidence exists.
 - [ ] Given only target/key creation succeeds, then integration status remains partial and the receipt cannot be marked verified.
 - [ ] Given webhooks exist for other services only, then integration status does not count `webhook_configured=true` for the current service.
+- [ ] Given an integration receipt is stale or only backed by registry text, then strict dogfood and integration status fail or report partial rather than verified coverage.
+- [ ] Given synthetic ingress/check-in cannot be read back through query, timeline, status, or dogfood value for the same service, then the receipt cannot be marked verified.
 - [ ] Given a browser app needs client capture, then the generated integration uses a safe relay or public-ingest design rather than exposing a secret API key in `NEXT_PUBLIC_*`.
 - [ ] Given Fly and Vercel projects are inspected, then env-name audit parity exists for production and preview/staging where the platform supports it.
 - [ ] Given MCP users want integration tools, then an installable MCP wrapper over the CLI manifest exists and is smoke-tested.
+
+## Verification System
+- Claim: integration status and receipts cannot overclaim service coverage.
+- Falsifier: a receipt is verified after target/key creation only, webhook coverage comes from another service, browser capture exposes a secret key, or stale evidence passes strict mode.
+- Driver: CLI unit tests, `bin/dogfood-inventory --strict --json` fixtures, `bin/canary integrate status/plan/apply --json` fixtures, and MCP wrapper smoke.
+- Grader: coverage stays partial until service-specific synthetic readback exists; receipts redact secrets and carry fresh evidence timestamps; MCP smoke returns a valid tool envelope.
+- Evidence packet: integration receipt fixtures plus a production or local throwaway app transcript.
+- Cadence: fast/unit tests for semantics; strict or dedicated integration smoke before marking the ticket done.
 
 ## Notes
 Why: `040` shipped a universal integration/enrollment engine, but the
@@ -32,7 +69,8 @@ integration receipts know what they must prove.
 ## Children
 1. Tighten receipt semantics so `verified` requires synthetic ingest/check-in and readback.
 2. Make webhook coverage service-specific.
-3. Add Fly/Vercel env audit parity and approved secret-handoff adapters.
-4. Design and implement safe browser capture through relay or public-ingest tokens.
-5. Add `integrate apply` orchestration over patch, enroll, platform env, smoke, synthetic signal, and readback.
-6. Ship an installable MCP wrapper over the CLI manifest.
+3. Fail strict/status on stale registry or stale receipt evidence when it is the only proof.
+4. Add Fly/Vercel env audit parity and approved secret-handoff adapters.
+5. Implement safe browser capture only after #048 defines the relay or public-ingest authority.
+6. Add `integrate apply` orchestration over patch, enroll, platform env, smoke, synthetic signal, and readback.
+7. Ship an installable MCP wrapper over the CLI manifest.

--- a/backlog.d/050-cold-agent-readiness-proof.md
+++ b/backlog.d/050-cold-agent-readiness-proof.md
@@ -1,0 +1,34 @@
+# Codify a cold-agent readiness proof
+
+Priority: P1 · Status: pending · Estimate: M
+
+## Goal
+Give a cold agent one discoverable Canary verification path that proves it can inspect, operate, and hand off evidence without re-deriving the repo runbook from scattered docs.
+
+## Oracle
+- [ ] Given a clean checkout with configured read/admin credentials, when a cold agent follows the readiness proof, then it runs `bin/canary doctor --json`, `bin/canary mcp-manifest`, the integration/status discovery smoke, and `./bin/validate --fast`, then writes a redacted receipt.
+- [ ] Given credentials or GitHub/Fly access are missing, then the proof reports a concrete blocked field and replacement command without printing secret values.
+- [ ] Given the MCP wrapper from #049 exists, then the readiness proof installs or launches it and invokes one no-op/read-only Canary tool through the wrapper.
+- [ ] Given the proof is stale, then the repo gate or a shell test fails on missing command names, stale manifest tools, or absent receipt fields.
+
+## Verification System
+- Claim: a cold agent can discover and verify Canary's agent-facing operating surface from one repo-local entrypoint.
+- Falsifier: an agent must read several docs to know what to run, the proof omits MCP/CLI/API evidence, or missing credentials look like generic failure.
+- Driver: a shell test or harness script plus the generated readiness receipt.
+- Grader: receipt contains command versions, doctor verdict, MCP tool count, integration/status result, validation result, redaction check, and explicit blocked/unavailable fields.
+- Evidence packet: checked-in fixture receipt plus live receipt path from the implementation run.
+- Cadence: fast gate for fixture shape; manual/live run before merging readiness changes.
+
+## Notes
+Why: the agent-readiness lane found that Canary has strong CLI JSON envelopes,
+OpenAPI guidance, and an MCP manifest, but no single repo-local verification
+entrypoint or skill-style artifact for a cold agent. This is smaller than #049:
+#049 ships the installable MCP wrapper and integration proof; this ticket makes
+the repo's own agent operating proof discoverable and repeatable.
+
+## Children
+1. Decide whether the entrypoint is a repo-local skill, script, or `bin/canary self-check`.
+2. Define the redacted readiness receipt schema.
+3. Add fixture tests for missing credentials and stale manifest/tool names.
+4. Integrate the MCP wrapper smoke after #049 lands it.
+5. Link the proof from `AGENTS.md`, `README.md`, and `docs/agent-inspection-cli.md`.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -47,6 +47,7 @@
 | 047 | Alert-plane reliability and SLO burn-rate | P0 | ready | XL |
 | 048 | Responder rich-context safety gate | P0 | pending | XL |
 | 049 | Integration evidence and capture gaps | P1 | pending | XL |
+| 050 | Cold-agent readiness proof | P1 | pending | M |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
 
@@ -84,14 +85,16 @@
 043 (agentic remediation claim protocol) — shipped; typed claims now add deterministic ownership/claim state for downstream triage agents
 045 (self-watch operator verdict) — makes Canary's own watchman state one actionable agent-readable verdict, including witness, worker pressure, incidents, dogfood gaps, and next operator action
 046 (dogfood value receipts) — turns coverage into per-service value proof: current signal, owner/claim, action, outcome, stale evidence, and verification receipt
-047 (alert-plane reliability/SLO burn-rate) — separates route readiness from alerting ability, adds check-in skew safety, and introduces SLO/error-budget feedback
-048 (responder rich-context safety gate) — narrows responder authority and redacts/audits rich context before arbitrary-user auto-triage
-049 (integration evidence/capture gaps) — closes residual post-040 overclaiming gaps: synthetic readback, service-specific webhooks, safe browser capture, platform env parity, integrate apply, and MCP wrapper
+047 (alert-plane reliability/SLO burn-rate) — separates route readiness from alerting ability, adds check-in skew safety, and introduces SLO/error-budget feedback after an induced impairment rehearsal proves the alert-plane verdict
+048 (responder rich-context safety gate) — narrows responder authority, enforces minimized/audited rich context, defines safe browser/public-ingest authority, and aligns HTTP/CLI/MCP responder privileges before arbitrary-user auto-triage
+049 (integration evidence/capture gaps) — closes residual post-040 overclaiming gaps: synthetic service-specific readback, service-specific webhooks, stale-evidence failure, safe browser capture after 048, platform env parity, integrate apply, and MCP wrapper
+050 (cold-agent readiness proof) — codifies a one-entrypoint proof that a cold agent can inspect Canary, discover MCP/CLI surfaces, run fast validation, and leave a redacted readiness receipt
 
 022 (contract hygiene) ──── ships independently; restores summary invariant + supervision-tree collapse
 023 (incident detail API) ──→ Canary-side substrate for the Bitterblossom responder workload (and thus 010 ramp pattern)
 024 (signal-agnostic annotations) ──→ blocked on 023; completes the Ramp-loop writable-metadata primitive
 046 ──→ 047 ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
+047 + 049 ──→ 050 (readiness proof consumes the real alert and MCP/integration surfaces)
 ```
 
 ## Execution Lanes
@@ -104,24 +107,31 @@
 **Lane 5 (dogfood coverage):** 020 (Adminifi HTTP surface verification) · **033 (deployed service registry lifecycle)** shipped the managed registry substrate · **035 (deployed app Canary coverage)** makes every active owned deployment covered or explicitly blocked · **036 (agent-native inspection surface)** gives agents the operating view · **037 (watch the watchmen)** proves Canary externally · **038 (one-command integration agent)** removes setup friction
 **Lane 6 (arbitrary-app productization):** 039 (external-user security/privacy foundation) → 041 (live integration verification harness) + 042 (runtime pressure/freshness ops) → 040 (universal integration/enrollment engine) → 043 (agentic remediation claim protocol) + 044 (telemetry/analytics signal model) → **048 (responder rich-context safety gate)** → Bitterblossom **055 (canary/incident responder template)** → **049 (integration evidence/capture gaps)** → 010 (Ramp pattern)
 **Lane 7 (product feedback loop):** 045 (self-watch operator verdict) shipped → 046 (dogfood value receipts) shipped → **047 (alert-plane reliability/SLO burn-rate)** — turns Canary dogfooding from coverage checks into value, alertability, and operator-action proof
+**Lane 8 (cold-agent readiness):** 050 — after the alert-plane and integration/MCP surfaces harden, package the cold-agent verification path into one discoverable proof and receipt
 
 ### Active order (2026-06-17)
 
 045 shipped in PR #163 (commit b0c43b5). 046 shipped the per-service dogfood
 value receipt loop. `bin/canary dogfood value --service <name> --json` now
 answers what Canary proves for one service, and `doctor --json` includes
-aggregate dogfood value counts. 047 is the best next pickup for alert-plane and
-SLO/error-budget feedback.
+aggregate dogfood value counts. 047 is still the best next pickup, but the
+first slice is now the induced alert-plane impairment proof: make doctor and
+the external witness degrade on alertability failure before implementing
+broader SLO/error-budget math.
 
 048 stays pending until the self-watch/value/SLO loops settle, because
 arbitrary-user rich-context responders need those contracts to avoid
-over-authorizing. After 048, the cross-repo pickup is Bitterblossom
+over-authorizing. 048 now also owns the public-ingest or relay boundary for
+browser capture and the HTTP/CLI/MCP authority parity that arbitrary responders
+need. After 048, the cross-repo pickup is Bitterblossom
 `/Users/phaedrus/Development/bitterblossom/backlog.d/055-workload-template-portfolio.md`
 child 2, the canary/incident responder template. 049 follows that responder
 template and closes residual integration evidence gaps without redoing shipped
-040 enrollment work. 020 stays blocked on Adminifi URLs. 010 stays blocked on
-that downstream Bitterblossom responder workload, but the new Lane 7 and
-responder-safety foundations now precede any claim that Canary is ready for
+040 enrollment work. 050 should not preempt 047/048/049; it packages the
+agent-facing verification proof once the surfaces it proves are real. 020 stays
+blocked on Adminifi URLs. 010 stays blocked on that downstream Bitterblossom
+responder workload, but the Lane 7 alertability proof, responder-safety
+foundation, and cold-agent proof now precede any claim that Canary is ready for
 arbitrary external users.
 
 022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
@@ -263,6 +273,14 @@ Bitterblossom workload. 020 stays blocked on Adminifi URLs.
   Live pilot receipts distinguish `linejam` as proven from `chrondle` stale
   registry evidence, `doctor --json` surfaces aggregate dogfood value counts,
   and MCP exposes `canary_dogfood_value`.
+- 2026-06-19: Strategic groom from the new agent-first vision. Live
+  `bin/canary doctor --json` was healthy with fresh witness receipts, but
+  `bin/canary dogfood audit --strict --json` still failed on 45 coverage and
+  evidence gaps. Swarm lanes converged on three backlog moves: sharpen 047
+  around an induced alert-plane impairment proof before burn-rate math, expand
+  048 into the arbitrary-responder safety gate including public-ingest/relay
+  and authority parity, keep 049 pending behind 048 while hardening its
+  anti-overclaim receipt oracle, and add 050 for a cold-agent readiness proof.
 
 ## Status
 

--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -231,6 +231,7 @@ request_json() {
 health_file="$tmpdir/healthz.json"
 ready_file="$tmpdir/readyz.json"
 query_file="$tmpdir/canary-query.json"
+alert_plane_file="$tmpdir/alert-plane.json"
 check_in_file="$tmpdir/check-in.json"
 observed_at="$(now_utc)"
 encoded_window="$(urlencode "$WINDOW")"
@@ -262,10 +263,82 @@ ready_ok="$(jq -r 'try (
     and ((.oldest_due_age_ms == null) or ((.oldest_due_age_ms | type) == "number"))
     and ((.backoff_or_circuit_open | type) == "boolean"))
 ) catch false' "$ready_file")"
+jq -n \
+  --slurpfile ready "$ready_file" \
+  'def worker_reason:
+    if ((.state // "unknown") != "started") then "\(.name // "unknown") \(.state // "unknown")"
+    elif ((.backoff_or_circuit_open // false) == true) then "\(.name // "unknown") backoff_or_circuit_open"
+    elif ((.health // "unknown") != "ok") then "\(.name // "unknown") \(.health // "unknown")"
+    elif ((.consecutive_failures // 0) > 0) then "\(.name // "unknown") consecutive_failures=\(.consecutive_failures // 0)"
+    elif ((.failure_count // 0) > 0) then "\(.name // "unknown") failure_count=\(.failure_count // 0)"
+    else "\(.name // "unknown") impaired"
+    end;
+  ($ready[0]) as $probe
+  | if (($probe.response | type) == "object"
+      and (($probe.response.checks.workers | type) == "array")) then
+      ($probe.response.checks.workers) as $workers
+      | ($workers
+        | map(select(
+          ((.state // "unknown") != "started")
+          or ((.health // "unknown") != "ok")
+          or ((.failure_count // 0) > 0)
+          or ((.consecutive_failures // 0) > 0)
+          or ((.backoff_or_circuit_open // false) == true)
+        ))
+        | map({
+          name: (.name // "unknown"),
+          state: (.state // "unknown"),
+          health: (.health // "unknown"),
+          failure_count: (.failure_count // 0),
+          consecutive_failures: (.consecutive_failures // 0),
+          due_count: (.due_count // 0),
+          in_flight_count: (.in_flight_count // 0),
+          oldest_due_age_ms: (.oldest_due_age_ms // null),
+          backoff_or_circuit_open: (.backoff_or_circuit_open // false),
+          reason: worker_reason
+        })) as $impaired
+      | {
+          available: true,
+          status: (if ($impaired | length) == 0 then "healthy" else "impaired" end),
+          worker_count: ($workers | length),
+          impaired_workers: ($impaired | length),
+          workers: $impaired,
+          reasons: ($impaired | map(.reason))
+        }
+    elif ($probe.ok != true) then {
+      available: false,
+      status: "unavailable",
+      reason: ($probe.error // "readyz unavailable"),
+      worker_count: 0,
+      impaired_workers: 0,
+      workers: [],
+      reasons: []
+    }
+    elif (($probe.response | type) != "object"
+      or (($probe.response.checks.workers | type) != "array")) then {
+      available: false,
+      status: "unavailable",
+      reason: "readyz worker checks missing",
+      worker_count: 0,
+      impaired_workers: 0,
+      workers: [],
+      reasons: []
+    }
+    else {
+      available: false,
+      status: "unavailable",
+      reason: "readyz worker checks missing",
+      worker_count: 0,
+      impaired_workers: 0,
+      workers: [],
+      reasons: []
+    }
+    end' >"$alert_plane_file"
+alert_plane_ok="$(jq -r '.status == "healthy"' "$alert_plane_file")"
 query_ok="$(jq -r 'try (.curl_exit == 0 and .http_status == 200 and (.response | type == "object") and .response.service == "canary" and (.response.total_errors | type == "number")) catch false' "$query_file")"
 transport_failures="$(jq -s '[.[] | select((.skipped // false | not) and (.curl_exit != 0))] | length' "$health_file" "$ready_file" "$query_file")"
 
-if [[ "$health_ok" == "true" && "$ready_ok" == "true" && "$query_ok" == "true" ]]; then
+if [[ "$health_ok" == "true" && "$ready_ok" == "true" && "$query_ok" == "true" && "$alert_plane_ok" == "true" ]]; then
   status="healthy"
 elif [[ "$transport_failures" != "0" ]]; then
   status="unreachable"
@@ -328,6 +401,7 @@ jq -n \
   --slurpfile health "$health_file" \
   --slurpfile ready "$ready_file" \
   --slurpfile query "$query_file" \
+  --slurpfile alert_plane "$alert_plane_file" \
   --slurpfile check_in "$check_in_file" \
   '{
     schema_version: $schema_version,
@@ -342,6 +416,7 @@ jq -n \
       readyz: $ready[0],
       canary_query: $query[0]
     },
+    alert_plane: $alert_plane[0],
     check_in: $check_in[0]
   }' >"$RECEIPT"
 
@@ -350,7 +425,7 @@ if [[ "$JSON_OUTPUT" == "1" ]]; then
 else
   printf 'status: %s\n' "$status"
   printf 'receipt: %s\n' "$RECEIPT"
-  jq -r '"healthz: \(.probes.healthz.http_status) \(.probes.healthz.latency_ms)ms", "readyz: \(.probes.readyz.http_status) \(.probes.readyz.latency_ms)ms", "canary_errors: \((if (.probes.canary_query.response | type) == "object" then .probes.canary_query.response.total_errors else null end) // "unknown")", "check_in: \(.check_in.http_status) \(.check_in.latency_ms // "n/a")ms"' "$RECEIPT"
+  jq -r '"healthz: \(.probes.healthz.http_status) \(.probes.healthz.latency_ms)ms", "readyz: \(.probes.readyz.http_status) \(.probes.readyz.latency_ms)ms", "alert_plane: \(.alert_plane.status)\(if ((.alert_plane.reasons // []) | length) > 0 then " \((.alert_plane.reasons // []) | join(", "))" else "" end)", "canary_errors: \((if (.probes.canary_query.response | type) == "object" then .probes.canary_query.response.total_errors else null end) // "unknown")", "check_in: \(.check_in.http_status) \(.check_in.latency_ms // "n/a")ms"' "$RECEIPT"
 fi
 
 if [[ "$status" == "healthy" ]]; then

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -2704,6 +2704,7 @@ pub fn doctor_report(client: &ApiClient, repo_root: &Path) -> Value {
         .unwrap_or_else(|| json!({"ok": false, "error": string_field(&dogfood, "error")}));
     let dr = dr_evidence_report(repo_root);
     let worker_readiness = worker_readiness_report(&readyz);
+    let alert_plane = alert_plane_report(&worker_readiness);
     let verdict = doctor_verdict(
         &healthz,
         &readyz,
@@ -2712,6 +2713,7 @@ pub fn doctor_report(client: &ApiClient, repo_root: &Path) -> Value {
         &canary_errors,
         &witness,
         &worker_readiness,
+        &alert_plane,
         &dogfood,
         &witness_runs,
         current_unix_ms(),
@@ -2738,6 +2740,7 @@ pub fn doctor_report(client: &ApiClient, repo_root: &Path) -> Value {
         "dogfood": dogfood,
         "dogfood_value": dogfood_value,
         "worker_readiness": worker_readiness,
+        "alert_plane": alert_plane,
         "verdict": verdict
     })
 }
@@ -2800,6 +2803,10 @@ pub fn summarize_doctor(value: &Value) -> Vec<String> {
         "worker_readiness: {}",
         worker_readiness_summary(value.get("worker_readiness"))
     ));
+    lines.push(format!(
+        "alert_plane: {}",
+        alert_plane_summary(value.get("alert_plane"))
+    ));
     lines
 }
 
@@ -2812,6 +2819,7 @@ fn doctor_verdict(
     canary_errors: &Value,
     witness: &Value,
     worker_readiness: &Value,
+    alert_plane: &Value,
     dogfood: &Value,
     receipt_run_references: &Value,
     now_unix_ms: u64,
@@ -2886,6 +2894,22 @@ fn doctor_verdict(
             string_field(worker_readiness, "reason")
         ));
     }
+    if !alert_plane
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        unable = true;
+        blocking_signals.push(format!(
+            "alert-plane unavailable: {}",
+            string_field(alert_plane, "reason")
+        ));
+    } else if string_field(alert_plane, "status") != "healthy" {
+        blocking_signals.push(format!(
+            "alert-plane impaired: {}",
+            alert_plane_reason_summary(alert_plane)
+        ));
+    }
     let failing_workers = worker_pressure
         .get("failing_workers")
         .and_then(Value::as_u64)
@@ -2899,12 +2923,6 @@ fn doctor_verdict(
             "{} worker(s) failing: {}",
             failing_workers,
             worker_names(&worker_pressure, "failing")
-        ));
-    }
-    if pressured_workers > 0 {
-        blocking_signals.push(format!(
-            "worker pressure: {}",
-            worker_names(&worker_pressure, "pressured")
         ));
     }
 
@@ -2939,6 +2957,7 @@ fn doctor_verdict(
         "next_operator_action": next_operator_action,
         "witness_age_ms": witness_age_ms,
         "open_canary_incident": open_canary_incident.unwrap_or(Value::Null),
+        "alert_plane": alert_plane,
         "worker_pressure": worker_pressure,
         "dogfood_gap_count": dogfood_gap_count,
         "receipt_run_references": receipt_run_references
@@ -2967,7 +2986,7 @@ fn next_operator_action(
         );
     }
     if failing_workers > 0 || pressured_workers > 0 {
-        return "Inspect `/readyz` worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`.".to_owned();
+        return "Inspect alert-plane worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`.".to_owned();
     }
     if canary_error_total > 0 {
         return "Run `bin/canary errors canary --window 1h --json`, fix the newest error class, and rerun `bin/canary doctor --json`.".to_owned();
@@ -3124,6 +3143,142 @@ fn worker_pressure_report(worker_readiness: &Value) -> Value {
         "workers": pressured,
         "failing": failing
     })
+}
+
+fn alert_plane_report(worker_readiness: &Value) -> Value {
+    if !worker_readiness
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return json!({
+            "available": false,
+            "status": "unavailable",
+            "reason": string_field(worker_readiness, "reason"),
+            "worker_count": 0,
+            "impaired_workers": 0,
+            "workers": [],
+            "reasons": []
+        });
+    }
+
+    let workers = worker_readiness
+        .get("workers")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let worker_count = worker_readiness
+        .get("worker_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(workers.len() as u64);
+    let impaired = workers
+        .iter()
+        .filter(|worker| alert_worker_is_impaired(worker))
+        .map(alert_plane_detail)
+        .collect::<Vec<_>>();
+    let reasons = impaired.iter().map(alert_plane_reason).collect::<Vec<_>>();
+    let status = if impaired.is_empty() {
+        "healthy"
+    } else {
+        "impaired"
+    };
+
+    json!({
+        "available": true,
+        "status": status,
+        "worker_count": worker_count,
+        "impaired_workers": impaired.len(),
+        "workers": impaired,
+        "reasons": reasons
+    })
+}
+
+fn alert_plane_detail(worker: &Value) -> Value {
+    json!({
+        "name": string_field(worker, "name"),
+        "state": string_field(worker, "state"),
+        "health": string_field(worker, "health"),
+        "failure_count": worker.get("failure_count").and_then(Value::as_u64).unwrap_or(0),
+        "consecutive_failures": worker.get("consecutive_failures").and_then(Value::as_u64).unwrap_or(0),
+        "due_count": worker.get("due_count").and_then(Value::as_u64).unwrap_or(0),
+        "in_flight_count": worker.get("in_flight_count").and_then(Value::as_u64).unwrap_or(0),
+        "oldest_due_age_ms": worker.get("oldest_due_age_ms").cloned().unwrap_or(Value::Null),
+        "backoff_or_circuit_open": worker.get("backoff_or_circuit_open").and_then(Value::as_bool).unwrap_or(false),
+        "reason": alert_worker_reason(worker)
+    })
+}
+
+fn alert_worker_is_impaired(worker: &Value) -> bool {
+    worker.get("state").and_then(Value::as_str) != Some("started")
+        || worker.get("health").and_then(Value::as_str) != Some("ok")
+        || worker
+            .get("failure_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            > 0
+        || worker
+            .get("consecutive_failures")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            > 0
+        || worker
+            .get("backoff_or_circuit_open")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+fn alert_worker_reason(worker: &Value) -> String {
+    let name = string_field(worker, "name");
+    let state = string_field(worker, "state");
+    let health = string_field(worker, "health");
+    if state != "started" {
+        return format!("{name} {state}");
+    }
+    if worker
+        .get("backoff_or_circuit_open")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return format!("{name} backoff_or_circuit_open");
+    }
+    if health != "ok" {
+        return format!("{name} {health}");
+    }
+    let consecutive_failures = worker
+        .get("consecutive_failures")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if consecutive_failures > 0 {
+        return format!("{name} consecutive_failures={consecutive_failures}");
+    }
+    let failure_count = worker
+        .get("failure_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if failure_count > 0 {
+        return format!("{name} failure_count={failure_count}");
+    }
+    format!("{name} impaired")
+}
+
+fn alert_plane_reason(worker: &Value) -> String {
+    worker
+        .get("reason")
+        .and_then(Value::as_str)
+        .map_or_else(|| alert_worker_reason(worker), ToOwned::to_owned)
+}
+
+fn alert_plane_reason_summary(alert_plane: &Value) -> String {
+    let reasons = alert_plane
+        .get("reasons")
+        .and_then(Value::as_array)
+        .map(|reasons| reasons.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .unwrap_or_default();
+    if reasons.is_empty() {
+        "unknown".to_owned()
+    } else {
+        reasons.join(", ")
+    }
 }
 
 fn worker_names(worker_pressure: &Value, key: &str) -> String {
@@ -3490,9 +3645,33 @@ fn item_state(item: &Value) -> &str {
 }
 
 fn public_probe(client: &ApiClient, path: &str) -> Value {
-    match client.get_public_json(path) {
-        Ok(value) => json!({"ok": true, "response": value}),
-        Err(error) => json!({"ok": false, "error": error.to_string()}),
+    let url = format!("{}{}", client.endpoint(), path);
+    let response = match client.client.get(url).send() {
+        Ok(response) => response,
+        Err(error) => return json!({"ok": false, "error": error.to_string()}),
+    };
+    let status = response.status();
+    let body = match response.text() {
+        Ok(body) => body,
+        Err(error) => return json!({"ok": false, "error": error.to_string()}),
+    };
+    let parsed = serde_json::from_str::<Value>(&body);
+    match (status.is_success(), parsed) {
+        (true, Ok(value)) => json!({"ok": true, "http_status": status.as_u16(), "response": value}),
+        (true, Err(error)) => {
+            json!({"ok": false, "http_status": status.as_u16(), "error": error.to_string()})
+        }
+        (false, Ok(value)) => json!({
+            "ok": false,
+            "http_status": status.as_u16(),
+            "error": format!("GET {path} returned {status}"),
+            "response": value
+        }),
+        (false, Err(_)) => json!({
+            "ok": false,
+            "http_status": status.as_u16(),
+            "error": format!("GET {path} returned {status}: {}", redact_text(&body))
+        }),
     }
 }
 
@@ -3587,13 +3766,6 @@ fn witness_monitor_report(status_probe: &Value, monitors_probe: &Value) -> Value
 }
 
 fn worker_readiness_report(readyz_probe: &Value) -> Value {
-    if !probe_ok(readyz_probe) {
-        return json!({
-            "available": false,
-            "reason": string_field(readyz_probe, "error")
-        });
-    }
-
     let Some(response) = readyz_probe.get("response") else {
         return json!({
             "available": false,
@@ -3765,6 +3937,40 @@ fn worker_readiness_summary(value: Option<&Value>) -> String {
         summary.push_str(&format!(", {missing_health} missing health fields"));
     }
     summary
+}
+
+fn alert_plane_summary(value: Option<&Value>) -> String {
+    let Some(value) = value else {
+        return "missing".to_owned();
+    };
+    if !value
+        .get("available")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return format!("unavailable: {}", string_field(value, "reason"));
+    }
+    let status = string_field(value, "status");
+    let worker_count = value
+        .get("worker_count")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    if status == "healthy" {
+        return format!("healthy {worker_count} workers");
+    }
+    let impaired_workers = value
+        .get("impaired_workers")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let noun = if impaired_workers == 1 {
+        "worker"
+    } else {
+        "workers"
+    };
+    format!(
+        "{status} {impaired_workers} {noun}: {}",
+        alert_plane_reason_summary(value)
+    )
 }
 
 fn dr_summary(value: Option<&Value>) -> String {
@@ -4059,6 +4265,7 @@ mod tests {
             "pressured_workers": 0,
             "workers": []
         });
+        let alert_plane = alert_plane_report(&worker_readiness);
         let dogfood = json!({
             "ok": true,
             "response": {
@@ -4088,6 +4295,7 @@ mod tests {
             &canary_errors,
             &witness,
             &worker_readiness,
+            &alert_plane,
             &dogfood,
             &receipt_runs,
             1_781_561_520_000,
@@ -4118,6 +4326,75 @@ mod tests {
     }
 
     #[test]
+    fn doctor_verdict_degrades_for_alert_plane_pressure_even_when_readyz_is_ready() {
+        let healthz = json!({"ok": true, "response": {"status": "ok"}});
+        let readyz = json!({"ok": true, "response": {"status": "ready"}});
+        let summary = json!({"ok": true, "summary": ["summary: Canary healthy"]});
+        let incidents = json!({"ok": true, "response": {"incidents": []}});
+        let canary_errors = json!({
+            "ok": true,
+            "response": {
+                "service": "canary",
+                "total_errors": 0
+            }
+        });
+        let witness = json!({
+            "status": "observed",
+            "monitor": "canary-watchman",
+            "state": "up",
+            "last_check_in_status": "alive",
+            "last_check_in_at": "2026-06-15T22:00:00Z",
+            "expected_every_ms": 600000
+        });
+        let worker_readiness = json!({
+            "available": true,
+            "status": "ready",
+            "worker_count": 2,
+            "failing_workers": 0,
+            "pressured_workers": 1,
+            "workers": [
+                {"name": "monitor_overdue", "state": "started", "health": "pressured", "failure_count": 0, "consecutive_failures": 0, "due_count": 1, "oldest_due_age_ms": 7200000, "backoff_or_circuit_open": false},
+                {"name": "target_probe", "state": "started", "health": "ok", "failure_count": 0, "consecutive_failures": 0, "due_count": 0, "oldest_due_age_ms": null, "backoff_or_circuit_open": false}
+            ]
+        });
+        let alert_plane = alert_plane_report(&worker_readiness);
+        let dogfood = json!({"ok": true, "response": {"strict_failures": []}});
+        let receipt_runs = json!({"ok": true, "runs": []});
+
+        let verdict = doctor_verdict(
+            &healthz,
+            &readyz,
+            &summary,
+            &incidents,
+            &canary_errors,
+            &witness,
+            &worker_readiness,
+            &alert_plane,
+            &dogfood,
+            &receipt_runs,
+            1_781_561_520_000,
+        );
+
+        assert_eq!(alert_plane["status"], "impaired");
+        assert_eq!(verdict["overall"], "degraded");
+        assert_eq!(verdict["alert_plane"]["status"], "impaired");
+        assert!(
+            verdict["blocking_signals"]
+                .as_array()
+                .is_some_and(|signals| signals.iter().any(|signal| signal
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("alert-plane impaired: monitor_overdue pressured")))
+        );
+        assert!(
+            verdict["next_operator_action"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("alert-plane")
+        );
+    }
+
+    #[test]
     fn worker_readiness_keeps_pressured_workers_separate_from_failures() {
         let readyz = json!({
             "ok": true,
@@ -4138,9 +4415,49 @@ mod tests {
         assert_eq!(report["worker_count"], 2);
         assert_eq!(report["failing_workers"], 0);
         assert_eq!(report["pressured_workers"], 1);
+        let alert_plane = alert_plane_report(&report);
+        assert_eq!(alert_plane["status"], "impaired");
+        assert_eq!(
+            alert_plane_summary(Some(&alert_plane)),
+            "impaired 1 worker: webhook_delivery pressured"
+        );
         assert_eq!(
             worker_readiness_summary(Some(&report)),
             "ready 2 workers, 0 failing, 1 pressured"
+        );
+    }
+
+    #[test]
+    fn alert_plane_uses_not_ready_worker_snapshots() {
+        let readyz = json!({
+            "ok": false,
+            "http_status": 503,
+            "error": "GET /readyz returned 503 Service Unavailable",
+            "response": {
+                "status": "not_ready",
+                "checks": {
+                    "workers": [
+                        {"name": "webhook_delivery", "state": "started", "health": "pressured", "failure_count": 0, "consecutive_failures": 0, "due_count": 9, "oldest_due_age_ms": 7200000, "backoff_or_circuit_open": true},
+                        {"name": "target_probe", "state": "started", "health": "failing", "failure_count": 3, "consecutive_failures": 3, "due_count": 1, "oldest_due_age_ms": 0, "backoff_or_circuit_open": false}
+                    ]
+                }
+            }
+        });
+
+        let report = worker_readiness_report(&readyz);
+        let alert_plane = alert_plane_report(&report);
+
+        assert_eq!(report["available"], true);
+        assert_eq!(report["status"], "not_ready");
+        assert_eq!(report["failing_workers"], 1);
+        assert_eq!(report["pressured_workers"], 1);
+        assert_eq!(alert_plane["status"], "impaired");
+        assert_eq!(
+            alert_plane["reasons"],
+            json!([
+                "webhook_delivery backoff_or_circuit_open",
+                "target_probe failing"
+            ])
         );
     }
 

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -120,6 +120,14 @@ fn doctor_summary_includes_watchman_and_self_errors() {
                 {"name": "retention_prune", "state": "started", "health": "ok", "failure_count": 0},
                 {"name": "tls_scan", "state": "started", "health": "ok", "failure_count": 0}
             ]
+        },
+        "alert_plane": {
+            "available": true,
+            "status": "healthy",
+            "worker_count": 5,
+            "impaired_workers": 0,
+            "workers": [],
+            "reasons": []
         }
     });
 
@@ -137,6 +145,11 @@ fn doctor_summary_includes_watchman_and_self_errors() {
         lines
             .iter()
             .any(|line| line == "worker_readiness: ready 5 workers, 0 failing")
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "alert_plane: healthy 5 workers")
     );
     assert!(
         lines.iter().any(|line| line
@@ -177,6 +190,16 @@ fn doctor_summary_flags_missing_restore_receipt_and_worker_health_schema() {
             "workers": [
                 {"name": "webhook_delivery", "state": "started", "failure_count": 0}
             ]
+        },
+        "alert_plane": {
+            "available": true,
+            "status": "impaired",
+            "worker_count": 1,
+            "impaired_workers": 1,
+            "workers": [
+                {"name": "webhook_delivery", "state": "started", "health": "unknown"}
+            ],
+            "reasons": ["webhook_delivery unknown"]
         }
     });
 
@@ -186,6 +209,11 @@ fn doctor_summary_flags_missing_restore_receipt_and_worker_health_schema() {
     assert!(lines.iter().any(
         |line| line == "worker_readiness: ready 1 workers, 1 failing, 1 missing health fields"
     ));
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "alert_plane: impaired 1 worker: webhook_delivery unknown")
+    );
 }
 
 #[test]
@@ -248,10 +276,20 @@ fn doctor_summary_reports_worker_pressure_separately() {
                 {"name": "target_probe", "state": "started", "health": "ok", "failure_count": 0}
             ]
         },
+        "alert_plane": {
+            "available": true,
+            "status": "impaired",
+            "worker_count": 2,
+            "impaired_workers": 1,
+            "workers": [
+                {"name": "webhook_delivery", "state": "started", "health": "pressured"}
+            ],
+            "reasons": ["webhook_delivery pressured"]
+        },
         "verdict": {
             "overall": "degraded",
-            "blocking_signals": ["worker pressure: webhook_delivery"],
-            "next_operator_action": "Inspect `/readyz` worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`."
+            "blocking_signals": ["alert-plane impaired: webhook_delivery pressured"],
+            "next_operator_action": "Inspect alert-plane worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`."
         }
     });
 
@@ -261,8 +299,13 @@ fn doctor_summary_reports_worker_pressure_separately() {
             .iter()
             .any(|line| line == "worker_readiness: ready 2 workers, 0 failing, 1 pressured")
     );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "alert_plane: impaired 1 worker: webhook_delivery pressured")
+    );
     assert!(lines.iter().any(|line| line
-        == "verdict: degraded; next: Inspect `/readyz` worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`."));
+        == "verdict: degraded; next: Inspect alert-plane worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`."));
 }
 
 #[test]

--- a/crates/canary-cli/tests/fixtures/doctor_watchman_down.json
+++ b/crates/canary-cli/tests/fixtures/doctor_watchman_down.json
@@ -101,6 +101,14 @@
     "schema_missing_health_fields": 0,
     "workers": []
   },
+  "alert_plane": {
+    "available": true,
+    "status": "healthy",
+    "worker_count": 5,
+    "impaired_workers": 0,
+    "workers": [],
+    "reasons": []
+  },
   "verdict": {
     "overall": "degraded",
     "blocking_signals": [

--- a/docs/agent-first-identity.md
+++ b/docs/agent-first-identity.md
@@ -1,0 +1,163 @@
+# Agent-First Identity
+
+Canary's identity is simple: production health for agents.
+
+The system exists so many agents can safely watch deployed applications, wake
+up on important events, coordinate ownership, query context, and write back
+evidence without a dashboard or a human-only incident process.
+
+## Core Philosophy
+
+Agents are not dashboard users. They are readers, writers, and responders.
+
+They need stable contracts, compact context, replayable timelines, and explicit
+ownership state. They do not need charts, tabs, or a pile of integrations that
+hide the actual event stream.
+
+Canary should feel like a small command center:
+
+- It records what happened.
+- It decides enough to make the first response cheap.
+- It wakes agents without making webhooks authoritative.
+- It lets agents claim work before acting.
+- It preserves the evidence trail after the agent goes away.
+
+## Design Laws
+
+### 1. Agents are the primary users
+
+Every public surface should work well in a transcript, CLI JSON envelope, API
+response, or MCP tool result. Human operators inspect those same surfaces.
+
+### 2. The timeline is truth
+
+Notifications can be missed, duplicated, retried, or delivered late. Agents
+recover by replaying timeline state from a persisted cursor.
+
+### 3. Webhooks wake; they do not decide
+
+A signed webhook tells a downstream agent to wake up. It must not be treated as
+the full source of context. The receiver verifies the signature, deduplicates
+the delivery id, then queries Canary.
+
+### 4. Claims prevent duplicate agents
+
+Before an agent investigates or repairs an incident, error group, target, or
+monitor, it creates a remediation claim with an idempotency key. Active claims
+are the coordination state.
+
+### 5. Every high-level read returns one next action
+
+Reports, doctor verdicts, integration status, and value receipts should avoid
+menus of vague suggestions. The default output is one concrete next action and
+links or ids for drill-down.
+
+### 6. Summaries are deterministic
+
+Canary may feed LLMs, but it does not put an LLM on the request path. Summaries
+are templates over typed state so agents can trust them as stable evidence.
+
+### 7. Integration is not installation
+
+Adding an SDK or target is not enough. A service is covered only when live
+readback proves health, ingest, query, and the relevant target, monitor,
+webhook, or receipt state.
+
+### 8. Canary does not fix production
+
+Canary records, correlates, routes, and coordinates. Repository mutation,
+issue creation, LLM triage, deployment rollback, and customer communication
+live downstream.
+
+### 9. The product stays small
+
+If a feature needs a dashboard, distributed trace store, human war room, or
+full log platform to make sense, it probably belongs outside Canary. Canary
+should integrate by durable events and read models instead.
+
+### 10. Self-watch is a first-class consumer
+
+Canary must prove itself the same way it asks other services to prove
+coverage: external witness, readback, receipts, worker readiness, and explicit
+operator verdicts.
+
+## Agent UX Contract
+
+The ideal agent flow is:
+
+1. Wake from a signed webhook or scheduled poll.
+2. Read `canary_doctor` or `GET /api/v1/report?window=1h`.
+3. If there is a subject to work, create a remediation claim.
+4. Read the specific subject: incident detail, error group, target, monitor,
+   timeline, annotations, and delivery diagnostics as needed.
+5. Act outside Canary.
+6. Write annotations, claim transitions, evidence links, and final status.
+7. Persist the timeline cursor and go idle.
+
+The CLI/API/MCP surface is good when an agent can complete that loop without
+knowing internal table names, raw route trivia, or chat-only instructions.
+
+## Current Useful Surfaces
+
+- `bin/canary doctor --json`: current trust verdict for Canary itself.
+- `bin/canary dogfood value --service <name> --json`: per-service value
+  receipt with coverage, live readback, stale evidence, and next action.
+- `GET /api/v1/report`: bounded current state for agents without saved cursors.
+- `GET /api/v1/timeline`: durable replay after report or webhook wake-up.
+- `GET /api/v1/incidents/{id}`: incident-level entrypoint with correlated
+  signals and annotations.
+- `POST /api/v1/claims`: ownership before triage or repair.
+- `POST /api/v1/annotations`: evidence and decisions after work.
+- `bin/canary integrate status/plan/patch/enroll`: setup loop for deployed
+  services.
+- `bin/canary mcp-manifest`: machine-readable tool contract for MCP wrappers.
+
+## Value To Consuming Applications
+
+For a consuming application, Canary provides:
+
+- one place to write production errors and operational events
+- one place to prove HTTP uptime or non-HTTP liveness
+- one durable incident and timeline model for downstream agents
+- one agent-readable readback contract instead of several human dashboards
+- one coordination primitive to prevent duplicate remediation agents
+- one integration receipt that says whether coverage is real or stale
+
+The value is strongest when the consuming app has agents ready to listen and
+respond. Without agents, Canary is still a useful small monitor, but it is not
+trying to beat mature human-first observability suites on breadth.
+
+## Anti-Patterns
+
+- Adding a human dashboard because a response shape is hard to read.
+- Treating webhook delivery as proof without timeline replay.
+- Marking a service covered because env vars or code paths exist.
+- Letting agents mutate repos or infrastructure through Canary-owned routes.
+- Adding broad logs, traces, metrics, or LLM eval features before the incident
+  and claim loop is excellent.
+- Returning several plausible next actions when one safe action can be named.
+- Allowing stale dogfood evidence to masquerade as current value.
+
+## Product Taste
+
+Canary should feel calm, terse, and exact.
+
+Good output:
+
+- names the unhealthy subject
+- says whether an agent already owns it
+- gives the recent facts that matter
+- links to the durable ids needed for replay
+- names one next action
+
+Bad output:
+
+- dumps raw telemetry
+- asks the agent to inspect a dashboard
+- hides stale evidence
+- wakes multiple agents with no claim path
+- creates incidents without enough context to act
+- blends human process with agent coordination
+
+The project should keep choosing the smaller primitive that makes agents more
+effective.

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -106,6 +106,14 @@ The doctor envelope's `response` object includes an operator verdict:
       "failing_workers": 0,
       "workers": []
     },
+    "alert_plane": {
+      "available": true,
+      "status": "healthy",
+      "worker_count": 5,
+      "impaired_workers": 0,
+      "workers": [],
+      "reasons": []
+    },
     "dogfood_gap_count": 3,
     "receipt_run_references": {
       "ok": true,
@@ -128,7 +136,7 @@ The doctor envelope's `response` object includes an operator verdict:
 
 `overall` is `healthy` only when the public routes are reachable, authenticated
 readback works, the external witness is observed as up, no `service=canary`
-incident is open, and workers are not failing or pressured. `degraded` means an
+incident is open, and `alert_plane.status` is `healthy`. `degraded` means an
 agent can still inspect Canary but has work to do. `unable` means Canary cannot
 produce enough authenticated self-watch evidence to trust the rest of the
 report. Dogfood gaps are counted in the verdict but are not by themselves a
@@ -138,14 +146,16 @@ The worker readiness line is derived from `/readyz` and should look like:
 
 ```text
 worker_readiness: ready 5 workers, 0 failing
+alert_plane: healthy 5 workers
 ```
 
 If a worker reports `health: pressured`, the route can still be ready. Doctor
-reports that as operational pressure rather than counting the same worker as
-both ready and failing:
+reports that as impaired alert-plane health rather than counting the same
+worker as both route-failing and healthy:
 
 ```text
 worker_readiness: ready 5 workers, 0 failing, 1 pressured
+alert_plane: impaired 1 worker: monitor_overdue pressured
 ```
 
 `doctor` also surfaces DR evidence:

--- a/docs/architecture/canary-agent-first-groom-2026-06-19.md
+++ b/docs/architecture/canary-agent-first-groom-2026-06-19.md
@@ -1,0 +1,114 @@
+# Canary Agent-First Groom - 2026-06-19
+
+## Source Matrix
+
+| Lane | Status | Evidence | Contribution |
+|---|---|---|---|
+| Tidy mechanics | complete | `harness-kit-checks backlog ids-from-range origin/master..master` returned no ids; active files only `010`, `020`, `047`, `048`, `049` before edits | No archive move. Active queue needed shaping, not cleanup. |
+| Vision | complete | `VISION.md`, `docs/agent-first-identity.md` | Vision is current and concrete: agent-first production health, timeline truth, claims before work, deterministic summaries, no dashboard. |
+| Live state | complete | `bin/canary doctor --json`; `bin/canary dogfood audit --strict --json`; `bin/canary dogfood value --service linejam --json`; `bin/canary dogfood value --service chrondle --json` | Runtime is healthy with fresh witness receipts, but dogfood strict still fails on 45 coverage/evidence gaps. `linejam` is proven; `chrondle` is stale-registry-evidence despite clean live readback. |
+| Product/value lane | complete | `VISION.md`, `docs/agent-first-identity.md`, `priv/dogfood/owned_services.json`, live dogfood commands | Canary's wedge is strong, but usefulness depends on stopping coverage/evidence overclaiming. Suggested promoting #049; lead kept it pending behind #048 safety. |
+| Runtime/ops lane | complete | `bin/canary-witness`, worker modules, #047 | #047 is real: route readiness and alert-plane health are different. First slice must be induced impairment, not SLO math. |
+| Security/privacy lane | complete | `server_auth.rs`, claims/annotations routes, OpenAPI, #048/#049 | #048 must own responder-write scope, minimized context, read-audit, public-ingest/relay, and CLI/MCP authority parity before broad responder/integration productization. |
+| Architecture lane | complete | `wc -l`; `crates/canary-server/src/lib.rs`; `crates/canary-store/src/query.rs`; CLI integrate commands | Server/router and query modules are large, but immediate product risk is semantic trust: integration apply/readback and context authority. Consolidating #048/#049 was rejected to preserve safety-before-evidence sequencing. |
+| Test/verification lane | complete | `dagger/src/index.ts`, `bin/canary-witness`, witness shell tests, #047/#049 | Gate is strong for the happy path. Missing falsifiers are induced alert-plane impairment, future check-in skew, and integration receipt overclaiming. |
+| Agent readiness lane | complete | `bin/canary --help`, `docs/agent-inspection-cli.md`, MCP manifest, `.codex/agents` | CLI JSON and MCP manifest are good; missing a single cold-agent readiness proof. Added #050. |
+| External exemplars | complete | Sentry, Better Stack, UptimeRobot, PagerDuty, incident.io, OpenTelemetry/Grafana/Honeycomb, Langfuse public positioning | Competitors are better for mature APM, incident command, generic uptime, broad telemetry, or LLM traces. Canary should borrow MCP/coding-agent integration and simple setup, but reject broad APM and LLM-on-request-path expansion. |
+
+## Strategic Read
+
+Canary is not missing a vision anymore. The current vision is sharp: a small
+agent-first production health command center where timelines are truth,
+webhooks wake agents, claims prevent duplicate work, and agents write back
+evidence. The backlog should now make that trustable.
+
+The live state says Canary is operationally healthy but not yet broadly
+trustworthy as a consumption substrate. `doctor` reports healthy runtime and
+fresh witness runs, while dogfood strict still reports 45 coverage/evidence
+failures. That is the product gap: not "can Canary observe something?", but
+"can agents trust Canary's signal, ownership, and receipts without rechecking
+the world?"
+
+## Decisions
+
+1. Keep #047 as the best next pickup.
+   The first slice is not burn-rate math. It is an induced alert-plane
+   impairment proof showing that doctor and the external witness degrade when
+   alertability is impaired even if `/readyz` remains route-ready.
+
+2. Keep #048 before #049.
+   Arbitrary responders need least-privilege claims/annotations, minimized
+   context envelopes, read audit, webhook conformance, public-ingest/relay
+   browser safety, and HTTP/CLI/MCP authority parity before integration apply
+   can be trusted for third-party or arbitrary-agent consumers.
+
+3. Keep #049 pending, but harden it.
+   The ticket remains the integration evidence closure epic. It now explicitly
+   forbids verified coverage from target/key creation alone, global webhook
+   presence, stale evidence, or missing synthetic service-specific readback.
+
+4. Add #050.
+   Canary has good docs and machine surfaces, but no one-entrypoint cold-agent
+   readiness proof. #050 packages the repo's agent operating proof into a
+   script/skill/self-check plus redacted receipt.
+
+5. Defer module-splitting backlog.
+   `crates/canary-server/src/lib.rs` and `crates/canary-store/src/query.rs` are
+   large enough to watch, but the current priority is semantic trust. A future
+   refactor ticket is warranted when #047/#048/#049 implementation touches
+   those modules enough that extraction pays for itself.
+
+## Backlog Diff
+
+- Updated `backlog.d/047-alert-plane-slo-burn-rate.md`:
+  - retitled around proving alert-plane health separately from route readiness
+  - added PRD summary, product requirements, technical design, and verification system
+  - reordered children so induced impairment comes before SLO/burn-rate work
+
+- Updated `backlog.d/048-responder-rich-context-safety-gate.md`:
+  - retitled around external responder safety
+  - added PRD summary, product requirements, technical design, and verification system
+  - expanded scope to include public-ingest/relay browser safety and HTTP/CLI/MCP authority parity
+
+- Updated `backlog.d/049-integration-evidence-closure.md`:
+  - added PRD summary, product requirements, technical design, and verification system
+  - hardened oracle around service-specific webhook coverage, synthetic readback, and stale-evidence failure
+  - kept status `pending` behind #048 safety work
+
+- Added `backlog.d/050-cold-agent-readiness-proof.md`:
+  - P1/M pending ticket for one cold-agent proof path and redacted readiness receipt
+
+- Updated `backlog.d/README.md`:
+  - added #050 to active order
+  - refreshed dependency map, lanes, active order, and migration notes
+
+## Rejected Moves
+
+- Do not consolidate #048 and #049 now. Safety and evidence are related but the
+  sequence matters: responder authority and context safety must precede broad
+  integration apply.
+- Do not promote #049 to ready yet. The safety substrate from #048 should land
+  first, or #049 risks implementing browser/MCP/apply mechanics around the
+  wrong trust model.
+- Do not add an AI/LLM feature epic. External competitors are adding AI helpers,
+  but Canary's identity is deterministic summaries and no LLM on the request
+  path. Agents can consume Canary; Canary should not become the agent brain.
+
+## External Sources
+
+- Sentry: <https://sentry.io/>
+- Better Stack: <https://betterstack.com/> and <https://betterstack.com/uptime>
+- UptimeRobot: <https://uptimerobot.com/>
+- PagerDuty: <https://www.pagerduty.com/platform/incident-management/>
+- incident.io: <https://incident.io/>
+- OpenTelemetry: <https://opentelemetry.io/>
+- Grafana: <https://grafana.com/products/cloud/features/>
+- Honeycomb: <https://www.honeycomb.io/platform/opentelemetry>
+- Langfuse: <https://langfuse.com/docs/observability/overview>
+
+## Best Next Pickup
+
+Pick up #047 child 1 and 3 together: implement the alert-plane verdict and the
+induced impairment rehearsal. That slice directly tests the core product claim:
+Canary can tell agents when its own alerting plane is not trustworthy, even if
+the HTTP service is still up.

--- a/docs/architecture/canary-agent-first-positioning-2026-06-19.html
+++ b/docs/architecture/canary-agent-first-positioning-2026-06-19.html
@@ -1,0 +1,407 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Canary Agent-First Positioning - 2026-06-19</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #151515;
+      --muted: #5f6368;
+      --line: #d8d8d8;
+      --wash: #f6f6f3;
+      --panel: #ffffff;
+      --accent: #0f5f6b;
+      --warn: #8a4b00;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: var(--wash);
+      line-height: 1.45;
+    }
+
+    main {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 32px 0 56px;
+    }
+
+    header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 0.42fr);
+      gap: 28px;
+      align-items: end;
+      min-height: 62vh;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 28px;
+    }
+
+    h1 {
+      max-width: 860px;
+      margin: 0;
+      font-size: clamp(40px, 7vw, 92px);
+      line-height: 0.95;
+      letter-spacing: 0;
+    }
+
+    h2,
+    h3 {
+      letter-spacing: 0;
+      line-height: 1.05;
+    }
+
+    .kicker,
+    .label {
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .lede {
+      max-width: 760px;
+      color: var(--muted);
+      font-size: 20px;
+    }
+
+    .panel,
+    .cell {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      padding: 20px;
+    }
+
+    .grid {
+      display: grid;
+      gap: 1px;
+      background: var(--line);
+      border: 1px solid var(--line);
+      margin-top: 28px;
+    }
+
+    .grid > * {
+      border: 0;
+    }
+
+    .cols-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .cols-4 {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    section {
+      margin-top: 48px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      margin-top: 18px;
+    }
+
+    th,
+    td {
+      border: 1px solid var(--line);
+      padding: 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      background: #eeeeea;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    code {
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 0.94em;
+      background: #eeeeea;
+      padding: 0.12em 0.28em;
+    }
+
+    a {
+      color: var(--accent);
+    }
+
+    .muted {
+      color: var(--muted);
+    }
+
+    .warn {
+      color: var(--warn);
+    }
+
+    ul {
+      padding-left: 1.2em;
+    }
+
+    @media (max-width: 860px) {
+      header,
+      .cols-2,
+      .cols-3,
+      .cols-4 {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div>
+      <p class="kicker">Context packet / 2026-06-19</p>
+      <h1>Make Canary the smallest agent-first command center for production health.</h1>
+      <p class="lede">Chosen direction: tighten the identity around errors, uptime, health, incidents, timeline replay, and remediation claims. Do not chase dashboards, APM breadth, or human incident-suite parity.</p>
+    </div>
+    <aside class="panel">
+      <p class="label">Proof surface</p>
+      <p>Live repo docs, checked-in dogfood registry, deployed Canary CLI readbacks, and current competitor research.</p>
+      <p class="label">Stop conditions</p>
+      <p>Stop if vision requires a dashboard, if agent ownership is ambiguous, or if coverage is claimed without live readback.</p>
+      <p class="muted">Premise source: direct operator request in current thread. Waiver: no standalone source file for the spoken premise; current-state claims are grounded below.</p>
+    </aside>
+  </header>
+
+  <section class="grid cols-4" aria-label="current-state-summary">
+    <article class="cell">
+      <p class="label">Runtime</p>
+      <p><code>bin/canary doctor --json</code> returned <strong>healthy</strong>, no runtime blockers, workers ready.</p>
+    </article>
+    <article class="cell">
+      <p class="label">Dogfood</p>
+      <p>Registry has 4 active services, 2 pending, 5 blocked, 2 follow-on, and 1 ignored service.</p>
+    </article>
+    <article class="cell">
+      <p class="label">Usefulness</p>
+      <p>Value receipts prove <code>linejam</code>, <code>canary-self</code>, and <code>vulcan</code>; <code>chrondle</code> is live-clean but has stale registry evidence.</p>
+    </article>
+    <article class="cell">
+      <p class="label">Weakness</p>
+      <p>Doctor still reports 45 dogfood strict failures and 42 value-unproven services, so the product is useful but over-noisy at portfolio scale.</p>
+    </article>
+  </section>
+
+  <section>
+    <h2>Position</h2>
+    <div class="grid cols-3">
+      <article class="cell">
+        <h3>What Canary owns</h3>
+        <p>Error ingest, health targets, check-in monitors, incidents, timelines, signed webhooks, delivery diagnostics, annotations, remediation claims, integration receipts, and compact agent reads.</p>
+      </article>
+      <article class="cell">
+        <h3>What consumers get</h3>
+        <p>A single command/API/MCP-shaped surface for agents to learn what broke, claim the work, avoid duplicate responders, query context, and write back evidence.</p>
+      </article>
+      <article class="cell">
+        <h3>What stays out</h3>
+        <p>Dashboards, broad APM, full logs, distributed tracing, LLM evaluation, human incident rooms, repo mutation, and autonomous remediation policy.</p>
+      </article>
+    </div>
+  </section>
+
+  <section>
+    <h2>Current Use</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Service</th>
+          <th>Current state</th>
+          <th>Value Canary provides</th>
+          <th>Gap</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>canary-self</code></td>
+          <td>Active, verified, value receipt proven.</td>
+          <td>Self health target, worker readiness, external witness, doctor verdict.</td>
+          <td>Keep witness receipts fresh and visible after deploys.</td>
+        </tr>
+        <tr>
+          <td><code>linejam</code></td>
+          <td>Active, verified, value receipt proven.</td>
+          <td>Reference integration for health, ingest, and downstream responder coverage.</td>
+          <td>Use as the canonical consumer exemplar.</td>
+        </tr>
+        <tr>
+          <td><code>chrondle</code></td>
+          <td>Active and live-clean, but receipt flags stale registry evidence.</td>
+          <td>Shows Canary can prevent stale triage claims from looking current.</td>
+          <td>Refresh dogfood registry evidence and next action.</td>
+        </tr>
+        <tr>
+          <td><code>vulcan</code></td>
+          <td>Active, verified, value receipt proven with 129 errors in 24h.</td>
+          <td>Health and error visibility for Adminifi orchestrator surface.</td>
+          <td>Needs ownership consolidation and triage policy outside Canary.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Competitor Map</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Tool class</th>
+          <th>Why teams choose it</th>
+          <th>Why choose Canary instead</th>
+          <th>Source</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Sentry</td>
+          <td>Developer-first error monitoring, stack traces, release health, performance, replay, broad SDKs, and now explicit MCP/agent setup docs.</td>
+          <td>Canary is smaller, self-hosted, and treats the event/timeline/claim loop as the product instead of issue triage UI.</td>
+          <td><a href="https://sentry.io/product/error-monitoring">Sentry error monitoring</a>, <a href="https://docs.sentry.io/">Sentry docs</a></td>
+        </tr>
+        <tr>
+          <td>UptimeRobot</td>
+          <td>Hosted uptime, SSL/domain/cron checks, status pages, webhooks, and simple API automation.</td>
+          <td>Canary combines uptime with error context, incidents, claims, annotations, and agent replay in one self-hosted ledger.</td>
+          <td><a href="https://uptimerobot.com/api">UptimeRobot API</a>, <a href="https://uptimerobot.com/knowledge-hub/monitoring/what-is-uptimerobot">UptimeRobot overview</a></td>
+        </tr>
+        <tr>
+          <td>Better Stack</td>
+          <td>Hosted logs, uptime, tracing, incident management, status pages, on-call, AI SRE, and MCP positioning at lower Datadog-style cost.</td>
+          <td>Canary is intentionally smaller and owner-operated; the agent coordination state is first-class rather than one workflow among many.</td>
+          <td><a href="https://betterstack.com/">Better Stack</a>, <a href="https://betterstack.com/uptime">Better Stack uptime</a></td>
+        </tr>
+        <tr>
+          <td>Datadog / New Relic / Grafana / Honeycomb</td>
+          <td>Full-stack logs, metrics, traces, OpenTelemetry, SLOs, high-cardinality analysis, dashboards, and enterprise observability.</td>
+          <td>Canary avoids telemetry platform breadth and optimizes the first agent response to production health events.</td>
+          <td><a href="https://www.honeycomb.io/">Honeycomb</a>, <a href="https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-opentelemetry">Grafana OpenTelemetry</a>, <a href="https://newrelic.com/platform/log-management">New Relic logs</a></td>
+        </tr>
+        <tr>
+          <td>PagerDuty / incident.io</td>
+          <td>Human on-call, escalation, incident rooms, workflows, customer communications, AI-assisted response, and enterprise process.</td>
+          <td>Canary is the upstream signal and coordination ledger for agents; downstream incident suites can still consume its webhooks and timeline.</td>
+          <td><a href="https://www.pagerduty.com/platform/aiops">PagerDuty AIOps</a>, <a href="https://incident.io/">incident.io</a></td>
+        </tr>
+        <tr>
+          <td>Langfuse / LLM observability</td>
+          <td>LLM traces, prompts, token cost, retrieval/tool-call visibility, evals, and human annotation for AI products.</td>
+          <td>Canary watches deployed application health. It can monitor agents as apps, but it should not become an LLM eval platform.</td>
+          <td><a href="https://langfuse.com">Langfuse</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Recommended Documentation Change</h2>
+    <div class="grid cols-3">
+      <article class="cell">
+        <h3><code>VISION.md</code></h3>
+        <p>Make this the canonical product promise, competitor stance, principles, and roadmap bias.</p>
+      </article>
+      <article class="cell">
+        <h3><code>docs/agent-first-identity.md</code></h3>
+        <p>Define the design laws and UX contract agents should experience across API, CLI, SDK, and MCP.</p>
+      </article>
+      <article class="cell">
+        <h3><code>README.md</code></h3>
+        <p>Link the identity docs from the project front door so future work starts with the right product frame.</p>
+      </article>
+    </div>
+  </section>
+
+  <section>
+    <h2>Oracle</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Check</th>
+          <th>Command or artifact</th>
+          <th>Expected result</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Cleanup</td>
+          <td><code>git worktree list --porcelain</code></td>
+          <td>Only <code>/Users/phaedrus/Development/canary</code> remains registered.</td>
+        </tr>
+        <tr>
+          <td>Docs compile as prose</td>
+          <td><code>rg -n "MCP server|dashboard" VISION.md docs/agent-first-identity.md README.md</code></td>
+          <td>No stale claim that Canary is not MCP-shaped; dashboard remains an explicit non-goal.</td>
+        </tr>
+        <tr>
+          <td>Live current-state evidence</td>
+          <td><code>bin/canary doctor --json</code> and <code>bin/canary dogfood value --service linejam --json</code></td>
+          <td>Canary health and dogfood usefulness claims are grounded in deployed readback.</td>
+        </tr>
+        <tr>
+          <td>Repo gate</td>
+          <td><code>./bin/validate --fast</code></td>
+          <td>Fast repo validation passes after documentation edits.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Research Source Matrix</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Lane</th>
+          <th>Status</th>
+          <th>Contribution</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Codebase</td>
+          <td>Complete</td>
+          <td><code>VISION.md</code>, <code>README.md</code>, <code>docs/agent-inspection-cli.md</code>, <code>docs/remediation-claims.md</code>, <code>priv/openapi/openapi.json</code>, and dogfood registry.</td>
+        </tr>
+        <tr>
+          <td>Live CLI</td>
+          <td>Complete</td>
+          <td><code>doctor</code>, service registry, open incidents, and active-service value receipts.</td>
+        </tr>
+        <tr>
+          <td>External retrieval</td>
+          <td>Complete</td>
+          <td>Official or near-official competitor positioning for Sentry, UptimeRobot, Better Stack, Honeycomb, Grafana, New Relic, PagerDuty, incident.io, and Langfuse.</td>
+        </tr>
+        <tr>
+          <td>Discourse / social</td>
+          <td>Skipped</td>
+          <td>Not required for the documentation decision; current official positioning was enough.</td>
+        </tr>
+        <tr>
+          <td>Repo-aware critique</td>
+          <td>Partial</td>
+          <td>Applied works-critique lens locally. Fresh external critic not dispatched because this is documentation shaping with low runtime risk.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/architecture/canary-alert-plane-delivery-plan-2026-06-20.html
+++ b/docs/architecture/canary-alert-plane-delivery-plan-2026-06-20.html
@@ -1,0 +1,299 @@
+<!doctype html>
+<html lang="en" data-ae-mode="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Canary Alert-Plane Delivery Plan</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=Geist+Mono:wght@100..900&amp;display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v2.5.1/aesthetic.css">
+  <style>
+    :root {
+      --ae-accent: #1f6f64;
+      --ae-accent-dark: #7bd0c4;
+    }
+
+    .plan-wide .ae-bar,
+    .plan-wide .ae-stage {
+      width: min(92rem, 100% - 4rem);
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(25em, 0.72fr);
+      gap: 3em;
+      align-items: end;
+    }
+
+    .kicker {
+      display: block;
+      margin-bottom: 0.8em;
+    }
+
+    .rule {
+      border-top: 1px solid var(--ae-line);
+      margin: 1.5em 0;
+    }
+
+    .grid-2,
+    .grid-3,
+    .grid-4,
+    .grid-5 {
+      display: grid;
+      gap: 1px;
+      background: var(--ae-line);
+    }
+
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .grid-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+
+    .cell {
+      min-width: 0;
+      background: var(--ae-surface);
+      padding: 1.2em 1.35em;
+    }
+
+    .wash { background: var(--ae-wash); }
+
+    .phase {
+      display: grid;
+      grid-template-columns: 8em minmax(0, 1fr) minmax(15em, 0.68fr);
+      gap: 1.3em;
+      border-top: 1px solid var(--ae-line);
+      padding-top: 1em;
+      margin-top: 1em;
+    }
+
+    .phase:first-child {
+      border-top: 0;
+      margin-top: 0;
+      padding-top: 0;
+    }
+
+    .table-wrap { overflow-x: auto; }
+
+    .status {
+      display: inline-flex;
+      gap: 0.45em;
+      align-items: baseline;
+    }
+
+    .status svg { transform: translateY(0.15em); }
+
+    .review-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 2em;
+    }
+
+    @media (max-width: 980px) {
+      .plan-wide .ae-bar,
+      .plan-wide .ae-stage {
+        width: min(100% - 2rem, 92rem);
+      }
+
+      .hero,
+      .grid-2,
+      .grid-3,
+      .grid-4,
+      .grid-5,
+      .phase,
+      .review-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+<svg aria-hidden="true" style="display: none" xmlns="http://www.w3.org/2000/svg">
+  <symbol id="i-check" viewBox="0 0 24 24">
+    <path d="M20 6 9 17l-5-5"></path>
+  </symbol>
+  <symbol id="i-alert" viewBox="0 0 24 24">
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"></path>
+    <path d="M12 9v4"></path>
+    <path d="M12 17h.01"></path>
+  </symbol>
+</svg>
+
+<div class="ae-screen plan-wide">
+  <header class="ae-bar">
+    <a class="ae-name" href="../../backlog.d/047-alert-plane-slo-burn-rate.md">BACKLOG 047 / ALERT PLANE</a>
+    <p class="ae-chrome">delivery plan opened before implementation</p>
+  </header>
+
+  <main class="ae-stage ae-stage-scroll">
+    <article class="ae-view">
+      <section class="hero" aria-label="Plan contract">
+        <div>
+          <p class="ae-chrome kicker">P0 FIRST DELIVERABLE</p>
+          <h1 class="ae-strong">Canary can be route-ready while refusing to call the alert plane healthy.</h1>
+          <p class="ae-lede">Add a stricter operational verdict over the existing worker readiness data. Keep <code>/readyz</code> as deploy readiness, then make <code>bin/canary doctor</code> and <code>bin/canary-witness</code> degrade when alert workers are pressured, in backoff, stale, failing, or otherwise unable to route events reliably.</p>
+        </div>
+        <aside class="ae-panel">
+          <h2 class="ae-h">CHOSEN DESIGN</h2>
+          <p><span class="status"><svg class="ae-icon ae-ok"><use href="#i-check"></use></svg> Derive an <code>alert_plane</code> verdict from current <code>/readyz</code> worker snapshots and expose it in doctor/witness receipts.</span></p>
+          <div class="rule"></div>
+          <h2 class="ae-h">QUALITY SYSTEM</h2>
+          <p>Standards: deterministic JSON, no new storage, no LLM request path, no change to route readiness semantics, no secret output.</p>
+          <p>Proof: shell witness fixture, CLI unit tests, fast gate, full gate, live doctor readback, and artifact-only critic.</p>
+          <div class="rule"></div>
+          <p class="ae-dim">Premise source: <code>sha256:9374c9f48c93a1e2792d45d1beb88885fb5090132a479475b24d5c5631f672ec backlog.d/047-alert-plane-slo-burn-rate.md</code></p>
+          <p class="ae-dim">Plan status: authored for rendered review before code.</p>
+        </aside>
+      </section>
+
+      <section class="grid-5" aria-label="Executive contract" style="margin-top: 2em">
+        <article class="cell">
+          <h2 class="ae-h">STANDARDS</h2>
+          <p>Small Rust/CLI diff, existing JSON envelope style, deterministic summaries, no weakening of <code>./bin/validate</code>.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">ACCEPTANCE</h2>
+          <p>Pressured alert workers make doctor and witness non-healthy while <code>/readyz</code> remains ready.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">VERIFY</h2>
+          <p><code>cargo test -p canary-cli</code>, <code>bash test/bin/canary_witness_test.sh</code>, <code>./bin/validate --fast</code>, <code>./bin/validate</code>.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">COMMUNICATE</h2>
+          <p>Report the chosen next ticket, edited surfaces, witness receipt behavior, review result, gate, and tree state.</p>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">STOP IF</h2>
+          <p>Implementation requires persistent SLO schema, new auth scopes, or changing <code>/readyz</code> failure semantics.</p>
+        </article>
+      </section>
+
+      <section class="grid-3" aria-label="Current change proof" style="margin-top: 1px">
+        <article class="cell">
+          <h2 class="ae-h">CURRENT STATE</h2>
+          <p><code>/readyz</code> returns HTTP 200 for <code>health: pressured</code>. The witness currently treats <code>ok</code> or <code>pressured</code> as acceptable.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">CHANGE SHAPE</h2>
+          <p>Add one alert-plane classifier reused by doctor summaries and witness jq checks. Update docs and tests to make pressure operationally degraded.</p>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">PROOF SURFACE</h2>
+          <p>The <code>pressured</code> fake-curl witness fixture must exit nonzero, skip check-in, and preserve the ready route response plus alert-plane reasons.</p>
+        </article>
+      </section>
+
+      <section class="grid-2" aria-label="Scope and anchors" style="margin-top: 2em">
+        <article class="cell">
+          <h2 class="ae-h">SCOPE</h2>
+          <p><strong>Goal:</strong> agents can distinguish HTTP readiness from alertability trust.</p>
+          <p><strong>Non-goals:</strong> SLO storage, burn-rate math, dashboard work, worker runtime rewrites, and monitor timestamp skew policy.</p>
+          <p><strong>Invariants:</strong> <code>/readyz</code> remains route readiness; all outputs stay deterministic; external witness remains shell-first.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">REPO ANCHORS</h2>
+          <p><a href="../../crates/canary-http/src/public.rs">crates/canary-http/src/public.rs</a> - route readiness semantics.</p>
+          <p><a href="../../crates/canary-cli/src/lib.rs">crates/canary-cli/src/lib.rs</a> - doctor report and summaries.</p>
+          <p><a href="../../bin/canary-witness">bin/canary-witness</a> - external witness receipt and exit behavior.</p>
+          <p><a href="../../test/bin/canary_witness_test.sh">test/bin/canary_witness_test.sh</a> - induced impairment fixture.</p>
+          <p><a href="../canary-witness.md">docs/canary-witness.md</a> - operator contract.</p>
+        </article>
+      </section>
+
+      <section class="ae-panel" aria-label="Execution plan" style="margin-top: 2em">
+        <h2 class="ae-h">EXECUTION PLAN</h2>
+        <div class="phase">
+          <strong class="ae-accent">1 red</strong>
+          <p>Update docs and tests so pressured workers are alert-plane impaired, not witness-healthy.</p>
+          <p class="ae-dim">Evidence: focused CLI and witness tests fail before implementation.</p>
+        </div>
+        <div class="phase">
+          <strong class="ae-accent">2 green</strong>
+          <p>Implement the smallest shared classifier and include <code>alert_plane</code> in doctor/witness JSON and text.</p>
+          <p class="ae-dim">Evidence: focused tests pass and fake pressured receipt shows degraded status.</p>
+        </div>
+        <div class="phase">
+          <strong class="ae-accent">3 live</strong>
+          <p>Run live <code>bin/canary doctor --json</code> and preserve a redacted evidence receipt for the current production surface.</p>
+          <p class="ae-dim">Evidence: architecture receipt records alert-plane verdict from live Canary.</p>
+        </div>
+        <div class="phase">
+          <strong class="ae-accent">4 close</strong>
+          <p>Run gate, fresh artifact-only critic, commit, and report residual scope left in #047.</p>
+          <p class="ae-dim">Evidence: review receipt, <code>./bin/validate</code>, clean tree status.</p>
+        </div>
+      </section>
+
+      <section class="grid-2" aria-label="Alternatives and risks" style="margin-top: 2em">
+        <article class="cell">
+          <h2 class="ae-h">ALTERNATIVE DESIGNS</h2>
+          <div class="table-wrap">
+            <table class="ae-table">
+              <thead>
+                <tr><th>option</th><th>why it helps</th><th>tradeoff</th><th>verdict</th></tr>
+              </thead>
+              <tbody>
+                <tr><td class="ae-item">Separate alert-plane classifier</td><td>Uses existing data, keeps <code>/readyz</code> stable.</td><td>Limited to worker snapshots for this slice.</td><td>choose</td></tr>
+                <tr><td class="ae-item">Make <code>/readyz</code> fail on pressure</td><td>Simple single status.</td><td>Conflates deploy readiness and alertability, violates ticket design.</td><td>reject</td></tr>
+                <tr><td class="ae-item">Build SLO/burn-rate first</td><td>More complete #047 vision.</td><td>No induced impairment proof; bigger storage/API blast radius.</td><td>defer</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">RISKS</h2>
+          <div class="table-wrap">
+            <table class="ae-table">
+              <thead>
+                <tr><th>risk</th><th>mitigation</th><th>owner</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>False-positive witness failures for mild worker pressure.</td><td>Use existing worker pressure thresholds; do not invent tighter thresholds.</td><td>agent</td></tr>
+                <tr><td>Operators lose deploy readiness signal.</td><td>Leave <code>/readyz</code> unchanged and expose alert-plane as separate field.</td><td>agent</td></tr>
+                <tr><td>Receipt lacks the reason for non-healthy status.</td><td>Persist <code>alert_plane.reasons</code> in witness and doctor JSON.</td><td>agent</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+      </section>
+
+      <section class="ae-panel" aria-label="Review topology" style="margin-top: 2em">
+        <h2 class="ae-h">REVIEW TOPOLOGY</h2>
+        <div class="table-wrap">
+          <table class="ae-table">
+            <thead>
+              <tr><th>selected tier</th><th>why this tier fits</th><th>critic lenses</th><th>waiver / escalation</th></tr>
+            </thead>
+            <tbody>
+              <tr><td class="ae-item">Substantive</td><td>Operator-facing CLI/witness behavior changes, but no auth/schema/data migration.</td><td>Public surface, operations, test strength.</td><td>Escalate if auth, persistent schema, or route readiness semantics change.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p><strong>Critic packet:</strong> diff plus this plan plus ticket oracle. Ask whether a production alert-plane failure could still be missed.</p>
+        <p><strong>Ignore:</strong> SLO feature requests and style-only naming feedback unless they hide a contract failure.</p>
+      </section>
+
+      <section class="review-grid" aria-label="Review and communication" style="margin-top: 2em">
+        <article class="ae-plate">
+          <p class="ae-plate-cap">REVIEW - useful attacks</p>
+          <p><span class="status"><svg class="ae-icon ae-warn"><use href="#i-alert"></use></svg> Weak separation.</span> Does any output imply route readiness and alert-plane readiness are the same?</p>
+          <p><span class="status"><svg class="ae-icon ae-warn"><use href="#i-alert"></use></svg> Weak oracle.</span> Can the pressured fixture still pass as healthy?</p>
+          <p><span class="status"><svg class="ae-icon ae-warn"><use href="#i-alert"></use></svg> Hidden state.</span> Are reasons visible without reading logs or chat?</p>
+        </article>
+        <article class="ae-plate">
+          <p class="ae-plate-cap">COMMUNICATION - agent cadence</p>
+          <p>Before edits: name #047 first-deliverable scope and current permissive witness behavior.</p>
+          <p>During edits: report docs/tests/code transitions and exact failing/passing commands.</p>
+          <p>Closeout: report live doctor receipt, review result, gate, unshipped #047 scope, and tree state.</p>
+        </article>
+      </section>
+    </article>
+  </main>
+
+  <footer class="ae-bar">
+    <p class="ae-foot">Generated for Canary #047. This plan intentionally avoids SLO/burn-rate implementation until the alert-plane impairment oracle is proven.</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/architecture/canary-alert-plane-evidence-2026-06-20.md
+++ b/docs/architecture/canary-alert-plane-evidence-2026-06-20.md
@@ -1,0 +1,169 @@
+# Canary Alert-Plane Evidence - 2026-06-20
+
+## Scope
+
+Backlog #047 first deliverable: prove alert-plane health separately from route
+readiness before adding SLO or burn-rate math.
+
+This slice keeps `GET /readyz` route readiness unchanged: a `pressured` worker
+can still appear inside a ready response. `bin/canary doctor` and
+`bin/canary-witness` now grade that same worker state as impaired
+alert-plane health.
+
+## Induced Impairment
+
+Command:
+
+```bash
+bash -n bin/canary-witness && bash test/bin/canary_witness_test.sh
+```
+
+Result:
+
+```text
+PASS pressured ready witness exits nonzero
+PASS pressured ready receipt status
+PASS pressured ready records worker pressure
+PASS pressured ready records alert-plane impairment
+PASS pressured ready names impaired worker
+PASS pressured ready skips check-in
+PASS not-ready worker witness exits nonzero
+PASS not-ready worker preserves readyz body
+PASS not-ready worker records alert-plane impairment
+PASS not-ready worker names backoff
+PASS not-ready worker names failing worker
+PASS not-ready worker skips check-in
+34 canary witness tests passed
+```
+
+The induced fixture returns HTTP 200 `/readyz` with
+`response.status == "ready"` and `monitor_overdue.health == "pressured"`.
+The suite also includes a `503` `/readyz` body with stale/failing worker
+snapshots so the alert plane still returns structured reasons when route
+readiness is already down. The pressured witness receipt records:
+
+```json
+{
+  "status": "degraded",
+  "alert_plane": {
+    "status": "impaired",
+    "impaired_workers": 1,
+    "reasons": ["monitor_overdue pressured"]
+  },
+  "check_in": {
+    "skipped": true,
+    "error": "self signals were not healthy"
+  }
+}
+```
+
+## CLI Contract
+
+Command:
+
+```bash
+cargo test -p canary-cli --locked
+```
+
+Result:
+
+```text
+28 unit tests passed
+12 fixture tests passed
+```
+
+The focused regression is
+`doctor_verdict_degrades_for_alert_plane_pressure_even_when_readyz_is_ready`.
+It proves a ready route plus a pressured worker yields:
+
+```json
+{
+  "overall": "degraded",
+  "alert_plane": {
+    "status": "impaired",
+    "reasons": ["monitor_overdue pressured"]
+  }
+}
+```
+
+The follow-up regression is `alert_plane_uses_not_ready_worker_snapshots`. It
+proves a non-2xx `/readyz` response that still carries worker snapshots yields
+structured reasons such as `webhook_delivery backoff_or_circuit_open` and
+`target_probe failing`.
+
+## Live Doctor Readback
+
+Command:
+
+```bash
+bin/canary doctor --json > /tmp/canary-alert-plane-doctor-live.json
+jq '{overall: .response.verdict.overall, alert_plane: .response.alert_plane, verdict_alert_plane: .response.verdict.alert_plane, worker_readiness: {status: .response.worker_readiness.status, worker_count: .response.worker_readiness.worker_count, failing_workers: .response.worker_readiness.failing_workers, pressured_workers: .response.worker_readiness.pressured_workers}, next_operator_action: .response.verdict.next_operator_action}' /tmp/canary-alert-plane-doctor-live.json
+```
+
+Result:
+
+```json
+{
+  "overall": "healthy",
+  "alert_plane": {
+    "available": true,
+    "impaired_workers": 0,
+    "reasons": [],
+    "status": "healthy",
+    "worker_count": 5,
+    "workers": []
+  },
+  "verdict_alert_plane": {
+    "available": true,
+    "impaired_workers": 0,
+    "reasons": [],
+    "status": "healthy",
+    "worker_count": 5,
+    "workers": []
+  },
+  "worker_readiness": {
+    "status": "ready",
+    "worker_count": 5,
+    "failing_workers": 0,
+    "pressured_workers": 0
+  },
+  "next_operator_action": "No runtime blocker; run `bin/canary dogfood audit --strict --json` and close the reported coverage gaps."
+}
+```
+
+## Validation
+
+Focused commands:
+
+```bash
+cargo fmt --all --check
+git diff --check
+cargo test -p canary-cli --locked
+bash -n bin/canary-witness && bash test/bin/canary_witness_test.sh
+env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" bash ./bin/validate --fast
+```
+
+Result: all passed. The fast gate includes the Debian `jq` 1.6 witness lane,
+which caught and verified the portable alert-plane JSON expression.
+
+Strict gate:
+
+```bash
+env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" bash ./bin/validate --strict
+```
+
+Result:
+
+```text
+✔ .strict(...): Void 6m8s
+```
+
+The final strict run used the repo-pinned Dagger `v0.20.5` binary after removing
+a stale `v0.21.6` engine that had blocked the earlier default `dagger check`
+wrapper.
+
+## Remaining #047 Scope
+
+This does not implement SLO configuration, multi-window burn-rate summaries, or
+the monitor future-timestamp skew policy. Those remain children of #047 after
+the alert-plane impairment oracle.

--- a/docs/architecture/canary-groom-plan-2026-06-19.html
+++ b/docs/architecture/canary-groom-plan-2026-06-19.html
@@ -1,0 +1,262 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Canary Groom Plan - 2026-06-19</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #111318;
+        --muted: #5d6675;
+        --line: #d8dee8;
+        --paper: #f7f4ee;
+        --panel: #ffffff;
+        --accent: #0f6c68;
+        --warn: #a75d00;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--ink);
+        background: var(--paper);
+        line-height: 1.45;
+      }
+      main {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 40px 24px 56px;
+      }
+      header {
+        border-bottom: 2px solid var(--ink);
+        padding-bottom: 22px;
+        margin-bottom: 26px;
+      }
+      .eyebrow {
+        text-transform: uppercase;
+        letter-spacing: .08em;
+        font-size: 12px;
+        color: var(--accent);
+        font-weight: 700;
+      }
+      h1 {
+        margin: 8px 0 10px;
+        font-size: clamp(34px, 5vw, 68px);
+        line-height: .96;
+        max-width: 980px;
+      }
+      h2 {
+        font-size: 18px;
+        margin: 0 0 12px;
+        text-transform: uppercase;
+        letter-spacing: .04em;
+      }
+      h3 {
+        margin: 0 0 8px;
+        font-size: 16px;
+      }
+      p { margin: 0; }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        gap: 14px;
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        padding: 18px;
+      }
+      .span-12 { grid-column: span 12; }
+      .span-8 { grid-column: span 8; }
+      .span-6 { grid-column: span 6; }
+      .span-4 { grid-column: span 4; }
+      .callout {
+        border-left: 5px solid var(--accent);
+      }
+      .warn {
+        border-left: 5px solid var(--warn);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+      }
+      th, td {
+        text-align: left;
+        vertical-align: top;
+        padding: 9px 8px;
+        border-top: 1px solid var(--line);
+      }
+      th {
+        color: var(--muted);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: .05em;
+      }
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      li + li { margin-top: 6px; }
+      code {
+        font-family: "SFMono-Regular", Consolas, monospace;
+        font-size: .94em;
+        background: #edf1f4;
+        padding: 1px 4px;
+      }
+      .muted { color: var(--muted); }
+      @media (max-width: 860px) {
+        .span-8, .span-6, .span-4 { grid-column: span 12; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="eyebrow">/groom execution contract</div>
+        <h1>Backchain Canary from the agent-first vision into a sharper backlog.</h1>
+        <p class="muted">
+          Baseline: local branch <code>docs/agent-first-vision</code> at
+          <code>fee9229</code>, with <code>master</code> synced to
+          <code>origin/master</code>. This groom treats the new vision and
+          identity docs as the north star, then audits whether the active
+          backlog is the right next expression of that product.
+        </p>
+      </header>
+
+      <div class="grid">
+        <section class="span-8 callout">
+          <h2>Target Outcome</h2>
+          <p>
+            Leave a durable backlog diff and groom receipt that say what Canary
+            should build next, why it is strategically correct, how it will be
+            verified, and what should stay blocked or merely proposed. The
+            output should make the next implementation lane obvious without
+            widening Canary beyond its small agent-first identity.
+          </p>
+        </section>
+
+        <section class="span-4 warn">
+          <h2>Stop Conditions</h2>
+          <ul>
+            <li>Do not delete, abandon, or silently merge backlog items.</li>
+            <li>Do not weaken <code>./bin/validate</code> or invent a second gate.</li>
+            <li>Do not claim live production usefulness without CLI/API evidence.</li>
+            <li>Stop and re-read if the same ticket needs more than three edits.</li>
+          </ul>
+        </section>
+
+        <section class="span-12">
+          <h2>Evidence Sources</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Surface</th>
+                <th>Primary Evidence</th>
+                <th>Question</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Vision</td>
+                <td><code>VISION.md</code>, <code>docs/agent-first-identity.md</code></td>
+                <td>What does excellence mean for agent-first production health?</td>
+              </tr>
+              <tr>
+                <td>Backlog</td>
+                <td><code>backlog.d/README.md</code>, <code>010</code>, <code>020</code>, <code>047</code>, <code>048</code>, <code>049</code></td>
+                <td>Are active items sequenced, scoped, and verifiable?</td>
+              </tr>
+              <tr>
+                <td>Live state</td>
+                <td><code>bin/canary doctor --json</code>, dogfood value receipts, incidents</td>
+                <td>What is Canary proving for its current consumers today?</td>
+              </tr>
+              <tr>
+                <td>Code and contracts</td>
+                <td><code>crates/canary-*</code>, <code>bin/</code>, <code>priv/openapi/</code>, <code>dagger/</code></td>
+                <td>Where does implementation contradict the intended product contract?</td>
+              </tr>
+              <tr>
+                <td>External exemplars</td>
+                <td>Sentry, Better Stack, UptimeRobot, PagerDuty, incident.io, OpenTelemetry, Langfuse</td>
+                <td>What should Canary borrow or deliberately avoid?</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="span-12">
+          <h2>Lane Topology</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Lane</th>
+                <th>Status</th>
+                <th>Expected Contribution</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Product/value</td>
+                <td>complete</td>
+                <td>Judge usefulness to current and prospective agent consumers.</td>
+              </tr>
+              <tr>
+                <td>Runtime/ops</td>
+                <td>complete</td>
+                <td>Stress #047 against worker pressure, alert-plane health, and temporal semantics.</td>
+              </tr>
+              <tr>
+                <td>Security/privacy</td>
+                <td>complete</td>
+                <td>Stress #048/#049 against arbitrary responder safety and authority.</td>
+              </tr>
+              <tr>
+                <td>Architecture</td>
+                <td>complete</td>
+                <td>Find semantic drift and module-depth risks across API, CLI, MCP, and store/server boundaries.</td>
+              </tr>
+              <tr>
+                <td>Test/verification</td>
+                <td>complete</td>
+                <td>Audit whether gates prove live agent workflows, not just unit correctness.</td>
+              </tr>
+              <tr>
+                <td>Agent readiness</td>
+                <td>complete</td>
+                <td>Check cold-agent docs, CLI JSON, MCP, receipts, and missing harness surfaces.</td>
+              </tr>
+              <tr>
+                <td>Lead synthesis</td>
+                <td>complete</td>
+                <td>Read live files, vet findings, write tickets, run checks, and keep the tree clean.</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="span-6">
+          <h2>Likely Backlog Moves</h2>
+          <ul>
+            <li>Rewrite #047 as the first ready epic with an explicit alert-plane contract and verification system.</li>
+            <li>Promote or split a small agent-readiness ticket if the current CLI/MCP/docs loop has a cold-start gap.</li>
+            <li>Keep #048 pending unless safety evidence says it must become the next P0 before alerting work.</li>
+            <li>Keep #049 pending behind responder proof unless integration overclaiming is currently harming dogfood value.</li>
+          </ul>
+        </section>
+
+        <section class="span-6">
+          <h2>Verification</h2>
+          <ul>
+            <li>Backlog mechanics: <code>harness-kit-checks backlog ids-from-range</code> and direct active-ticket inspection.</li>
+            <li>Static hygiene: <code>git diff --check</code> and grep for stale identity contradictions.</li>
+            <li>Repo gate: <code>./bin/validate --fast</code> through pinned Dagger for docs/backlog changes.</li>
+            <li>Closeout: clean <code>git status --short --branch --untracked-files=all</code> and explicit branch/remote state.</li>
+          </ul>
+        </section>
+      </div>
+    </main>
+  </body>
+</html>

--- a/docs/architecture/runtime-pressure-freshness-ops-2026-06-14.md
+++ b/docs/architecture/runtime-pressure-freshness-ops-2026-06-14.md
@@ -6,8 +6,10 @@ Date: 2026-06-14
 
 Canary readiness now treats background-worker health as an operational signal,
 not just thread liveness. `GET /readyz` fails when any required worker is
-stopped, stale, repeatedly failing, or pressured. Each worker snapshot exposes
-the values an agent needs to decide whether the runtime is keeping up:
+stopped, stale, or repeatedly failing. A `pressured` worker can remain
+route-ready, but doctor and the external witness treat it as impaired
+alert-plane health. Each worker snapshot exposes the values an agent needs to
+decide whether the runtime is keeping up:
 
 - `health`: `ok`, `stale`, `failing`, `pressured`, or `stopped`.
 - `last_success_at` and `last_success_age_ms`.

--- a/docs/architecture/worker-lifecycle-readiness-2026-06-12.md
+++ b/docs/architecture/worker-lifecycle-readiness-2026-06-12.md
@@ -36,13 +36,14 @@ Each worker snapshot contains:
   interruption, or fanout pressure.
 
 `/readyz` remains unauthenticated and returns `not_ready` when the database,
-supervisor, or any worker is not ready. Worker health is not just thread
-liveness: fast workers become stale after 30 seconds without a successful pass,
-daily maintenance workers become stale after 25 hours, three consecutive
-failures mark a worker failing, and overdue work beyond the pressure threshold
-marks the worker pressured. Worker internals remain hidden behind their
-lifecycle modules; route handling only serializes the already-computed
-snapshot.
+supervisor, or any worker is stopped, stale, or failing. Worker health is not
+just thread liveness: fast workers become stale after 30 seconds without a
+successful pass, daily maintenance workers become stale after 25 hours, three
+consecutive failures mark a worker failing, and overdue work beyond the
+pressure threshold marks the worker pressured. Pressured workers remain
+route-ready, but doctor and the external witness report impaired alert-plane
+health. Worker internals remain hidden behind their lifecycle modules; route
+handling only serializes the already-computed snapshot.
 
 ## Design Notes
 

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -21,10 +21,11 @@ is checking.
 | Signal | Route | Healthy expectation |
 |---|---|---|
 | Liveness | `GET /healthz` | HTTP 200 and `{"status":"ok"}` |
-| Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, database and supervisor `ok`, and all five worker lifecycle snapshots started with zero failures. Worker `health` may be `ok` or `pressured`; stale, failing, and stopped workers are unhealthy. |
+| Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, database and supervisor `ok`, and all five worker lifecycle snapshots started with zero failures. This is route readiness, not alert-plane health. |
+| Alert plane | `/readyz` worker snapshots | Every required worker has `health: ok`, no backoff/circuit pressure, and no stale due-work pressure. A `pressured` worker can remain route-ready, but the witness reports a degraded alert plane and does not send the healthy check-in. |
 | Error readback | `GET /api/v1/query?service=canary&window=1h` | HTTP 200, service `canary`, and numeric `total_errors` |
 
-When all three signals are healthy, the witness sends an ingest check-in:
+When all route and alert-plane signals are healthy, the witness sends an ingest check-in:
 
 ```json
 {
@@ -89,16 +90,16 @@ Actions receipt. If it is `observed`, the check-in state and timestamp are the
 current external witness evidence.
 
 `doctor` also summarizes worker lifecycle readiness from `/readyz`, for example
-`worker_readiness: ready 5 workers, 0 failing`. Treat a missing or failing
-worker readiness line as a stale inspection surface or a runtime pressure
-signal, not as a healthy witness result.
+`worker_readiness: ready 5 workers, 0 failing`, and the stricter alert-plane
+verdict, for example `alert_plane: healthy 5 workers`. Treat a missing,
+failing, or impaired alert-plane line as an operational alertability signal,
+not as a deploy-readiness signal.
 
 The witness itself now requires each `/readyz` worker to report `state:
-started`, `health: ok` or `health: pressured`, zero cumulative and consecutive
-failures, a string `last_success_at`, numeric pressure counters, and a boolean
-`backoff_or_circuit_open`. A pressured worker is still route-ready evidence; a
-worker thread that is stale, repeatedly failing, stopped, or in backoff/circuit
-open remains an unhealthy witness result.
+started`, `health: ok`, zero cumulative and consecutive failures, a string
+`last_success_at`, numeric pressure counters, and `backoff_or_circuit_open:
+false` before the alert plane is healthy. A pressured worker is still
+route-ready evidence; it is not healthy alert-plane evidence.
 
 `doctor` also prints a `dr:` line. That line reflects the operator
 `bin/dr-status --app canary-obs` Litestream check when available and points to

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -75,6 +75,7 @@ assert_check_in_payload() {
 
 READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 PRESSURED_READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
+NOT_READY_WORKERS_BODY='{"status":"not_ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":12,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":true},{"name":"target_probe","state":"started","health":"failing","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":3,"consecutive_failures":3,"last_error_class":"runtime_error","due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 
 case "${STUB_SCENARIO:?}:$method:$url" in
   healthy:GET:https://canary.example/healthz)
@@ -103,6 +104,16 @@ case "${STUB_SCENARIO:?}:$method:$url" in
   pressured:POST:https://canary.example/api/v1/check-ins)
     assert_check_in_payload
     write_response 201 0.040 '{"monitor":"canary-watchman","status":"alive"}'
+    ;;
+
+  notready-workers:GET:https://canary.example/healthz)
+    write_response 200 0.010 '{"status":"ok"}'
+    ;;
+  notready-workers:GET:https://canary.example/readyz)
+    write_response 503 0.020 "$NOT_READY_WORKERS_BODY"
+    ;;
+  notready-workers:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
+    write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
     ;;
 
   degraded:GET:https://canary.example/healthz)
@@ -228,7 +239,7 @@ assert_json_equals "$receipt" '.status' 'healthy' "healthy ttl receipt status"
 assert_json_equals "$receipt" '.check_in.http_status' '201' "healthy ttl sends check-in"
 
 receipt="$TMPDIR_TEST/pressured.json"
-run_success "pressured ready witness exits zero" \
+run_failure "pressured ready witness exits nonzero" \
   env \
     STUB_SCENARIO=pressured \
     "${WITNESS[@]}" \
@@ -238,9 +249,28 @@ run_success "pressured ready witness exits zero" \
     --receipt "$receipt" \
     --require-check-in \
     --json
-assert_json_equals "$receipt" '.status' 'healthy' "pressured ready receipt status"
+assert_json_equals "$receipt" '.status' 'degraded' "pressured ready receipt status"
 assert_json_equals "$receipt" '.probes.readyz.response.checks.workers[] | select(.name == "monitor_overdue") | .health' 'pressured' "pressured ready records worker pressure"
-assert_json_equals "$receipt" '.check_in.http_status' '201' "pressured ready sends check-in"
+assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "pressured ready records alert-plane impairment"
+assert_json_equals "$receipt" '.alert_plane.workers[] | select(.name == "monitor_overdue") | .health' 'pressured' "pressured ready names impaired worker"
+assert_json_equals "$receipt" '.check_in.skipped' 'true' "pressured ready skips check-in"
+
+receipt="$TMPDIR_TEST/notready-workers.json"
+run_failure "not-ready worker witness exits nonzero" \
+  env \
+    STUB_SCENARIO=notready-workers \
+    "${WITNESS[@]}" \
+    --endpoint https://canary.example \
+    --read-api-key read-key \
+    --ingest-api-key ingest-key \
+    --receipt "$receipt" \
+    --json
+assert_json_equals "$receipt" '.status' 'degraded' "not-ready worker receipt status"
+assert_json_equals "$receipt" '.probes.readyz.response.status' 'not_ready' "not-ready worker preserves readyz body"
+assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "not-ready worker records alert-plane impairment"
+assert_json_equals "$receipt" '.alert_plane.reasons[] | select(. == "webhook_delivery backoff_or_circuit_open")' 'webhook_delivery backoff_or_circuit_open' "not-ready worker names backoff"
+assert_json_equals "$receipt" '.alert_plane.reasons[] | select(. == "target_probe failing")' 'target_probe failing' "not-ready worker names failing worker"
+assert_json_equals "$receipt" '.check_in.skipped' 'true' "not-ready worker skips check-in"
 
 receipt="$TMPDIR_TEST/degraded.json"
 run_failure "degraded witness exits nonzero" \


### PR DESCRIPTION
## Summary

- Defines Canary's agent-first product identity and backlog shape for the current branch.
- Separates alert-plane health from route readiness in `bin/canary doctor` and `bin/canary-witness`.
- Keeps `/readyz` semantics unchanged while letting agents degrade on worker pressure, backoff, circuit, failure, and stale worker snapshots.
- Adds planning and evidence receipts under `docs/architecture/`.

## Validation

- `open docs/architecture/canary-alert-plane-delivery-plan-2026-06-20.html`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p canary-cli --locked`
- `bash -n bin/canary-witness && bash test/bin/canary_witness_test.sh`
- `env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" bash ./bin/validate --fast`
- `env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" bash ./bin/validate --strict`
- Pre-commit hook reran `./bin/validate --fast`.
- Pre-push hook reran `./bin/validate --strict`.
- `bin/canary doctor --json > /tmp/canary-alert-plane-doctor-live.json` reported overall `healthy`, alert plane `healthy`, and `5` ready workers.

## Review

Fresh critic returned no blockers. Follow-up fixes preserved non-2xx `/readyz` worker snapshots and surfaced specific backoff/circuit reasons instead of collapsing them into generic pressure.

## Remaining Scope

This is the first #047 slice. SLO configuration, multi-window burn-rate summaries, check-in future timestamp skew policy, and broader induced production impairment proof remain for later #047 children.

## Notes

A default `./bin/validate`/`dagger check` attempt initially hit stale Dagger engine/version contention. Final proof used the repo-pinned `v0.20.5` binary from `dagger.json`.
