### PR TITLE
feat(alert-plane): windowed service SLIs, default SLO classes, and check-in skew safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ service binding, and is not advanced by `report.cursor`:
     {
       "service": "volume",
       "window": "1h",
+      "slo": {
+        "class": "standard",
+        "source": "default_health_surface",
+        "availability_target": 0.995,
+        "latency_ms_average_target": 1000,
+        "error_budget_events_per_hour": 5
+      },
       "targets": {
         "configured": 2,
         "checks": 120,

--- a/README.md
+++ b/README.md
@@ -252,7 +252,10 @@ curl "https://canary-obs.fly.dev/api/v1/report?window=1h" \
 ```
 
 Response combines the current health view, active error groups, recent transitions,
-and correlated incidents in one bounded payload:
+windowed service SLIs, and correlated incidents in one current-state payload.
+Targets, monitors, and error groups are cursor-paginated; `service_sli` is a
+compact per-service whole-window summary scoped by auth, window, and any API-key
+service binding, and is not advanced by `report.cursor`:
 
 ```json
 {
@@ -260,6 +263,36 @@ and correlated incidents in one bounded payload:
   "summary": "3 health surfaces monitored. 1 degraded (volume). 14 errors across 1 service in the last hour.",
   "targets": [...],
   "monitors": [...],
+  "service_sli": [
+    {
+      "service": "volume",
+      "window": "1h",
+      "targets": {
+        "configured": 2,
+        "checks": 120,
+        "successful_checks": 118,
+        "failed_checks": 2,
+        "availability_ratio": 0.9833333333333333,
+        "latency_ms_average": 84.5
+      },
+      "monitors": {
+        "configured": 1,
+        "check_ins": 12,
+        "healthy_check_ins": 11,
+        "failed_check_ins": 1,
+        "availability_ratio": 0.9166666666666666
+      },
+      "errors": {
+        "total": 14,
+        "groups": 3
+      },
+      "incidents": {
+        "opened": 1,
+        "resolved": 0,
+        "active": 1
+      }
+    }
+  ],
   "error_groups": [...],
   "incidents": [
     {

--- a/README.md
+++ b/README.md
@@ -365,12 +365,15 @@ curl -X POST https://canary-obs.fly.dev/api/v1/check-ins \
   -H "Authorization: Bearer $CANARY_INGEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "monitor_id": "MON-...",
-    "status": "alive"
+    "monitor": "desktop-active-timer",
+    "status": "alive",
+    "observed_at": "2026-06-20T18:00:00Z"
   }'
 ```
 
 Healthy check-ins advance the monitor state without creating error groups.
+`observed_at` is optional, but when supplied it cannot be more than five
+minutes in the future relative to Canary receipt time.
 Crash or exception telemetry still belongs on `POST /api/v1/errors`.
 
 ### Target Management

--- a/backlog.d/047-alert-plane-slo-burn-rate.md
+++ b/backlog.d/047-alert-plane-slo-burn-rate.md
@@ -69,6 +69,17 @@ future check-in timestamp skew policy, production-image induced impairment
 gate wiring beyond the shell fixture, SLO configuration, and burn-rate
 summaries.
 
+2026-06-23 slice: children 2–5 have shipped on branch
+`deliver/047-alert-plane-reliability`. Future check-in timestamp skew
+(`a5bb058`), production-image induced impairment rehearsal (`063dece`),
+windowed service SLI read models (`51751e1`), and deterministic default SLO
+classes (`6bde51d`) are committed. A stray `expect_used`/`expect_err` clippy
+debt the unpushed branch had accumulated in tests was also cleared (`5458e51`),
+so `cargo clippy --workspace --all-targets -- -D warnings` is clean under the
+repo-pinned 1.94 toolchain. Remaining scope: child #6 only — multi-window
+burn-rate summaries across report/CLI/MCP and page-vs-ticket notification
+severity routing.
+
 ## Children
 1. Define alert-plane health separately from route readiness.
 2. Add check-in timestamp skew policy and tests.

--- a/crates/canary-core/src/lib.rs
+++ b/crates/canary-core/src/lib.rs
@@ -10,4 +10,5 @@ pub mod ingest;
 pub mod metrics;
 pub mod query;
 pub mod secrets;
+pub mod slo;
 pub mod webhook_events;

--- a/crates/canary-core/src/slo.rs
+++ b/crates/canary-core/src/slo.rs
@@ -1,0 +1,59 @@
+//! Deterministic service SLO class defaults.
+//!
+//! Canary does not store per-service SLO overrides yet. These defaults give
+//! agents stable objectives to reason against without adding a configuration
+//! table before the burn-rate surface needs one.
+
+/// Service-level objective metadata attached to service SLI summaries.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ServiceSloObjective {
+    /// Coarse SLO class name.
+    pub class: &'static str,
+    /// Why Canary assigned this class.
+    pub source: &'static str,
+    /// Availability target as a ratio from 0.0 to 1.0.
+    pub availability_target: f64,
+    /// Average latency target in milliseconds.
+    pub latency_ms_average_target: u64,
+    /// Allowed error events per hour before the service spends its error budget.
+    pub error_budget_events_per_hour: u64,
+}
+
+/// Default for services with an HTTP target or non-HTTP monitor.
+pub const STANDARD_HEALTH_SURFACE: ServiceSloObjective = ServiceSloObjective {
+    class: "standard",
+    source: "default_health_surface",
+    availability_target: 0.995,
+    latency_ms_average_target: 1_000,
+    error_budget_events_per_hour: 5,
+};
+
+/// Default for services that only appear through errors, incidents, or timeline
+/// signals and do not yet have a configured health surface.
+pub const BEST_EFFORT_SIGNAL_ONLY: ServiceSloObjective = ServiceSloObjective {
+    class: "best_effort",
+    source: "default_signal_only",
+    availability_target: 0.99,
+    latency_ms_average_target: 2_500,
+    error_budget_events_per_hour: 20,
+};
+
+/// Choose the default SLO objective for a service row.
+pub fn default_service_slo(has_health_surface: bool) -> ServiceSloObjective {
+    if has_health_surface {
+        STANDARD_HEALTH_SURFACE
+    } else {
+        BEST_EFFORT_SIGNAL_ONLY
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_service_slo_uses_health_surface_as_the_standard_class_boundary() {
+        assert_eq!(default_service_slo(true), STANDARD_HEALTH_SURFACE);
+        assert_eq!(default_service_slo(false), BEST_EFFORT_SIGNAL_ONLY);
+    }
+}

--- a/crates/canary-http/src/problem_details.rs
+++ b/crates/canary-http/src/problem_details.rs
@@ -161,6 +161,20 @@ pub fn invalid_observed_at_problem() -> ProblemDetails {
     )
 }
 
+/// Build the future observed-at validation problem.
+pub fn future_observed_at_problem() -> ProblemDetails {
+    ProblemDetails::new(
+        422,
+        ProblemCode::ValidationError,
+        "observed_at is too far in the future.",
+        None,
+    )
+    .with_extra(
+        "errors",
+        json!({"observed_at": ["must not be more than 5 minutes in the future"]}),
+    )
+}
+
 /// Build a generic 404 problem.
 pub fn not_found_problem(detail: impl Into<String>) -> ProblemDetails {
     ProblemDetails::new(404, ProblemCode::NotFound, detail, None)

--- a/crates/canary-server/src/ingest_routes.rs
+++ b/crates/canary-server/src/ingest_routes.rs
@@ -6,14 +6,14 @@
 //! best-effort fanout after the SQLite commit.
 
 use axum::{
-    body::{Body, Bytes},
+    body::{Body, Bytes, to_bytes},
     extract::State,
-    http::{HeaderMap, Response, StatusCode},
+    http::{HeaderMap, Request, Response, StatusCode},
 };
 use canary_http::{
     problem_details::{
-        ProblemDetails, internal_problem, invalid_observed_at_problem, not_found_problem,
-        payload_too_large_problem, validation_problem,
+        ProblemDetails, future_observed_at_problem, internal_problem, invalid_observed_at_problem,
+        not_found_problem, payload_too_large_problem, validation_problem,
     },
     request::{MAX_JSON_BODY_BYTES, decode_json_object},
 };
@@ -36,7 +36,6 @@ use crate::{
 
 struct ParsedCheckIn {
     monitor_name: String,
-    observed_at: String,
     input: MonitorCheckInInput,
 }
 
@@ -108,12 +107,24 @@ pub(crate) async fn create_error(
 
 pub(crate) async fn create_check_in(
     State(state): State<IngestState>,
-    headers: HeaderMap,
-    body: Bytes,
+    request: Request<Body>,
 ) -> Response<Body> {
+    let received_at = current_rfc3339();
+    let (parts, body) = request.into_parts();
+    let headers = parts.headers;
+
     if let Err(problem) = check_content_length(&headers) {
         return problem_response(*problem);
     }
+
+    let body = match to_bytes(body, (MAX_JSON_BODY_BYTES + 1) as usize).await {
+        Ok(body) => body,
+        Err(_) => {
+            return problem_response(payload_too_large_problem(
+                "Request body exceeds 100KB limit.",
+            ));
+        }
+    };
 
     if body.len() as u64 > MAX_JSON_BODY_BYTES {
         return problem_response(payload_too_large_problem(
@@ -130,7 +141,7 @@ pub(crate) async fn create_check_in(
         Ok(attrs) => attrs,
         Err(problem) => return problem_response(*problem),
     };
-    let check_in = match parse_check_in(attrs) {
+    let check_in = match parse_check_in(attrs, &received_at) {
         Ok(check_in) => check_in,
         Err(problem) => return problem_response(*problem),
     };
@@ -157,7 +168,7 @@ pub(crate) async fn create_check_in(
         Err(_) => return problem_response(internal_problem()),
     };
     let context = ObservationContext {
-        now: check_in.observed_at.clone(),
+        now: received_at,
         now_millis: current_unix_millis(),
         event_id: canary_core::ids::EventId::generate(),
         incident_id: canary_core::ids::IncidentId::generate(),
@@ -167,6 +178,9 @@ pub(crate) async fn create_check_in(
         Ok(plan) => plan,
         Err(HealthPlanError::InvalidObservedAt(_)) => {
             return problem_response(invalid_observed_at_problem());
+        }
+        Err(HealthPlanError::ObservedAtTooFarInFuture) => {
+            return problem_response(future_observed_at_problem());
         }
     };
     let response_observed_at = plan.commit.check_in.observed_at.clone();
@@ -197,7 +211,10 @@ pub(crate) async fn create_check_in(
     )
 }
 
-fn parse_check_in(attrs: Map<String, Value>) -> Result<ParsedCheckIn, Box<ProblemDetails>> {
+fn parse_check_in(
+    attrs: Map<String, Value>,
+    received_at: &str,
+) -> Result<ParsedCheckIn, Box<ProblemDetails>> {
     let mut errors: ValidationErrors = ValidationErrors::new();
     let monitor_name = required_string(&attrs, "monitor", &mut errors);
     let status = parse_check_in_status(attrs.get("status"), &mut errors);
@@ -223,13 +240,12 @@ fn parse_check_in(attrs: Map<String, Value>) -> Result<ParsedCheckIn, Box<Proble
     };
     let observed_at = match attrs.get("observed_at") {
         Some(Value::String(value)) => value.clone(),
-        Some(Value::Null) | None => current_rfc3339(),
+        Some(Value::Null) | None => received_at.to_owned(),
         Some(_) => return Err(Box::new(invalid_observed_at_problem())),
     };
 
     Ok(ParsedCheckIn {
         monitor_name,
-        observed_at: observed_at.clone(),
         input: MonitorCheckInInput {
             id: canary_core::ids::CheckInId::generate().into_string(),
             external_id: optional_string(attrs.get("check_in_id")),

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -6617,6 +6617,11 @@ mod tests {
             .find(|summary| summary["service"] == "api")
             .ok_or("missing api SLI")?;
         assert_eq!(api["window"], "1h");
+        assert_eq!(api["slo"]["class"], "standard");
+        assert_eq!(api["slo"]["source"], "default_health_surface");
+        assert_eq!(api["slo"]["availability_target"], 0.995);
+        assert_eq!(api["slo"]["latency_ms_average_target"], 1_000);
+        assert_eq!(api["slo"]["error_budget_events_per_hour"], 5);
         assert_eq!(api["targets"]["checks"], 1);
         assert_eq!(api["targets"]["availability_ratio"], 1.0);
         assert_eq!(api["monitors"]["healthy_check_ins"], 1);

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -208,6 +208,7 @@ mod tests {
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::process;
+    use std::str::FromStr;
     use std::sync::{
         Arc, Mutex, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -222,7 +223,7 @@ mod tests {
         },
     };
     use canary_core::{
-        ids::{ErrorId, EventId},
+        ids::{ErrorId, EventId, IncidentId},
         ingest::classification::{Category, Classification, Component, Persistence},
     };
     use canary_http::{
@@ -235,10 +236,10 @@ mod tests {
     use canary_ingest::{IngestConfig, IngestEffect};
     use canary_store::{
         API_KEY_PREFIX_LEN, AnnotationInsert, ApiKeyInsert, ErrorIngest, ErrorIngestIds,
-        ErrorIngestPayload, MonitorInsert, Store, TargetCheckObservation, TargetInsert,
-        TargetProbeCommit, WebhookDeliveryInsert, WebhookDeliveryJobCompletion,
-        WebhookDeliveryJobInsert, WebhookDeliveryJobState, WebhookDeliveryStatus,
-        WebhookSubscriptionInsert,
+        ErrorIngestPayload, MonitorCheckInCommit, MonitorCheckInObservation, MonitorInsert, Store,
+        TargetCheckObservation, TargetInsert, TargetProbeCommit, WebhookDeliveryInsert,
+        WebhookDeliveryJobCompletion, WebhookDeliveryJobInsert, WebhookDeliveryJobState,
+        WebhookDeliveryStatus, WebhookSubscriptionInsert,
     };
     use canary_workers::{
         retention::RetentionPolicy,
@@ -6425,6 +6426,12 @@ mod tests {
             bootstrap_report["error_groups"][0]["group_hash"],
             "group-bootstrap-scope"
         );
+        assert_eq!(
+            bootstrap_report["service_sli"].as_array().map(Vec::len),
+            Some(1)
+        );
+        assert_eq!(bootstrap_report["service_sli"][0]["service"], "shared-api");
+        assert_eq!(bootstrap_report["service_sli"][0]["errors"]["total"], 1);
         assert_eq!(bootstrap_report["search_results"], json!([]));
 
         let other_report = router
@@ -6438,6 +6445,12 @@ mod tests {
             other_report["error_groups"][0]["group_hash"],
             "group-other-scope"
         );
+        assert_eq!(
+            other_report["service_sli"].as_array().map(Vec::len),
+            Some(1)
+        );
+        assert_eq!(other_report["service_sli"][0]["service"], "shared-api");
+        assert_eq!(other_report["service_sli"][0]["errors"]["total"], 1);
         assert_eq!(other_report["search_results"][0]["id"], other_error_id);
 
         Ok(())
@@ -6493,6 +6506,129 @@ mod tests {
         assert_eq!(body["error_groups"][0]["service"], "linejam");
         assert_eq!(body["search_results"].as_array().map(Vec::len), Some(1));
         assert_eq!(body["search_results"][0]["service"], "linejam");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn report_includes_windowed_service_sli_and_applies_service_binding()
+    -> Result<(), Box<dyn Error>> {
+        let state = test_ingest_state()?;
+        let read_key = "sk_live_report_sli_api_secret";
+        let now = server_time::current_rfc3339();
+        {
+            let mut store = state.lock_store().map_err(|_| "store lock poisoned")?;
+            seed_read_api_key_for_service(&mut store, "KEY-report-sli-api", read_key, "api")?;
+            seed_target(&mut store, "api")?;
+            seed_target(&mut store, "worker")?;
+            seed_monitor(&mut store, "api")?;
+            seed_monitor(&mut store, "worker")?;
+            for (service, result, check_succeeded) in
+                [("api", "success", true), ("worker", "error", false)]
+            {
+                store.commit_target_probe(TargetProbeCommit {
+                    target_id: format!("TGT-{service}"),
+                    state: if check_succeeded { "up" } else { "down" }.to_owned(),
+                    consecutive_failures: if check_succeeded { 0 } else { 1 },
+                    consecutive_successes: if check_succeeded { 1 } else { 0 },
+                    check_succeeded,
+                    check: TargetCheckObservation {
+                        status_code: if check_succeeded {
+                            Some(200)
+                        } else {
+                            Some(500)
+                        },
+                        latency_ms: Some(42),
+                        result: result.to_owned(),
+                        tls_expires_at: None,
+                        error_detail: None,
+                        region: None,
+                    },
+                    now: now.clone(),
+                    transition: None,
+                })?;
+            }
+            for (service, status) in [("api", "alive"), ("worker", "error")] {
+                store.commit_monitor_check_in(MonitorCheckInCommit {
+                    monitor_id: format!("MON-{service}"),
+                    state: if status == "error" { "down" } else { "up" }.to_owned(),
+                    last_check_in_at: Some(now.clone()),
+                    last_check_in_status: Some(status.to_owned()),
+                    deadline_at: Some(now.clone()),
+                    check_in: MonitorCheckInObservation {
+                        id: format!("CHK-{service}-sli"),
+                        external_id: None,
+                        status: status.to_owned(),
+                        observed_at: now.clone(),
+                        ttl_ms: None,
+                        summary: None,
+                        context: None,
+                    },
+                    now: now.clone(),
+                    transition: None,
+                })?;
+            }
+            let mut api_error = owned_error_ingest(
+                canary_store::BOOTSTRAP_TENANT_ID,
+                canary_store::BOOTSTRAP_PROJECT_ID,
+                "ERR-sliapi000001",
+                "EVT-sliapi000001",
+                "group-report-sli-api",
+                "api",
+                "api timeout",
+            )?;
+            api_error.payload.created_at = now.clone();
+            store.commit_error_ingest(api_error)?;
+            let mut worker_error = owned_error_ingest(
+                canary_store::BOOTSTRAP_TENANT_ID,
+                canary_store::BOOTSTRAP_PROJECT_ID,
+                "ERR-sliworker001",
+                "EVT-sliworker001",
+                "group-report-sli-worker",
+                "worker",
+                "worker timeout",
+            )?;
+            worker_error.payload.created_at = now.clone();
+            store.commit_error_ingest(worker_error)?;
+            store.correlate_incident(IncidentCorrelation {
+                tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
+                project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
+                signal_type: "error_group".to_owned(),
+                signal_ref: "group-report-sli-api".to_owned(),
+                service: "api".to_owned(),
+                incident_id: IncidentId::from_str("INC-sliapi000001")?,
+                event_id: EventId::from_str("EVT-sliinc000001")?,
+                now: now.clone(),
+            })?;
+        }
+        let router = ingest_router(state);
+
+        let report = router
+            .clone()
+            .oneshot(read_request(READ_KEY, "/api/v1/report?window=1h")?)
+            .await?;
+        let report = json_body(report).await?;
+        let service_sli = report["service_sli"]
+            .as_array()
+            .ok_or("report should include service_sli")?;
+        assert_eq!(service_sli.len(), 2);
+        let api = service_sli
+            .iter()
+            .find(|summary| summary["service"] == "api")
+            .ok_or("missing api SLI")?;
+        assert_eq!(api["window"], "1h");
+        assert_eq!(api["targets"]["checks"], 1);
+        assert_eq!(api["targets"]["availability_ratio"], 1.0);
+        assert_eq!(api["monitors"]["healthy_check_ins"], 1);
+        assert_eq!(api["errors"]["total"], 1);
+        assert_eq!(api["incidents"]["active"], 1);
+
+        let bound = router
+            .oneshot(read_request(read_key, "/api/v1/report?window=1h")?)
+            .await?;
+        let bound = json_body(bound).await?;
+        assert_eq!(bound["service_sli"].as_array().map(Vec::len), Some(1));
+        assert_eq!(bound["service_sli"][0]["service"], "api");
 
         Ok(())
     }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -2999,6 +2999,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn monitor_check_in_rejects_future_observed_at_without_writing()
+    -> Result<(), Box<dyn Error>> {
+        let state = test_ingest_state_with_monitor("desktop-active-timer")?;
+        let router = ingest_router(state.clone());
+
+        let response = router
+            .oneshot(check_in_request(
+                INGEST_KEY,
+                r#"{"monitor":"desktop-active-timer","status":"alive","observed_at":"2999-01-01T00:00:00Z","ttl_ms":120000}"#,
+            )?)
+            .await?;
+        let status = response.status();
+        let body = json_body(response).await?;
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["code"], "validation_error");
+        assert_eq!(body["detail"], "observed_at is too far in the future.");
+        assert_eq!(
+            body["errors"]["observed_at"],
+            json!(["must not be more than 5 minutes in the future"])
+        );
+
+        let accepted = ingest_router(state)
+            .oneshot(check_in_request(INGEST_KEY, valid_check_in_body())?)
+            .await?;
+        let accepted_body = json_body(accepted).await?;
+        assert_eq!(accepted_body["sequence"], 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn monitor_check_in_rejects_missing_invalid_revoked_and_wrong_scope_keys()
     -> Result<(), Box<dyn Error>> {
         let cases = [

--- a/crates/canary-server/src/report_routes.rs
+++ b/crates/canary-server/src/report_routes.rs
@@ -248,6 +248,13 @@ fn service_sli_response(summary: &ServiceSliSummary) -> Value {
     json!({
         "service": summary.service,
         "window": summary.window,
+        "slo": {
+            "class": summary.slo.class,
+            "source": summary.slo.source,
+            "availability_target": summary.slo.availability_target,
+            "latency_ms_average_target": summary.slo.latency_ms_average_target,
+            "error_budget_events_per_hour": summary.slo.error_budget_events_per_hour,
+        },
         "targets": {
             "configured": summary.targets.configured,
             "checks": summary.targets.checks,

--- a/crates/canary-server/src/report_routes.rs
+++ b/crates/canary-server/src/report_routes.rs
@@ -17,8 +17,8 @@ use canary_http::problem_details::{
     invalid_string_param_problem, invalid_window_problem,
 };
 use canary_store::{
-    IncidentListOptions, QueryError, RecentTransition, SearchResult, TimelineQueryError,
-    TimelineQueryOptions,
+    IncidentListOptions, QueryError, RecentTransition, SearchResult, ServiceSliSummary,
+    TimelineQueryError, TimelineQueryOptions,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -82,6 +82,11 @@ pub(crate) async fn report(
             Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
             Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
         };
+    let mut service_sli = match store.service_sli_scoped(window, &key.tenant_id, &key.project_id) {
+        Ok(service_sli) => service_sli,
+        Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
+        Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
+    };
     let mut error_groups =
         match store.report_error_groups_scoped(window, &key.tenant_id, &key.project_id) {
             Ok(groups) => groups,
@@ -135,6 +140,7 @@ pub(crate) async fn report(
         targets.retain(|target| target.service == bound_service);
         monitors.retain(|monitor| monitor.service == bound_service);
         error_summary.retain(|summary| summary.service == bound_service);
+        service_sli.retain(|summary| summary.service == bound_service);
         error_groups.retain(|group| group.service == bound_service);
         incidents.retain(|incident| incident.service == bound_service);
         transitions.retain(|transition| transition.service == bound_service);
@@ -154,6 +160,8 @@ pub(crate) async fn report(
         Some(limit.unwrap_or(25)),
         cursor.error_groups_offset,
     );
+    // service_sli is a compact per-service snapshot; report cursors advance
+    // only repeated detail sections.
     let next_cursor = ReportCursor {
         targets_offset: next_targets_offset,
         monitor_offset: next_monitor_offset,
@@ -167,6 +175,7 @@ pub(crate) async fn report(
         "summary": summary,
         "targets": targets.iter().map(health_target_response).collect::<Vec<_>>(),
         "monitors": monitors.iter().map(health_monitor_response).collect::<Vec<_>>(),
+        "service_sli": service_sli.iter().map(service_sli_response).collect::<Vec<_>>(),
         "error_groups": error_groups.iter().map(error_group_response).collect::<Vec<_>>(),
         "incidents": incidents,
         "recent_transitions": transitions.iter().map(recent_transition_response).collect::<Vec<_>>(),
@@ -232,6 +241,37 @@ fn search_result_response(result: &SearchResult) -> Value {
         "group_hash": result.group_hash,
         "created_at": result.created_at,
         "score": result.score,
+    })
+}
+
+fn service_sli_response(summary: &ServiceSliSummary) -> Value {
+    json!({
+        "service": summary.service,
+        "window": summary.window,
+        "targets": {
+            "configured": summary.targets.configured,
+            "checks": summary.targets.checks,
+            "successful_checks": summary.targets.successful_checks,
+            "failed_checks": summary.targets.failed_checks,
+            "availability_ratio": summary.targets.availability_ratio,
+            "latency_ms_average": summary.targets.latency_ms_average,
+        },
+        "monitors": {
+            "configured": summary.monitors.configured,
+            "check_ins": summary.monitors.check_ins,
+            "healthy_check_ins": summary.monitors.healthy_check_ins,
+            "failed_check_ins": summary.monitors.failed_check_ins,
+            "availability_ratio": summary.monitors.availability_ratio,
+        },
+        "errors": {
+            "total": summary.errors.total,
+            "groups": summary.errors.groups,
+        },
+        "incidents": {
+            "opened": summary.incidents.opened,
+            "resolved": summary.incidents.resolved,
+            "active": summary.incidents.active,
+        },
     })
 }
 

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -23,6 +23,7 @@ mod rate_limits;
 mod retention;
 mod schema;
 mod seeds;
+mod service_sli;
 mod telemetry;
 mod webhook_deliveries;
 
@@ -66,6 +67,7 @@ pub use retention::{
     RetentionPrune, RetentionPruneBatch, RetentionPruneBatchReport, RetentionPruneReport,
     RetentionPruneTable,
 };
+pub use service_sli::ServiceSliSummary;
 pub use telemetry::{TelemetryEventError, TelemetryEventInsert, TelemetryEventResult};
 pub use webhook_deliveries::{
     WebhookDeliveryInsert, WebhookDeliveryListOptions, WebhookDeliveryPageError,
@@ -661,6 +663,30 @@ impl Store {
         project_id: &str,
     ) -> QueryResult<Vec<ErrorSummaryItem>> {
         query::error_summary_scoped(&self.connection, window, tenant_id, project_id)
+    }
+
+    /// Query windowed service SLI aggregates.
+    pub fn service_sli(&self, window: &str) -> QueryResult<Vec<ServiceSliSummary>> {
+        service_sli::service_sli(&self.connection, window)
+    }
+
+    /// Query windowed service SLI aggregates for one tenant/project.
+    pub fn service_sli_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<ServiceSliSummary>> {
+        service_sli::service_sli_scoped(&self.connection, window, tenant_id, project_id)
+    }
+
+    /// Query windowed service SLI aggregates at a deterministic evaluation time.
+    pub fn service_sli_at(
+        &self,
+        window: &str,
+        now: time::OffsetDateTime,
+    ) -> QueryResult<Vec<ServiceSliSummary>> {
+        service_sli::service_sli_at(&self.connection, window, now)
     }
 
     /// Query active error groups for the unified report.

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -665,11 +665,6 @@ impl Store {
         query::error_summary_scoped(&self.connection, window, tenant_id, project_id)
     }
 
-    /// Query windowed service SLI aggregates.
-    pub fn service_sli(&self, window: &str) -> QueryResult<Vec<ServiceSliSummary>> {
-        service_sli::service_sli(&self.connection, window)
-    }
-
     /// Query windowed service SLI aggregates for one tenant/project.
     pub fn service_sli_scoped(
         &self,

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -1,0 +1,616 @@
+//! Windowed service SLI read models.
+//!
+//! These projections derive service health from persisted observations only.
+//! They do not own SLO objectives, budgets, alert routing, or health-state
+//! transitions.
+
+use std::collections::BTreeMap;
+
+use canary_core::query::QueryWindow;
+use rusqlite::{Connection, params_from_iter};
+use time::OffsetDateTime;
+
+use crate::query::{QueryError, QueryResult};
+
+/// Per-service SLI projection returned by the unified report.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServiceSliSummary {
+    /// Service name.
+    pub service: String,
+    /// Query window used to calculate the windowed fields.
+    pub window: String,
+    /// HTTP-target availability and latency signals.
+    pub targets: TargetSliSummary,
+    /// Non-HTTP monitor availability signals.
+    pub monitors: MonitorSliSummary,
+    /// Error ingest signals.
+    pub errors: ErrorSliSummary,
+    /// Incident pressure signals.
+    pub incidents: IncidentSliSummary,
+}
+
+/// HTTP-target SLI aggregate for one service.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TargetSliSummary {
+    /// Configured target count for this service.
+    pub configured: u64,
+    /// Target checks observed in the query window.
+    pub checks: u64,
+    /// Target checks whose result was `success`.
+    pub successful_checks: u64,
+    /// Target checks whose result was not `success`.
+    pub failed_checks: u64,
+    /// Successful checks divided by total checks, when checks exist.
+    pub availability_ratio: Option<f64>,
+    /// Average target latency in milliseconds, when any check reported latency.
+    pub latency_ms_average: Option<f64>,
+}
+
+/// Non-HTTP monitor SLI aggregate for one service.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MonitorSliSummary {
+    /// Configured monitor count for this service.
+    pub configured: u64,
+    /// Monitor check-ins observed in the query window.
+    pub check_ins: u64,
+    /// Check-ins that map to an up health state.
+    pub healthy_check_ins: u64,
+    /// Check-ins that reported `error`.
+    pub failed_check_ins: u64,
+    /// Healthy check-ins divided by total check-ins, when check-ins exist.
+    pub availability_ratio: Option<f64>,
+}
+
+/// Error ingest SLI aggregate for one service.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ErrorSliSummary {
+    /// Error rows observed in the query window.
+    pub total: u64,
+    /// Distinct error groups observed in the query window.
+    pub groups: u64,
+}
+
+/// Incident SLI aggregate for one service.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IncidentSliSummary {
+    /// Incidents opened in the query window.
+    pub opened: u64,
+    /// Incidents resolved in the query window.
+    pub resolved: u64,
+    /// Current unresolved incidents for this service.
+    pub active: u64,
+}
+
+pub(crate) fn service_sli(
+    connection: &Connection,
+    window: &str,
+) -> QueryResult<Vec<ServiceSliSummary>> {
+    service_sli_at(connection, window, OffsetDateTime::now_utc())
+}
+
+pub(crate) fn service_sli_scoped(
+    connection: &Connection,
+    window: &str,
+    tenant_id: &str,
+    project_id: &str,
+) -> QueryResult<Vec<ServiceSliSummary>> {
+    service_sli_at_scoped(
+        connection,
+        window,
+        OffsetDateTime::now_utc(),
+        Some((tenant_id, project_id)),
+    )
+}
+
+pub(crate) fn service_sli_at(
+    connection: &Connection,
+    window: &str,
+    now: OffsetDateTime,
+) -> QueryResult<Vec<ServiceSliSummary>> {
+    service_sli_at_scoped(connection, window, now, None)
+}
+
+fn service_sli_at_scoped(
+    connection: &Connection,
+    window: &str,
+    now: OffsetDateTime,
+    owner: Option<(&str, &str)>,
+) -> QueryResult<Vec<ServiceSliSummary>> {
+    let window = QueryWindow::parse(window).ok_or(QueryError::InvalidWindow)?;
+    let cutoff = window.cutoff_at(now);
+    let mut summaries = BTreeMap::new();
+
+    add_target_sli(connection, owner, window, &mut summaries)?;
+    add_target_check_sli(connection, &cutoff, owner, window, &mut summaries)?;
+    add_monitor_sli(connection, owner, window, &mut summaries)?;
+    add_monitor_check_in_sli(connection, &cutoff, owner, window, &mut summaries)?;
+    add_error_sli(connection, &cutoff, owner, window, &mut summaries)?;
+    add_incident_sli(connection, &cutoff, owner, window, &mut summaries)?;
+
+    Ok(summaries.into_values().collect())
+}
+
+fn service_sli_entry<'a>(
+    summaries: &'a mut BTreeMap<String, ServiceSliSummary>,
+    service: &str,
+    window: QueryWindow,
+) -> &'a mut ServiceSliSummary {
+    summaries
+        .entry(service.to_owned())
+        .or_insert_with(|| ServiceSliSummary {
+            service: service.to_owned(),
+            window: window.as_str().to_owned(),
+            targets: TargetSliSummary::default(),
+            monitors: MonitorSliSummary::default(),
+            errors: ErrorSliSummary::default(),
+            incidents: IncidentSliSummary::default(),
+        })
+}
+
+fn add_target_sli(
+    connection: &Connection,
+    owner: Option<(&str, &str)>,
+    window: QueryWindow,
+    summaries: &mut BTreeMap<String, ServiceSliSummary>,
+) -> QueryResult<()> {
+    let sql = format!(
+        "SELECT COALESCE(NULLIF(t.service, ''), t.name), COUNT(*)
+         FROM targets t
+         WHERE 1 = 1
+         {}
+         GROUP BY 1",
+        owner_clause("t", 1, owner)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(params_from_iter(owner_params(owner)), configured_sli_row)?;
+    for row in rows {
+        let (service, configured) = row?;
+        service_sli_entry(summaries, &service, window)
+            .targets
+            .configured = configured;
+    }
+    Ok(())
+}
+
+fn add_target_check_sli(
+    connection: &Connection,
+    cutoff: &str,
+    owner: Option<(&str, &str)>,
+    window: QueryWindow,
+    summaries: &mut BTreeMap<String, ServiceSliSummary>,
+) -> QueryResult<()> {
+    let sql = format!(
+        "SELECT
+            COALESCE(NULLIF(t.service, ''), t.name),
+            COUNT(*),
+            SUM(CASE WHEN c.result = 'success' THEN 1 ELSE 0 END),
+            SUM(CASE WHEN c.result != 'success' THEN 1 ELSE 0 END),
+            AVG(c.latency_ms)
+         FROM target_checks c
+         JOIN targets t ON t.id = c.target_id
+         WHERE c.checked_at >= ?1
+         {}
+         GROUP BY 1",
+        owner_clause("t", 2, owner)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(
+        params_from_iter(window_params(cutoff, owner)),
+        target_sli_row,
+    )?;
+    for row in rows {
+        let row = row?;
+        let target = &mut service_sli_entry(summaries, &row.service, window).targets;
+        target.checks = row.total;
+        target.successful_checks = row.successful;
+        target.failed_checks = row.failed;
+        target.availability_ratio = ratio(row.successful, row.total);
+        target.latency_ms_average = row.latency_ms_average;
+    }
+    Ok(())
+}
+
+fn add_monitor_sli(
+    connection: &Connection,
+    owner: Option<(&str, &str)>,
+    window: QueryWindow,
+    summaries: &mut BTreeMap<String, ServiceSliSummary>,
+) -> QueryResult<()> {
+    let sql = format!(
+        "SELECT COALESCE(NULLIF(m.service, ''), m.name), COUNT(*)
+         FROM monitors m
+         WHERE 1 = 1
+         {}
+         GROUP BY 1",
+        owner_clause("m", 1, owner)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(params_from_iter(owner_params(owner)), configured_sli_row)?;
+    for row in rows {
+        let (service, configured) = row?;
+        service_sli_entry(summaries, &service, window)
+            .monitors
+            .configured = configured;
+    }
+    Ok(())
+}
+
+fn add_monitor_check_in_sli(
+    connection: &Connection,
+    cutoff: &str,
+    owner: Option<(&str, &str)>,
+    window: QueryWindow,
+    summaries: &mut BTreeMap<String, ServiceSliSummary>,
+) -> QueryResult<()> {
+    let sql = format!(
+        "SELECT
+            COALESCE(NULLIF(m.service, ''), m.name),
+            COUNT(*),
+            SUM(CASE WHEN c.status IN ('alive', 'ok', 'in_progress') THEN 1 ELSE 0 END),
+            SUM(CASE WHEN c.status = 'error' THEN 1 ELSE 0 END)
+         FROM monitor_check_ins c
+         JOIN monitors m ON m.id = c.monitor_id
+         WHERE c.observed_at >= ?1
+         {}
+         GROUP BY 1",
+        owner_clause("m", 2, owner)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(
+        params_from_iter(window_params(cutoff, owner)),
+        monitor_sli_row,
+    )?;
+    for row in rows {
+        let row = row?;
+        let monitor = &mut service_sli_entry(summaries, &row.service, window).monitors;
+        monitor.check_ins = row.total;
+        monitor.healthy_check_ins = row.successful;
+        monitor.failed_check_ins = row.failed;
+        monitor.availability_ratio = ratio(row.successful, row.total);
+    }
+    Ok(())
+}
+
+fn add_error_sli(
+    connection: &Connection,
+    cutoff: &str,
+    owner: Option<(&str, &str)>,
+    window: QueryWindow,
+    summaries: &mut BTreeMap<String, ServiceSliSummary>,
+) -> QueryResult<()> {
+    let sql = format!(
+        "SELECT e.service, COUNT(*), COUNT(DISTINCT e.group_hash)
+         FROM errors e
+         WHERE e.created_at >= ?1
+         {}
+         GROUP BY e.service",
+        owner_clause("e", 2, owner)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(
+        params_from_iter(window_params(cutoff, owner)),
+        error_sli_row,
+    )?;
+    for row in rows {
+        let (service, total, groups) = row?;
+        let errors = &mut service_sli_entry(summaries, &service, window).errors;
+        errors.total = total;
+        errors.groups = groups;
+    }
+    Ok(())
+}
+
+fn add_incident_sli(
+    connection: &Connection,
+    cutoff: &str,
+    owner: Option<(&str, &str)>,
+    window: QueryWindow,
+    summaries: &mut BTreeMap<String, ServiceSliSummary>,
+) -> QueryResult<()> {
+    let sql = format!(
+        "SELECT
+            i.service,
+            SUM(CASE WHEN i.opened_at >= ?1 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN i.resolved_at >= ?1 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN i.state != 'resolved' THEN 1 ELSE 0 END)
+         FROM incidents i
+         WHERE (i.opened_at >= ?1 OR i.resolved_at >= ?1 OR i.state != 'resolved')
+         {}
+         GROUP BY i.service",
+        owner_clause("i", 2, owner)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(
+        params_from_iter(window_params(cutoff, owner)),
+        incident_sli_row,
+    )?;
+    for row in rows {
+        let row = row?;
+        let incidents = &mut service_sli_entry(summaries, &row.service, window).incidents;
+        incidents.opened = row.opened;
+        incidents.resolved = row.resolved;
+        incidents.active = row.active;
+    }
+    Ok(())
+}
+
+struct HealthSliRow {
+    service: String,
+    total: u64,
+    successful: u64,
+    failed: u64,
+    latency_ms_average: Option<f64>,
+}
+
+fn configured_sli_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<(String, u64)> {
+    Ok((row.get(0)?, row.get(1)?))
+}
+
+fn target_sli_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HealthSliRow> {
+    Ok(HealthSliRow {
+        service: row.get(0)?,
+        total: row.get(1)?,
+        successful: row.get(2)?,
+        failed: row.get(3)?,
+        latency_ms_average: row.get(4)?,
+    })
+}
+
+fn monitor_sli_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HealthSliRow> {
+    Ok(HealthSliRow {
+        service: row.get(0)?,
+        total: row.get(1)?,
+        successful: row.get(2)?,
+        failed: row.get(3)?,
+        latency_ms_average: None,
+    })
+}
+
+fn error_sli_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<(String, u64, u64)> {
+    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+}
+
+struct IncidentSliRow {
+    service: String,
+    opened: u64,
+    resolved: u64,
+    active: u64,
+}
+
+fn incident_sli_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IncidentSliRow> {
+    Ok(IncidentSliRow {
+        service: row.get(0)?,
+        opened: row.get(1)?,
+        resolved: row.get(2)?,
+        active: row.get(3)?,
+    })
+}
+
+fn ratio(successful: u64, total: u64) -> Option<f64> {
+    (total > 0).then_some(successful as f64 / total as f64)
+}
+
+fn owner_clause(alias: &str, first_parameter: usize, owner: Option<(&str, &str)>) -> String {
+    owner
+        .map(|_| {
+            format!(
+                "AND {alias}.tenant_id = ?{first_parameter} AND {alias}.project_id = ?{}",
+                first_parameter + 1
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn owner_params<'a>(owner: Option<(&'a str, &'a str)>) -> Vec<&'a str> {
+    owner
+        .map(|(tenant_id, project_id)| vec![tenant_id, project_id])
+        .unwrap_or_default()
+}
+
+fn window_params<'a>(cutoff: &'a str, owner: Option<(&'a str, &'a str)>) -> Vec<&'a str> {
+    let mut values = vec![cutoff];
+    if let Some((tenant_id, project_id)) = owner {
+        values.push(tenant_id);
+        values.push(project_id);
+    }
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+    use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+    use super::*;
+    use crate::{MonitorInsert, Store, TargetInsert};
+
+    #[test]
+    fn service_sli_counts_windowed_health_errors_and_incidents_by_service()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        store.insert_target(TargetInsert {
+            id: "TGT-api".to_owned(),
+            url: "https://api.example.test/health".to_owned(),
+            name: "API".to_owned(),
+            service: "api".to_owned(),
+            method: "GET".to_owned(),
+            headers: None,
+            interval_ms: 60_000,
+            timeout_ms: 10_000,
+            expected_status: "200".to_owned(),
+            body_contains: None,
+            degraded_after: 2,
+            down_after: 3,
+            up_after: 1,
+            active: true,
+            created_at: "2026-05-28T20:00:00Z".to_owned(),
+        })?;
+        store.insert_monitor(MonitorInsert {
+            id: "MON-api".to_owned(),
+            name: "API worker".to_owned(),
+            service: "api".to_owned(),
+            mode: "ttl".to_owned(),
+            expected_every_ms: 60_000,
+            grace_ms: 5_000,
+            created_at: "2026-05-28T20:00:00Z".to_owned(),
+        })?;
+        store.insert_monitor(MonitorInsert {
+            id: "MON-worker".to_owned(),
+            name: "Worker".to_owned(),
+            service: "worker".to_owned(),
+            mode: "ttl".to_owned(),
+            expected_every_ms: 60_000,
+            grace_ms: 5_000,
+            created_at: "2026-05-28T20:00:00Z".to_owned(),
+        })?;
+        for (checked_at, result, latency_ms) in [
+            ("2026-05-28T20:55:00Z", "success", 50),
+            ("2026-05-28T20:50:00Z", "error", 100),
+            ("2026-05-28T20:45:00Z", "success", 150),
+            ("2026-05-28T14:00:00Z", "error", 999),
+        ] {
+            store.connection.execute(
+                "INSERT INTO target_checks (
+                    target_id, checked_at, status_code, latency_ms, result
+                 ) VALUES ('TGT-api', ?1, 200, ?2, ?3)",
+                params![checked_at, latency_ms, result],
+            )?;
+        }
+        for (id, monitor_id, status, observed_at) in [
+            ("CHK-api-alive", "MON-api", "alive", "2026-05-28T20:58:00Z"),
+            ("CHK-api-error", "MON-api", "error", "2026-05-28T20:57:00Z"),
+            (
+                "CHK-api-in-progress-old",
+                "MON-api",
+                "in_progress",
+                "2026-05-28T14:00:00Z",
+            ),
+            (
+                "CHK-worker-in-progress",
+                "MON-worker",
+                "in_progress",
+                "2026-05-28T20:56:00Z",
+            ),
+        ] {
+            store.connection.execute(
+                "INSERT INTO monitor_check_ins (id, monitor_id, status, observed_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![id, monitor_id, status, observed_at],
+            )?;
+        }
+        for (id, group_hash, service, created_at) in [
+            (
+                "ERR-sliapi000001",
+                "group-sli-api-a",
+                "api",
+                "2026-05-28T20:54:00Z",
+            ),
+            (
+                "ERR-sliapi000002",
+                "group-sli-api-b",
+                "api",
+                "2026-05-28T20:53:00Z",
+            ),
+            (
+                "ERR-sliapiold01",
+                "group-sli-api-old",
+                "api",
+                "2026-05-28T14:00:00Z",
+            ),
+        ] {
+            store.connection.execute(
+                "INSERT INTO errors (
+                    id, service, error_class, message, group_hash, created_at
+                 ) VALUES (?1, ?2, 'RuntimeError', 'boom', ?3, ?4)",
+                params![id, service, group_hash, created_at],
+            )?;
+        }
+        for (id, service, state, opened_at, resolved_at) in [
+            (
+                "INC-sliapi000001",
+                "api",
+                "investigating",
+                "2026-05-28T20:52:00Z",
+                None,
+            ),
+            (
+                "INC-sliapi000002",
+                "api",
+                "resolved",
+                "2026-05-28T20:51:00Z",
+                Some("2026-05-28T20:59:00Z"),
+            ),
+            (
+                "INC-sliapiold01",
+                "api",
+                "resolved",
+                "2026-05-28T14:00:00Z",
+                Some("2026-05-28T14:30:00Z"),
+            ),
+        ] {
+            store.connection.execute(
+                "INSERT INTO incidents (id, service, state, severity, title, opened_at, resolved_at)
+                 VALUES (?1, ?2, ?3, 'medium', 'sli incident', ?4, ?5)",
+                params![id, service, state, opened_at, resolved_at],
+            )?;
+        }
+        let now = OffsetDateTime::parse("2026-05-28T21:00:00Z", &Rfc3339)?;
+
+        let summaries = store.service_sli_at("6h", now)?;
+
+        assert_eq!(summaries.len(), 2);
+        let api = summaries
+            .iter()
+            .find(|summary| summary.service == "api")
+            .ok_or("missing api SLI")?;
+        assert_eq!(api.window, "6h");
+        assert_eq!(api.targets.configured, 1);
+        assert_eq!(api.targets.checks, 3);
+        assert_eq!(api.targets.successful_checks, 2);
+        assert_eq!(api.targets.failed_checks, 1);
+        assert_ratio(api.targets.availability_ratio, 2.0 / 3.0);
+        assert_eq!(api.targets.latency_ms_average, Some(100.0));
+        assert_eq!(api.monitors.configured, 1);
+        assert_eq!(api.monitors.check_ins, 2);
+        assert_eq!(api.monitors.healthy_check_ins, 1);
+        assert_eq!(api.monitors.failed_check_ins, 1);
+        assert_ratio(api.monitors.availability_ratio, 0.5);
+        assert_eq!(api.errors.total, 2);
+        assert_eq!(api.errors.groups, 2);
+        assert_eq!(api.incidents.opened, 2);
+        assert_eq!(api.incidents.resolved, 1);
+        assert_eq!(api.incidents.active, 1);
+
+        let worker = summaries
+            .iter()
+            .find(|summary| summary.service == "worker")
+            .ok_or("missing worker SLI")?;
+        assert_eq!(worker.targets.configured, 0);
+        assert_eq!(worker.monitors.configured, 1);
+        assert_eq!(worker.monitors.check_ins, 1);
+        assert_eq!(worker.monitors.healthy_check_ins, 1);
+        assert_ratio(worker.monitors.availability_ratio, 1.0);
+        assert_eq!(worker.errors.total, 0);
+        assert_eq!(worker.incidents.active, 0);
+        assert!(matches!(
+            store.service_sli_at("99h", now),
+            Err(QueryError::InvalidWindow)
+        ));
+
+        Ok(())
+    }
+
+    fn migrated_store() -> crate::Result<Store> {
+        let mut store = Store::open_in_memory()?;
+        store.migrate()?;
+        Ok(store)
+    }
+
+    fn assert_ratio(actual: Option<f64>, expected: f64) {
+        let actual = actual.expect("ratio should be present");
+        assert!(
+            (actual - expected).abs() < f64::EPSILON,
+            "expected ratio {expected}, got {actual}"
+        );
+    }
+}

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -644,10 +644,7 @@ mod tests {
     }
 
     fn assert_ratio(actual: Option<f64>, expected: f64) {
-        let actual = actual.expect("ratio should be present");
-        assert!(
-            (actual - expected).abs() < f64::EPSILON,
-            "expected ratio {expected}, got {actual}"
-        );
+        let within_epsilon = actual.is_some_and(|actual| (actual - expected).abs() < f64::EPSILON);
+        assert!(within_epsilon, "expected ratio {expected}, got {actual:?}");
     }
 }

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -1,12 +1,15 @@
 //! Windowed service SLI read models.
 //!
 //! These projections derive service health from persisted observations only.
-//! They do not own SLO objectives, budgets, alert routing, or health-state
-//! transitions.
+//! They attach deterministic default SLO class metadata, but do not own budget
+//! burn, alert routing, or health-state transitions.
 
 use std::collections::BTreeMap;
 
-use canary_core::query::QueryWindow;
+use canary_core::{
+    query::QueryWindow,
+    slo::{ServiceSloObjective, default_service_slo},
+};
 use rusqlite::{Connection, params_from_iter};
 use time::OffsetDateTime;
 
@@ -19,6 +22,8 @@ pub struct ServiceSliSummary {
     pub service: String,
     /// Query window used to calculate the windowed fields.
     pub window: String,
+    /// Default SLO class and objective metadata for this service.
+    pub slo: ServiceSloObjective,
     /// HTTP-target availability and latency signals.
     pub targets: TargetSliSummary,
     /// Non-HTTP monitor availability signals.
@@ -126,6 +131,7 @@ fn service_sli_at_scoped(
     add_monitor_check_in_sli(connection, &cutoff, owner, window, &mut summaries)?;
     add_error_sli(connection, &cutoff, owner, window, &mut summaries)?;
     add_incident_sli(connection, &cutoff, owner, window, &mut summaries)?;
+    apply_default_slo(&mut summaries);
 
     Ok(summaries.into_values().collect())
 }
@@ -140,11 +146,19 @@ fn service_sli_entry<'a>(
         .or_insert_with(|| ServiceSliSummary {
             service: service.to_owned(),
             window: window.as_str().to_owned(),
+            slo: default_service_slo(false),
             targets: TargetSliSummary::default(),
             monitors: MonitorSliSummary::default(),
             errors: ErrorSliSummary::default(),
             incidents: IncidentSliSummary::default(),
         })
+}
+
+fn apply_default_slo(summaries: &mut BTreeMap<String, ServiceSliSummary>) {
+    for summary in summaries.values_mut() {
+        let has_health_surface = summary.targets.configured > 0 || summary.monitors.configured > 0;
+        summary.slo = default_service_slo(has_health_surface);
+    }
 }
 
 fn add_target_sli(
@@ -517,6 +531,12 @@ mod tests {
                 "api",
                 "2026-05-28T14:00:00Z",
             ),
+            (
+                "ERR-slibatch001",
+                "group-sli-batch-a",
+                "batch-worker",
+                "2026-05-28T20:52:30Z",
+            ),
         ] {
             store.connection.execute(
                 "INSERT INTO errors (
@@ -558,12 +578,17 @@ mod tests {
 
         let summaries = store.service_sli_at("6h", now)?;
 
-        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries.len(), 3);
         let api = summaries
             .iter()
             .find(|summary| summary.service == "api")
             .ok_or("missing api SLI")?;
         assert_eq!(api.window, "6h");
+        assert_eq!(api.slo.class, "standard");
+        assert_eq!(api.slo.source, "default_health_surface");
+        assert_ratio(Some(api.slo.availability_target), 0.995);
+        assert_eq!(api.slo.latency_ms_average_target, 1_000);
+        assert_eq!(api.slo.error_budget_events_per_hour, 5);
         assert_eq!(api.targets.configured, 1);
         assert_eq!(api.targets.checks, 3);
         assert_eq!(api.targets.successful_checks, 2);
@@ -592,6 +617,18 @@ mod tests {
         assert_ratio(worker.monitors.availability_ratio, 1.0);
         assert_eq!(worker.errors.total, 0);
         assert_eq!(worker.incidents.active, 0);
+        let batch = summaries
+            .iter()
+            .find(|summary| summary.service == "batch-worker")
+            .ok_or("missing batch-worker SLI")?;
+        assert_eq!(batch.slo.class, "best_effort");
+        assert_eq!(batch.slo.source, "default_signal_only");
+        assert_ratio(Some(batch.slo.availability_target), 0.99);
+        assert_eq!(batch.slo.latency_ms_average_target, 2_500);
+        assert_eq!(batch.slo.error_budget_events_per_hour, 20);
+        assert_eq!(batch.errors.total, 1);
+        assert_eq!(batch.targets.configured, 0);
+        assert_eq!(batch.monitors.configured, 0);
         assert!(matches!(
             store.service_sli_at("99h", now),
             Err(QueryError::InvalidWindow)

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -86,13 +86,6 @@ pub struct IncidentSliSummary {
     pub active: u64,
 }
 
-pub(crate) fn service_sli(
-    connection: &Connection,
-    window: &str,
-) -> QueryResult<Vec<ServiceSliSummary>> {
-    service_sli_at(connection, window, OffsetDateTime::now_utc())
-}
-
 pub(crate) fn service_sli_scoped(
     connection: &Connection,
     window: &str,

--- a/crates/canary-workers/src/health.rs
+++ b/crates/canary-workers/src/health.rs
@@ -630,12 +630,13 @@ mod tests {
         let mut input = check_in(MonitorCheckInStatus::Alive);
         input.observed_at = "2026-05-28T20:05:01Z".to_owned();
 
-        let error = plan_monitor_check_in(
+        let Err(error) = plan_monitor_check_in(
             monitor(HealthState::Unknown, MonitorMode::Ttl),
             input,
             context()?,
-        )
-        .expect_err("future observed_at beyond skew should be rejected");
+        ) else {
+            return Err("future observed_at beyond skew should be rejected".into());
+        };
 
         assert_eq!(
             error.to_string(),

--- a/crates/canary-workers/src/health.rs
+++ b/crates/canary-workers/src/health.rs
@@ -21,6 +21,8 @@ use canary_store::{
 };
 use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
+const MAX_MONITOR_OBSERVED_AT_FUTURE_SKEW_SECONDS: i64 = 300;
+
 /// Runtime timestamp and ids for a health observation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObservationContext {
@@ -265,6 +267,8 @@ pub struct PlannedMonitorOverdue {
 pub enum HealthPlanError {
     /// The observed check-in timestamp was not RFC3339.
     InvalidObservedAt(String),
+    /// The observed check-in timestamp is beyond the accepted future clock skew.
+    ObservedAtTooFarInFuture,
 }
 
 impl fmt::Display for HealthPlanError {
@@ -273,6 +277,10 @@ impl fmt::Display for HealthPlanError {
             Self::InvalidObservedAt(value) => {
                 write!(formatter, "invalid monitor observed_at timestamp: {value}")
             }
+            Self::ObservedAtTooFarInFuture => write!(
+                formatter,
+                "monitor observed_at cannot be more than {MAX_MONITOR_OBSERVED_AT_FUTURE_SKEW_SECONDS} seconds after receipt time"
+            ),
         }
     }
 }
@@ -286,7 +294,9 @@ pub fn plan_monitor_check_in(
     context: ObservationContext,
 ) -> Result<PlannedMonitorCheckIn, HealthPlanError> {
     let state = input.status.state();
-    let deadline_at = deadline_at(&monitor, &input)?;
+    let observed_at = parse_observed_at(&input.observed_at)?;
+    reject_observed_at_after_receipt(observed_at, &context.now)?;
+    let deadline_at = deadline_at(&monitor, &input, observed_at)?;
     let transitioned = monitor.state != state;
     let transition = transitioned.then(|| MonitorTransitionEvent {
         name: monitor.name,
@@ -386,15 +396,32 @@ pub fn plan_monitor_overdue(
 fn deadline_at(
     monitor: &MonitorSnapshot,
     input: &MonitorCheckInInput,
+    observed: OffsetDateTime,
 ) -> Result<String, HealthPlanError> {
-    let observed = OffsetDateTime::parse(&input.observed_at, &Rfc3339)
-        .map_err(|_| HealthPlanError::InvalidObservedAt(input.observed_at.clone()))?;
     let deadline = observed
         + Duration::milliseconds(effective_interval_ms(monitor, input))
         + Duration::milliseconds(monitor.grace_ms);
     deadline
         .format(&Rfc3339)
         .map_err(|_| HealthPlanError::InvalidObservedAt(input.observed_at.clone()))
+}
+
+fn parse_observed_at(value: &str) -> Result<OffsetDateTime, HealthPlanError> {
+    OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| HealthPlanError::InvalidObservedAt(value.to_owned()))
+}
+
+fn reject_observed_at_after_receipt(
+    observed_at: OffsetDateTime,
+    receipt_time: &str,
+) -> Result<(), HealthPlanError> {
+    let Some(receipt_time) = parse_monitor_timestamp("now", receipt_time) else {
+        return Ok(());
+    };
+    if observed_at - receipt_time > Duration::seconds(MAX_MONITOR_OBSERVED_AT_FUTURE_SKEW_SECONDS) {
+        return Err(HealthPlanError::ObservedAtTooFarInFuture);
+    }
+    Ok(())
 }
 
 fn effective_interval_ms(monitor: &MonitorSnapshot, input: &MonitorCheckInInput) -> i64 {
@@ -594,6 +621,45 @@ mod tests {
             Some("2026-05-28T20:02:05Z")
         );
         assert!(plan.commit.transition.is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn monitor_check_in_rejects_observed_at_beyond_future_skew() -> Result<(), Box<dyn Error>> {
+        let mut input = check_in(MonitorCheckInStatus::Alive);
+        input.observed_at = "2026-05-28T20:05:01Z".to_owned();
+
+        let error = plan_monitor_check_in(
+            monitor(HealthState::Unknown, MonitorMode::Ttl),
+            input,
+            context()?,
+        )
+        .expect_err("future observed_at beyond skew should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "monitor observed_at cannot be more than 300 seconds after receipt time"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn monitor_check_in_accepts_observed_at_at_future_skew_limit() -> Result<(), Box<dyn Error>> {
+        let mut input = check_in(MonitorCheckInStatus::Alive);
+        input.observed_at = "2026-05-28T20:05:00Z".to_owned();
+
+        let plan = plan_monitor_check_in(
+            monitor(HealthState::Unknown, MonitorMode::Ttl),
+            input,
+            context()?,
+        )?;
+
+        assert_eq!(
+            plan.commit.deadline_at.as_deref(),
+            Some("2026-05-28T20:07:05Z")
+        );
 
         Ok(())
     }

--- a/crates/canary-workers/src/health.rs
+++ b/crates/canary-workers/src/health.rs
@@ -672,15 +672,18 @@ mod tests {
 
     #[test]
     fn future_check_in_cannot_defer_an_overdue_alert() -> Result<(), Box<dyn Error>> {
-        // A monitor already past its deadline is overdue at `now`.
+        // Baseline: a monitor past its deadline is overdue at `now` — this is
+        // the alert a forged future check-in must not be able to defer.
         let overdue = overdue_monitor(HealthState::Up, Some("2026-05-28T19:59:59Z"), None);
         assert!(
-            plan_monitor_overdue(overdue.clone(), context()?)?.is_some(),
+            plan_monitor_overdue(overdue, context()?)?.is_some(),
             "monitor past its deadline must be overdue at now"
         );
 
         // A forged check-in an hour in the future would push the deadline far
-        // ahead if honored; it must be rejected, not allowed to defer the alert.
+        // ahead if honored. plan_monitor_check_in runs the skew guard before it
+        // computes deadline_at, so the check-in is rejected before any deadline
+        // is produced — the overdue alert can never be deferred.
         let mut forged = check_in(MonitorCheckInStatus::Alive);
         forged.observed_at = "2026-05-28T21:00:00Z".to_owned();
         let Err(error) = plan_monitor_check_in(
@@ -693,12 +696,6 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "monitor observed_at cannot be more than 300 seconds after receipt time"
-        );
-
-        // The rejected check-in cannot move the deadline, so the alert fires.
-        assert!(
-            plan_monitor_overdue(overdue, context()?)?.is_some(),
-            "a rejected future check-in must not defer the overdue alert"
         );
 
         Ok(())
@@ -721,7 +718,7 @@ mod tests {
             broken,
         );
         assert!(
-            rejected.is_err(),
+            matches!(rejected, Err(HealthPlanError::InvalidObservedAt(_))),
             "an unparseable receipt clock must reject the check-in, not skip the skew guard"
         );
 

--- a/crates/canary-workers/src/health.rs
+++ b/crates/canary-workers/src/health.rs
@@ -411,13 +411,18 @@ fn parse_observed_at(value: &str) -> Result<OffsetDateTime, HealthPlanError> {
         .map_err(|_| HealthPlanError::InvalidObservedAt(value.to_owned()))
 }
 
+/// Reject a check-in whose `observed_at` is implausibly far in the future
+/// relative to server receipt time, so a forged future timestamp cannot defer
+/// an overdue alert beyond the allowed skew.
+///
+/// `receipt_time` is `ObservationContext::now` (server-generated RFC 3339). An
+/// unparseable receipt clock fails closed: the check-in is rejected rather than
+/// silently skipping the skew guard.
 fn reject_observed_at_after_receipt(
     observed_at: OffsetDateTime,
     receipt_time: &str,
 ) -> Result<(), HealthPlanError> {
-    let Some(receipt_time) = parse_monitor_timestamp("now", receipt_time) else {
-        return Ok(());
-    };
+    let receipt_time = parse_observed_at(receipt_time)?;
     if observed_at - receipt_time > Duration::seconds(MAX_MONITOR_OBSERVED_AT_FUTURE_SKEW_SECONDS) {
         return Err(HealthPlanError::ObservedAtTooFarInFuture);
     }
@@ -660,6 +665,64 @@ mod tests {
         assert_eq!(
             plan.commit.deadline_at.as_deref(),
             Some("2026-05-28T20:07:05Z")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn future_check_in_cannot_defer_an_overdue_alert() -> Result<(), Box<dyn Error>> {
+        // A monitor already past its deadline is overdue at `now`.
+        let overdue = overdue_monitor(HealthState::Up, Some("2026-05-28T19:59:59Z"), None);
+        assert!(
+            plan_monitor_overdue(overdue.clone(), context()?)?.is_some(),
+            "monitor past its deadline must be overdue at now"
+        );
+
+        // A forged check-in an hour in the future would push the deadline far
+        // ahead if honored; it must be rejected, not allowed to defer the alert.
+        let mut forged = check_in(MonitorCheckInStatus::Alive);
+        forged.observed_at = "2026-05-28T21:00:00Z".to_owned();
+        let Err(error) = plan_monitor_check_in(
+            monitor(HealthState::Up, MonitorMode::Ttl),
+            forged,
+            context()?,
+        ) else {
+            return Err("future check-in must be rejected, not deferred".into());
+        };
+        assert_eq!(
+            error.to_string(),
+            "monitor observed_at cannot be more than 300 seconds after receipt time"
+        );
+
+        // The rejected check-in cannot move the deadline, so the alert fires.
+        assert!(
+            plan_monitor_overdue(overdue, context()?)?.is_some(),
+            "a rejected future check-in must not defer the overdue alert"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn monitor_check_in_rejects_unparseable_receipt_clock() -> Result<(), Box<dyn Error>> {
+        // The future-skew guard depends on a valid server receipt clock; an
+        // unparseable `now` must fail closed (reject), never silently skip the
+        // guard and accept a forgeable future observed_at.
+        let mut broken = context()?;
+        broken.now = "not-a-timestamp".to_owned();
+
+        let mut input = check_in(MonitorCheckInStatus::Alive);
+        input.observed_at = "2026-05-28T20:05:00Z".to_owned();
+
+        let rejected = plan_monitor_check_in(
+            monitor(HealthState::Unknown, MonitorMode::Ttl),
+            input,
+            broken,
+        );
+        assert!(
+            rejected.is_err(),
+            "an unparseable receipt clock must reject the check-in, not skip the skew guard"
         );
 
         Ok(())

--- a/dagger/scripts/sync_source_arguments.py
+++ b/dagger/scripts/sync_source_arguments.py
@@ -36,6 +36,7 @@ FUNCTION_POLICIES = {
     "typescriptQuality": "without_git",
     "rustQuality": "without_git",
     "productionImageSmoke": "without_git",
+    "productionImageAlertPlaneRehearsal": "without_git",
     "rustAdvisories": "without_git",
     "secrets": "with_git",
     "secretsHistory": "with_git",

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -426,6 +426,103 @@ jq -e '
 `
   }
 
+  private alertPlaneImpairmentRehearsalScript(): string {
+    return `
+prefix="dagger-alert-plane-$(date -u +%Y%m%d%H%M%S)-$$"
+monitor="canary-alert-plane-$prefix"
+observed_at="$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
+
+monitor_payload="$(
+  jq -cn \
+    --arg name "$monitor" \
+    '{
+      name: $name,
+      service: "canary",
+      mode: "ttl",
+      expected_every_ms: 1000,
+      grace_ms: 0
+    }'
+)"
+curl --fail --silent --show-error \
+  -X POST "$CANARY_ENDPOINT/api/v1/monitors" \
+  -H "Authorization: Bearer $CANARY_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data "$monitor_payload" >/tmp/canary-alert-plane-monitor.json
+
+check_in_payload="$(
+  jq -cn \
+    --arg monitor "$monitor" \
+    --arg observed_at "$observed_at" \
+    '{
+      monitor: $monitor,
+      status: "alive",
+      observed_at: $observed_at,
+      ttl_ms: 1000,
+      summary: "Dagger production-image alert-plane impairment rehearsal"
+    }'
+)"
+curl --fail --silent --show-error \
+  -X POST "$CANARY_ENDPOINT/api/v1/check-ins" \
+  -H "Authorization: Bearer $CANARY_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data "$check_in_payload" >/tmp/canary-alert-plane-check-in.json
+
+for attempt in $(seq 1 30); do
+  bin/canary doctor --json >/tmp/canary-alert-plane-doctor.json
+  if jq -e '
+    .response.reachability.readyz.ok == true
+    and .response.reachability.readyz.http_status == 200
+    and .response.reachability.readyz.response.status == "ready"
+    and .response.worker_readiness.status == "ready"
+    and .response.worker_readiness.pressured_workers >= 1
+    and .response.alert_plane.status == "impaired"
+    and (.response.alert_plane.reasons | index("monitor_overdue pressured") != null)
+    and any(.response.alert_plane.workers[]?;
+      .name == "monitor_overdue"
+      and .health == "pressured"
+      and ((.oldest_due_age_ms // 0) > 120000))
+    and any(.response.verdict.blocking_signals[]?;
+      startswith("alert-plane impaired:"))
+  ' /tmp/canary-alert-plane-doctor.json >/dev/null; then
+    set +e
+    bin/canary-witness \
+      --endpoint "$CANARY_ENDPOINT" \
+      --read-api-key "$CANARY_API_KEY" \
+      --ingest-api-key "$CANARY_API_KEY" \
+      --receipt /tmp/canary-alert-plane-witness.json \
+      --require-check-in \
+      --json >/tmp/canary-alert-plane-witness.out
+    witness_status=$?
+    set -e
+    test "$witness_status" != "0"
+    jq -e '
+      .status == "degraded"
+      and .alert_plane.status == "impaired"
+      and (.alert_plane.reasons | index("monitor_overdue pressured") != null)
+      and .check_in.skipped == true
+    ' /tmp/canary-alert-plane-witness.json >/dev/null
+    jq '{
+      route_ready: .response.reachability.readyz.response.status,
+      alert_plane: .response.alert_plane,
+      verdict: .response.verdict.overall
+    }' /tmp/canary-alert-plane-doctor.json
+    jq '{
+      status: .status,
+      alert_plane: .alert_plane,
+      check_in: .check_in
+    }' /tmp/canary-alert-plane-witness.json
+    exit 0
+  fi
+  sleep 1
+done
+
+cat /tmp/canary-alert-plane-doctor.json 2>/dev/null || true
+cat /tmp/canary-alert-plane-witness.out 2>/dev/null || true
+curl --silent --show-error "$CANARY_ENDPOINT/readyz" || true
+exit 1
+`
+  }
+
   private async productionImageNodeSmokeContainer(
     source: Directory,
     service: Service,
@@ -466,11 +563,27 @@ jq -e '
       .withExec(["bash", "-ceu", this.doctorAndMcpSmokeScript()])
   }
 
+  private async productionImageAlertPlaneRehearsalContainer(
+    source: Directory,
+    service: Service,
+    adminKey: Secret,
+  ): Promise<Container> {
+    return (await rustContainer(source))
+      .withExec(["apt-get", "update", "-q"])
+      .withExec(["apt-get", "install", "-yq", "--no-install-recommends", "curl", "jq"])
+      .withServiceBinding("canary", service)
+      .withSecretVariable("CANARY_API_KEY", adminKey)
+      .withEnvVariable("CANARY_ENDPOINT", "http://canary:4000")
+      .withExec(["bash", "-ceu", this.readinessProbeScript()])
+      .withExec(["bash", "-ceu", this.alertPlaneImpairmentRehearsalScript()])
+  }
+
   private async productionImageIntegration(source: Directory): Promise<void> {
     const { service, adminKey } = await this.productionImageService(source)
 
     await (await this.productionImageNodeSmokeContainer(source, service, adminKey)).sync()
     await (await this.productionImageDoctorSmokeContainer(source, service, adminKey)).sync()
+    await (await this.productionImageAlertPlaneRehearsalContainer(source, service, adminKey)).sync()
   }
 
   @func()
@@ -704,6 +817,29 @@ jq -e '
     source?: Directory,
   ): Promise<void> {
     await this.productionImageIntegration(source!)
+  }
+
+  @func()
+  async productionImageAlertPlaneRehearsal(
+    @argument({
+      defaultPath: "/",
+      ignore: [
+        ".git",
+        "_build",
+        "deps",
+        "cover",
+        "clients/typescript/node_modules",
+        "clients/typescript/dist",
+        "clients/typescript/coverage",
+        "dagger/node_modules",
+        "target",
+      ],
+    })
+    source?: Directory,
+  ): Promise<void> {
+    const { service, adminKey } = await this.productionImageService(source!)
+
+    await (await this.productionImageAlertPlaneRehearsalContainer(source!, service, adminKey)).sync()
   }
 
   @func()

--- a/docs/architecture/canary-alert-plane-047-completion-plan-2026-06-20.html
+++ b/docs/architecture/canary-alert-plane-047-completion-plan-2026-06-20.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en" data-ae-mode="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Canary 047 Completion Plan</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=Geist+Mono:wght@100..900&amp;display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v2.5.1/aesthetic.css">
+  <style>
+    :root { --ae-accent: #1f6f64; --ae-accent-dark: #7bd0c4; }
+    .plan-wide .ae-bar, .plan-wide .ae-stage { width: min(92rem, 100% - 4rem); }
+    .hero { display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(24em, 0.72fr); gap: 3em; align-items: end; }
+    .grid-2, .grid-3, .grid-4 { display: grid; gap: 1px; background: var(--ae-line); }
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .cell { min-width: 0; background: var(--ae-surface); padding: 1.2em 1.35em; }
+    .wash { background: var(--ae-wash); }
+    .rule { border-top: 1px solid var(--ae-line); margin: 1.3em 0; }
+    .phase { display: grid; grid-template-columns: 8em minmax(0, 1fr) minmax(15em, 0.7fr); gap: 1.2em; border-top: 1px solid var(--ae-line); padding-top: 1em; margin-top: 1em; }
+    .phase:first-child { border-top: 0; margin-top: 0; padding-top: 0; }
+    .table-wrap { overflow-x: auto; }
+    @media (max-width: 980px) {
+      .plan-wide .ae-bar, .plan-wide .ae-stage { width: min(100% - 2rem, 92rem); }
+      .hero, .grid-2, .grid-3, .grid-4, .phase { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+<div class="ae-screen plan-wide">
+  <header class="ae-bar">
+    <a class="ae-name" href="../../backlog.d/047-alert-plane-slo-burn-rate.md">BACKLOG 047 / COMPLETION</a>
+    <p class="ae-chrome">plan for the remaining alert-plane reliability slice</p>
+  </header>
+
+  <main class="ae-stage ae-stage-scroll">
+    <article class="ae-view">
+      <section class="hero" aria-label="Plan contract">
+        <div>
+          <p class="ae-chrome">P0 ALERTABILITY TRUST</p>
+          <h1 class="ae-strong">Future check-ins cannot hide overdue monitor alerts, and alert-plane impairment has a production-image proof.</h1>
+          <p class="ae-lede">Complete the rest of #047 without widening the product surface prematurely. First add an explicit future timestamp skew policy at the monitor check-in boundary, then wire a production-image induced impairment rehearsal, then add only the minimal SLO and burn-rate surfaces needed by agents.</p>
+        </div>
+        <aside class="ae-panel">
+          <h2 class="ae-h">CHOSEN DESIGN</h2>
+          <p>Reject monitor check-ins whose <code>observed_at</code> is more than five minutes ahead of receipt time. Do not clamp silently.</p>
+          <p>Keep deadline math in <code>canary-workers::health</code>; keep RFC 9457 HTTP shape in <code>ingest_routes</code>; keep SQLite as a commit ledger, not a policy engine.</p>
+          <div class="rule"></div>
+          <h2 class="ae-h">QUALITY SYSTEM</h2>
+          <p>Risk tier: substantive. Proof requires focused Rust tests, route-level Problem Details tests, production-image rehearsal, live doctor readback, and a fresh artifact-only critic.</p>
+          <p class="ae-dim">Plan status: added before the remaining 047 edits; preserve the earlier first-slice plan as historical evidence.</p>
+        </aside>
+      </section>
+
+      <section class="grid-4" aria-label="Executive contract" style="margin-top: 2em">
+        <article class="cell">
+          <h2 class="ae-h">STANDARDS</h2>
+          <p>Canonical Rust layer, deterministic Problem Details, no hidden write pools, no readiness semantic drift, no LLM path.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">ACCEPTANCE</h2>
+          <p>Future check-ins beyond skew fail and do not write; induced impairment fails doctor or witness while <code>/readyz</code> stays route-ready.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">VERIFY</h2>
+          <p>Focused tests first, <code>./bin/validate --fast</code> per milestone, <code>./bin/validate --strict</code> before PR, then CI, deploy, and live proof after squash merge.</p>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">STOP IF</h2>
+          <p>A step needs new auth scopes, persistent SLO schema ambiguity, altered <code>/readyz</code> semantics, or an unprovable production rehearsal.</p>
+        </article>
+      </section>
+
+      <section class="grid-3" aria-label="Current state" style="margin-top: 1px">
+        <article class="cell">
+          <h2 class="ae-h">CURRENT STATE</h2>
+          <p>PR #167 exposed <code>alert_plane</code> in doctor and witness. Remaining #047 work still allows far-future <code>observed_at</code> values to push monitor deadlines forward.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">CHANGE SHAPE</h2>
+          <p>Small pure policy in worker planning, route error mapping, OpenAPI guidance, and regression tests. Later milestones add Dagger rehearsal and SLO/burn-rate read models.</p>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">PROOF SURFACE</h2>
+          <p>Planner test proves deadline policy. Route test proves RFC 9457 body and no write. Dagger rehearsal proves production image catches alert-plane impairment.</p>
+        </article>
+      </section>
+
+      <section class="grid-2" aria-label="Scope and anchors" style="margin-top: 2em">
+        <article class="cell">
+          <h2 class="ae-h">SCOPE</h2>
+          <p><strong>Goal:</strong> make agent-facing alertability claims resistant to stale or future-dated monitor data.</p>
+          <p><strong>Non-goals:</strong> dashboard work, distributed tracing, per-customer SLO custom policy, responder mutation, and changing deploy readiness.</p>
+          <p><strong>Policy:</strong> accept clock skew up to five minutes; reject anything beyond it with structured validation.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">REPO ANCHORS</h2>
+          <p><a href="../../crates/canary-workers/src/health.rs">crates/canary-workers/src/health.rs</a> - monitor deadline and skew planning.</p>
+          <p><a href="../../crates/canary-server/src/ingest_routes.rs">crates/canary-server/src/ingest_routes.rs</a> - HTTP boundary and Problem Details mapping.</p>
+          <p><a href="../../crates/canary-server/src/lib.rs">crates/canary-server/src/lib.rs</a> - route regression tests.</p>
+          <p><a href="../../dagger/src/index.ts">dagger/src/index.ts</a> - strict and production-image rehearsals.</p>
+          <p><a href="../../priv/openapi/openapi.json">priv/openapi/openapi.json</a> - agent-facing contract.</p>
+        </article>
+      </section>
+
+      <section class="ae-panel" aria-label="Execution plan" style="margin-top: 2em">
+        <h2 class="ae-h">EXECUTION PLAN</h2>
+        <div class="phase">
+          <strong class="ae-accent">1 skew</strong>
+          <p>Add failing planner and route tests for far-future <code>observed_at</code>. Implement the five-minute policy and RFC 9457 mapping.</p>
+          <p class="ae-dim">Evidence: focused <code>canary-workers</code> and <code>canary-server</code> tests fail red, then pass green.</p>
+        </div>
+        <div class="phase">
+          <strong class="ae-accent">2 rehearse</strong>
+          <p>Wire a production-image induced impairment command into strict or a dedicated ops lane without weakening existing gates.</p>
+          <p class="ae-dim">Evidence: production image remains route-ready while doctor or witness returns impaired.</p>
+        </div>
+        <div class="phase">
+          <strong class="ae-accent">3 SLO</strong>
+          <p>Add coarse service SLO configuration and deterministic windowed SLI read models only after the impairment oracle is real.</p>
+          <p class="ae-dim">Evidence: report, CLI, and API fixtures expose service windows and budget state.</p>
+        </div>
+        <div class="phase">
+          <strong class="ae-accent">4 land</strong>
+          <p>Run fast and strict gates, live doctor, fresh-context review, thermo maintainability pass, PR, CI, deploy, live proof, then squash merge to <code>master</code>.</p>
+          <p class="ae-dim">Evidence: PR receipt plus ledger entry with merge commit and post-merge checks.</p>
+        </div>
+      </section>
+
+      <section class="grid-2" aria-label="Alternatives and risks" style="margin-top: 2em">
+        <article class="cell">
+          <h2 class="ae-h">ALTERNATIVES</h2>
+          <div class="table-wrap">
+            <table class="ae-table">
+              <thead><tr><th>option</th><th>why</th><th>verdict</th></tr></thead>
+              <tbody>
+                <tr><td class="ae-item">Reject future timestamps beyond five minutes</td><td>Auditable, simple, trust-boundary explicit.</td><td>choose</td></tr>
+                <tr><td class="ae-item">Clamp to receipt time</td><td>Keeps writes flowing.</td><td>reject: hides caller clock bugs and rewrites event time.</td></tr>
+                <tr><td class="ae-item">Store-level rejection</td><td>Hard backstop.</td><td>defer: policy belongs before commit planning and needs HTTP context.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">REVIEW FOCUS</h2>
+          <p>Can a future check-in still defer overdue alerts? Does the error response stay RFC 9457 and agent-readable? Did the production-image rehearsal actually exercise the changed alert-plane path? Did any new SLO surface add shallow abstractions before the proof loop exists?</p>
+        </article>
+      </section>
+    </article>
+  </main>
+
+  <footer class="ae-bar">
+    <p class="ae-foot">Canary #047 completion. Each backlog item lands through its own squash-merged PR before the next item starts.</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/architecture/canary-alert-plane-evidence-2026-06-20.md
+++ b/docs/architecture/canary-alert-plane-evidence-2026-06-20.md
@@ -131,6 +131,81 @@ Result:
 }
 ```
 
+## Production-Image Rehearsal
+
+Command:
+
+```bash
+PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" ./bin/dagger call production-image-alert-plane-rehearsal
+```
+
+Red result before the Dagger entrypoint existed:
+
+```text
+unknown command "production-image-alert-plane-rehearsal" for "dagger call"
+```
+
+Green result after wiring the rehearsal:
+
+```json
+{
+  "route_ready": "ready",
+  "alert_plane": {
+    "available": true,
+    "impaired_workers": 1,
+    "reasons": ["monitor_overdue pressured"],
+    "status": "impaired",
+    "worker_count": 5,
+    "workers": [
+      {
+        "name": "monitor_overdue",
+        "state": "started",
+        "health": "pressured",
+        "due_count": 1,
+        "oldest_due_age_ms": 620818,
+        "reason": "monitor_overdue pressured"
+      }
+    ]
+  },
+  "verdict": "degraded"
+}
+```
+
+The same Dagger run also executed `bin/canary-witness` against the production
+image service. The witness exited nonzero and recorded:
+
+```json
+{
+  "status": "degraded",
+  "alert_plane": {
+    "status": "impaired",
+    "reasons": ["monitor_overdue pressured"]
+  },
+  "check_in": {
+    "skipped": true,
+    "error": "self signals were not healthy"
+  }
+}
+```
+
+The rehearsal uses the disposable production-image smoke database. It creates a
+unique TTL monitor through the admin API, writes one backdated check-in through
+the ingest API, waits for the real `monitor_overdue` worker to observe the
+overdue deadline, then requires both doctor and witness to degrade while
+`/readyz` remains route-ready.
+
+Integrated production-image smoke:
+
+```bash
+PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" ./bin/dagger call production-image-smoke
+```
+
+Result: passed. The integrated smoke ran the existing SDK write/readback,
+write-path rehearsal, doctor/MCP smoke, and the new production-image
+alert-plane rehearsal. The final rehearsal summary reported
+`route_ready: "ready"`, `alert_plane.status: "impaired"`,
+`monitor_overdue.health: "pressured"`, and witness `status: "degraded"`.
+
 ## Validation
 
 Focused commands:
@@ -140,13 +215,14 @@ cargo fmt --all --check
 git diff --check
 cargo test -p canary-cli --locked
 bash -n bin/canary-witness && bash test/bin/canary_witness_test.sh
+env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" ./bin/dagger call production-image-alert-plane-rehearsal
 env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" bash ./bin/validate --fast
 ```
 
 Result: all passed. The fast gate includes the Debian `jq` 1.6 witness lane,
 which caught and verified the portable alert-plane JSON expression.
 
-Strict gate:
+Earlier first-slice strict gate:
 
 ```bash
 env PATH="/tmp/canary-dagger-0.20.5.OgaFYN:$PATH" bash ./bin/validate --strict
@@ -162,8 +238,12 @@ The final strict run used the repo-pinned Dagger `v0.20.5` binary after removing
 a stale `v0.21.6` engine that had blocked the earlier default `dagger check`
 wrapper.
 
+The full branch strict gate still runs before the #047 PR and squash merge. The
+current production-image rehearsal is already wired into `productionImageSmoke`,
+which strict reaches through `deterministic`.
+
 ## Remaining #047 Scope
 
 This does not implement SLO configuration, multi-window burn-rate summaries, or
-the monitor future-timestamp skew policy. Those remain children of #047 after
-the alert-plane impairment oracle.
+the report/CLI/MCP burn-rate surfaces. Those remain children of #047 after the
+alert-plane impairment oracle and timestamp skew policy.

--- a/docs/architecture/rust-rewrite.md
+++ b/docs/architecture/rust-rewrite.md
@@ -611,9 +611,12 @@ the Rust server accepts production traffic:
     active window-wide error groups, recent target/monitor transitions,
     windowed service SLI aggregates for targets, monitors, errors, and
     incidents, and FTS error search with the same quoted-query and BM25
-    weighting as Phoenix. Service SLI rows are a compact whole-window
-    per-service snapshot scoped by auth/window/service binding; report cursors
-    advance repeated detail sections, not this summary section.
+    weighting as Phoenix. Service SLI rows include deterministic default SLO
+    class metadata (`standard` for services with a configured health surface,
+    `best_effort` for signal-only services) but not budget burn or alert
+    severity yet. They are a compact whole-window per-service snapshot scoped
+    by auth/window/service binding; report cursors advance repeated detail
+    sections, not this summary section.
     The server owns read-scope auth, query-shape validation, positive-integer
     limit parsing, CSV content negotiation, section pagination, RFC 9457
     projection for invalid window/limit/cursor/query inputs, and the final

--- a/docs/architecture/rust-rewrite.md
+++ b/docs/architecture/rust-rewrite.md
@@ -608,8 +608,12 @@ the Rust server accepts production traffic:
     offset cursor: base64url JSON carrying independent target, monitor, and
     error-group offsets where `null` means that section is exhausted. The store
     owns the report read models that were missing from earlier slices:
-    active window-wide error groups, recent target/monitor transitions, and
-    FTS error search with the same quoted-query and BM25 weighting as Phoenix.
+    active window-wide error groups, recent target/monitor transitions,
+    windowed service SLI aggregates for targets, monitors, errors, and
+    incidents, and FTS error search with the same quoted-query and BM25
+    weighting as Phoenix. Service SLI rows are a compact whole-window
+    per-service snapshot scoped by auth/window/service binding; report cursors
+    advance repeated detail sections, not this summary section.
     The server owns read-scope auth, query-shape validation, positive-integer
     limit parsing, CSV content negotiation, section pagination, RFC 9457
     projection for invalid window/limit/cursor/query inputs, and the final
@@ -893,8 +897,9 @@ the Rust server accepts production traffic:
     owns `GET /api/v1/report`, including read-scope enforcement, `q` array
     rejection, default `1h` window, invalid-window mapping, report limit/cursor
     validation, store fan-in, independent target/monitor/error-group
-    pagination, report body assembly, optional search results, CSV content
-    negotiation, and CSV row shaping. `ingest_router` still owns the route
+    pagination, whole-window service SLI inclusion, report body assembly,
+    optional search results, CSV content negotiation, and CSV row shaping.
+    `ingest_router` still owns the route
     string. Cursor encoding remains in `canary-core`, Problem Details factories
     remain in `canary-http`, report read models remain in `canary-store`, and
     canonical health projections remain in `health_routes` so report does not

--- a/docs/non-http-health-semantics.md
+++ b/docs/non-http-health-semantics.md
@@ -109,6 +109,11 @@ Supported statuses:
 `check_in_id` is optional but recommended when a client wants Canary to match a
 specific `in_progress` signal with a later `ok` or `error`.
 
+`observed_at` is optional and should be the runtime's actual observation time.
+Canary rejects values more than five minutes in the future relative to receipt
+time so a bad agent or host clock cannot push the monitor's overdue deadline
+far enough forward to hide a missed heartbeat.
+
 ### Monitor Modes
 
 Use one API with two server-side monitor modes:

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -5038,6 +5038,173 @@
           }
         }
       },
+      "ServiceSliSummary": {
+        "type": "object",
+        "description": "Per-service whole-window SLI summary returned in report.service_sli. This section is scoped by auth, window, and any API-key service binding; it is not advanced by report.cursor.",
+        "additionalProperties": false,
+        "required": [
+          "service",
+          "window",
+          "targets",
+          "monitors",
+          "errors",
+          "incidents"
+        ],
+        "properties": {
+          "service": {
+            "type": "string",
+            "description": "Service name used to join target, monitor, error, and incident signals."
+          },
+          "window": {
+            "type": "string",
+            "description": "Query window used for windowed counts and ratios.",
+            "enum": [
+              "1h",
+              "6h",
+              "24h",
+              "7d",
+              "30d"
+            ]
+          },
+          "targets": {
+            "$ref": "#/components/schemas/TargetSliSummary"
+          },
+          "monitors": {
+            "$ref": "#/components/schemas/MonitorSliSummary"
+          },
+          "errors": {
+            "$ref": "#/components/schemas/ErrorSliSummary"
+          },
+          "incidents": {
+            "$ref": "#/components/schemas/IncidentSliSummary"
+          }
+        }
+      },
+      "TargetSliSummary": {
+        "type": "object",
+        "description": "HTTP target SLI aggregate for one service in the selected report window.",
+        "additionalProperties": false,
+        "required": [
+          "configured",
+          "checks",
+          "successful_checks",
+          "failed_checks",
+          "availability_ratio",
+          "latency_ms_average"
+        ],
+        "properties": {
+          "configured": {
+            "type": "integer",
+            "description": "Configured HTTP target count for this service."
+          },
+          "checks": {
+            "type": "integer",
+            "description": "Target checks observed inside the selected window."
+          },
+          "successful_checks": {
+            "type": "integer",
+            "description": "Target checks whose persisted result is success."
+          },
+          "failed_checks": {
+            "type": "integer",
+            "description": "Target checks whose persisted result is not success."
+          },
+          "availability_ratio": {
+            "description": "successful_checks divided by checks; null when checks is zero.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "latency_ms_average": {
+            "description": "Average target-check latency in milliseconds; null when no windowed check reported latency.",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        }
+      },
+      "MonitorSliSummary": {
+        "type": "object",
+        "description": "Non-HTTP monitor SLI aggregate for one service in the selected report window.",
+        "additionalProperties": false,
+        "required": [
+          "configured",
+          "check_ins",
+          "healthy_check_ins",
+          "failed_check_ins",
+          "availability_ratio"
+        ],
+        "properties": {
+          "configured": {
+            "type": "integer",
+            "description": "Configured monitor count for this service."
+          },
+          "check_ins": {
+            "type": "integer",
+            "description": "Monitor check-ins observed inside the selected window."
+          },
+          "healthy_check_ins": {
+            "type": "integer",
+            "description": "Check-ins that map to an up health state: alive, ok, or in_progress."
+          },
+          "failed_check_ins": {
+            "type": "integer",
+            "description": "Check-ins whose status is error."
+          },
+          "availability_ratio": {
+            "description": "healthy_check_ins divided by check_ins; null when check_ins is zero.",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        }
+      },
+      "ErrorSliSummary": {
+        "type": "object",
+        "description": "Error ingest aggregate for one service in the selected report window.",
+        "additionalProperties": false,
+        "required": [
+          "total",
+          "groups"
+        ],
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Error rows observed inside the selected window."
+          },
+          "groups": {
+            "type": "integer",
+            "description": "Distinct error groups observed inside the selected window."
+          }
+        }
+      },
+      "IncidentSliSummary": {
+        "type": "object",
+        "description": "Incident pressure aggregate for one service.",
+        "additionalProperties": false,
+        "required": [
+          "opened",
+          "resolved",
+          "active"
+        ],
+        "properties": {
+          "opened": {
+            "type": "integer",
+            "description": "Incidents opened inside the selected window."
+          },
+          "resolved": {
+            "description": "Incidents resolved inside the selected window.",
+            "type": "integer"
+          },
+          "active": {
+            "type": "integer",
+            "description": "Current unresolved incidents for this service, regardless of when they opened."
+          }
+        }
+      },
       "ReportResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -5046,6 +5213,7 @@
           "summary",
           "targets",
           "monitors",
+          "service_sli",
           "error_groups",
           "incidents",
           "recent_transitions",
@@ -5077,6 +5245,13 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/HealthMonitor"
+            }
+          },
+          "service_sli": {
+            "type": "array",
+            "description": "Compact per-service whole-window SLI summaries. This section is auth/window/service scoped and is not paginated by report.cursor.",
+            "items": {
+              "$ref": "#/components/schemas/ServiceSliSummary"
             }
           },
           "error_groups": {

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -2902,8 +2902,12 @@
             "type": "string"
           },
           "observed_at": {
-            "type": "string",
-            "format": "date-time"
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Optional runtime observation time. Canary rejects values more than 5 minutes in the future to prevent check-ins from deferring overdue alerts."
           },
           "ttl_ms": {
             "type": "integer",

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -5045,6 +5045,7 @@
         "required": [
           "service",
           "window",
+          "slo",
           "targets",
           "monitors",
           "errors",
@@ -5066,6 +5067,9 @@
               "30d"
             ]
           },
+          "slo": {
+            "$ref": "#/components/schemas/ServiceSloObjective"
+          },
           "targets": {
             "$ref": "#/components/schemas/TargetSliSummary"
           },
@@ -5077,6 +5081,48 @@
           },
           "incidents": {
             "$ref": "#/components/schemas/IncidentSliSummary"
+          }
+        }
+      },
+      "ServiceSloObjective": {
+        "type": "object",
+        "description": "Deterministic default SLO objective metadata for a service. This is class configuration only; budget burn and alert severity are computed by later read models.",
+        "additionalProperties": false,
+        "required": [
+          "class",
+          "source",
+          "availability_target",
+          "latency_ms_average_target",
+          "error_budget_events_per_hour"
+        ],
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "Default SLO class assigned by Canary.",
+            "enum": [
+              "standard",
+              "best_effort"
+            ]
+          },
+          "source": {
+            "type": "string",
+            "description": "Reason Canary assigned the default class.",
+            "enum": [
+              "default_health_surface",
+              "default_signal_only"
+            ]
+          },
+          "availability_target": {
+            "type": "number",
+            "description": "Default availability target as a ratio from 0.0 to 1.0."
+          },
+          "latency_ms_average_target": {
+            "type": "integer",
+            "description": "Default average latency target in milliseconds."
+          },
+          "error_budget_events_per_hour": {
+            "type": "integer",
+            "description": "Default allowed error events per hour before budget burn calculations consider the service over budget."
           }
         }
       },

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -5242,8 +5242,8 @@
             "description": "Incidents opened inside the selected window."
           },
           "resolved": {
-            "description": "Incidents resolved inside the selected window.",
-            "type": "integer"
+            "type": "integer",
+            "description": "Incidents resolved inside the selected window."
           },
           "active": {
             "type": "integer",


### PR DESCRIPTION
## Ticket 047 — Prove alert-plane health separately from route readiness

Ships children 2–5 of the XL ticket (child #1, the alert-plane-vs-readiness split, already on master). **Child #6 (burn-rate summaries + page-vs-ticket notification severity) remains**, so 047 stays open after this merge.

### What's in this PR
- **Monitor check-in skew safety** — a future `observed_at` beyond a 300s skew is rejected with RFC 9457; the guard fails closed on an unparseable receipt clock. A regression test proves a forged future check-in cannot defer an overdue alert.
- **Production-image alert-plane impairment rehearsal** — induces sustained worker pressure and asserts the external witness / `doctor` degrade with an alert-plane impairment reason *while `/readyz` stays route-ready*.
- **Windowed service SLI read models** — per-service availability / error / latency / incident aggregates over persisted observations, scoped by auth/window/service, exposed on `/api/v1/report`.
- **Default SLO class metadata** — deterministic `standard` / `best_effort` objectives attached to the SLI summaries (class config only; budget burn is child #6).
- **Hardening** — removed the dead unscoped `Store::service_sli` (auth-bypass footgun); bumped `quinn-proto` to 0.11.15 for RUSTSEC-2026-0185.

### Verification
- Full `dagger call strict` green: rust fmt / clippy `-D warnings` / test, TS client, operator shell tests, production Docker `/healthz`+`/readyz` smoke, and `cargo audit`.
- Two fresh-context thermo-nuclear review passes (4-lane, then 3-lane pre-merge re-review); all findings addressed.
- Schema is byte-identical to master — **no DB migration on deploy**; this is additive read-model + guard work only.

⚠️ Merging auto-deploys to `canary-obs` production via `deploy.yml` on green master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-service SLI summaries to the unified report response, including SLO details, target/monitor stats, error totals, and incident counts.
  * Added support for optional check-in observation timestamps and a clearer check-in payload shape.
  * Introduced deterministic default SLO classes for services and a new alert-plane impairment rehearsal step in CI.

* **Bug Fixes**
  * Rejected check-ins with `observed_at` timestamps too far in the future.
  * Improved report handling for service-scoped access and windowed summary data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->