### PR TITLE
chore(backlog): groom tickets 051-055

### DIFF
--- a/backlog.d/051-typescript-sdk-npm-publish.md
+++ b/backlog.d/051-typescript-sdk-npm-publish.md
@@ -1,0 +1,18 @@
+# Publish the TypeScript SDK (@canary-obs/sdk) to npm
+
+Priority: P1 · Status: pending · Estimate: S
+
+## Goal
+Make the documented `npm install @canary-obs/sdk` integration path actually work, so external consumers (e.g. Adminifi Habitat) can adopt the Next.js SDK without git/`file:` workarounds.
+
+## Why now
+Habitat-dogfooding surfaced this. `clients/typescript/INTEGRATION.md` instructs `npm install @canary-obs/sdk` (incl. the `@canary-obs/sdk/nextjs` subpath), but the package is **not published** — `npm view @canary-obs/sdk` returns 404 and no workflow runs `npm publish`. The SDK exists, is built (committed `dist/`), and is tested (`clients/typescript/test/nextjs.test.ts`), so this is a **release-pipeline gap, not a build gap**. Today an external consumer must POST the raw HTTP ingest contract (`/api/v1/errors`, `/api/v1/check-ins`) or vendor the SDK — friction that blocks the advertised onboarding.
+
+## Oracle
+- [ ] `npm view @canary-obs/sdk` resolves a published version, with the `@canary-obs/sdk/nextjs` subpath export intact.
+- [ ] A CI workflow publishes on tag/release (semver bump + provenance), gated on the existing TS test suite.
+- [ ] `INTEGRATION.md`'s `npm install` path works from a clean external project (Next.js).
+- [ ] The package leaves the `0.1.0` placeholder for a real release version.
+
+## Relationship to existing backlog
+Net-new — no existing item covers SDK release. Complements #049 (which ships the MCP wrapper + browser-capture helpers but does not address npm publication). Unblocks the polished integration path; the raw-HTTP fallback remains available regardless.

--- a/backlog.d/052-mcp-server.md
+++ b/backlog.d/052-mcp-server.md
@@ -1,0 +1,17 @@
+# Ship a runnable Canary MCP server
+
+Priority: P1 · Status: pending · Estimate: M
+
+## Goal
+Let an agent connect to Canary over MCP (not just shell out to the CLI or hit the HTTP read API), exposing the read + remediation-claims surface as MCP tools — so agent operators get first-class "what's erroring / claim this incident" access from their own MCP client.
+
+## Why now
+Habitat-dogfooding surfaced this. `canary mcp-manifest` emits a 15-tool manifest (`priv/mcp/canary-cli-tools.json`), but there is **no running MCP server** — agents currently shell out to the CLI or call the HTTP read API. For an agent-operated consumer (Habitat is run by the Olympus/Argus/Vulcan agents), MCP is the native control surface, and "is prod ok?" should be one tool call away.
+
+## Oracle
+- [ ] An installable MCP server wraps the CLI manifest; an MCP client lists the tools and invokes one read-only/no-op tool end to end.
+- [ ] Tool schemas stay **generated from the CLI** (no separate semantic API) — preserves the #036 invariant.
+- [ ] A smoke proof covers install + one tool invocation through the wrapper.
+
+## Relationship to existing backlog
+ELEVATES the MCP-wrapper requirement currently embedded as one P1 bullet inside #049 ("ship an installable MCP wrapper over the CLI manifest with a smoke proof"); #050's cold-agent readiness proof depends on it. Filed as a focused, standalone deliverable for discoverability — fold back into #049 if you'd rather keep it bundled.

--- a/backlog.d/053-human-alert-delivery.md
+++ b/backlog.d/053-human-alert-delivery.md
@@ -1,0 +1,22 @@
+# Human-facing alert delivery for real consumers (decision + optional bridge)
+
+Priority: P2 · Status: pending · Estimate: M
+
+## Goal
+Decide how human operators of a Canary-monitored service get woken up, and provide a reference path — WITHOUT violating Canary's "webhooks wake, they don't decide / no opinionated integrations in core" stance.
+
+## Why now
+Habitat-dogfooding surfaced this. Canary's only outbound channel is generic HMAC-signed webhooks — by design (see #030 non-goal "Add GitHub/Slack/PagerDuty or other opinionated integrations", #047 non-goal "human dashboard", and the "webhooks wake, they don't decide" principle). A real external consumer (Habitat) needs a human notification (Slack/email) when prod breaks, and today every consumer must build that bridge from scratch with no reference.
+
+## Decision to make
+1. **Keep core webhook-only** (consistent with current architecture) and ship a documented, OPTIONAL reference consumer bridge (webhook → Slack/email) that lives OUTSIDE canary core — so consumers don't reinvent it; OR
+2. **Revisit** the no-opinionated-integrations stance now that external consumers exist (heavier; risks scope creep into core and contradicts #030/#047).
+
+Recommendation: option 1 — preserve the boundary, lower the consumer's cost with a reference bridge + documented signed-webhook contract.
+
+## Oracle (if option 1)
+- [ ] A copy-pasteable webhook → {Slack | email} bridge example exists (small worker/function), kept out of canary core.
+- [ ] The signed-webhook contract + signature verification is documented for consumers.
+
+## Relationship to existing backlog
+Tensions DELIBERATELY with the #030 / #047 non-goals — filed as a DECISION item, not a commitment to build human integrations into core. The consumer-side need is also tracked on the Habitat side (HA-007 / HA-052: wire Canary's webhook → a thin human-alert path). Resolve the decision before either side builds.

--- a/backlog.d/054-serving-model-self-hosted.md
+++ b/backlog.d/054-serving-model-self-hosted.md
@@ -1,0 +1,43 @@
+# Serving model: self-hosted product, managed-hosting later, not multi-tenant SaaS
+
+Priority: P2 · Status: pending · Estimate: S
+
+## Goal
+Add an explicit "Serving Model" section to `VISION.md` that states, as a written
+contract rather than an inferred one, how Canary is served:
+1. **Self-hosted single-tenant binary is THE product** (and the competitive wedge).
+2. **Optional managed hosting** of that *same single-tenant binary*, one isolated
+   instance per customer, is a possible *later* offering (open-core / Plausible /
+   PostHog model) — convenience/revenue, not a re-architecture.
+3. **Multi-tenant SaaS is out by default** — a clustered store + tenant isolation
+   would forfeit the single-binary elegance and put Canary on the incumbents' turf.
+
+## Why now
+Surfaced onboarding the first external reference consumer (Adminifi Habitat), whose
+operator asked directly: "self-hosted, not SaaS — yeah?" The answer is yes, but today
+it has to be reverse-engineered from `fly.toml` + scattered doc lines. `VISION.md`
+states the *negative* ("Not multi-tenant SaaS by default", #79-80) and PRINCIPLES #7
+says "No multi-tenant support (internal tool)", but the *positive* serving model is
+implied, not declared. The architecture already commits to it — SQLite single-writer
+on one machine **is** single-tenant — so the doc should say so plainly. The
+competitive position (VISION: "does not try to out-feature the incumbents") depends on
+the self-hosted wedge being intentional, not incidental.
+
+## Scope / decision to record
+- self-hosted single-tenant binary = the product and the wedge.
+- managed hosting = run the SAME single-tenant binary per customer; a future
+  revenue/convenience path, NOT multi-tenant SaaS. Don't build it now; don't foreclose
+  it — PRINCIPLE #9 ("design for migration, don't build for it") already keeps the door
+  open.
+- multi-tenant SaaS = explicitly out by default; revisiting it is a deliberate,
+  security-reviewed decision gated by #039 (external-user security/privacy foundation).
+
+## Oracle
+- [ ] `VISION.md` has a "Serving Model" section stating the three-way distinction above.
+- [ ] It reconciles with "What Canary Is Not" (#79-80) and PRINCIPLES #2/#7 — cross-referenced, no contradiction.
+- [ ] A new reader can answer "self-hosted, managed-later, or SaaS?" from `VISION.md` alone, without reading `fly.toml` or the code.
+
+## Relationship to existing backlog
+Pure doc/positioning; no code impact. Complements #039 (external-user security/privacy
+foundation — the gate any hosted/multi-tenant productization must pass). Pairs with #055
+(both are doc-truth fixes surfaced by the Habitat dogfooding pass).

--- a/backlog.d/055-principles-rust-cutover-refresh.md
+++ b/backlog.d/055-principles-rust-cutover-refresh.md
@@ -1,0 +1,30 @@
+# Refresh PRINCIPLES.md examples to match the Rust + SQLite implementation (post-cutover)
+
+Priority: P3 · Status: pending · Estimate: S
+
+## Goal
+Update `PRINCIPLES.md` so its illustrative examples describe the current Rust + Axum +
+SQLite service, not the retired Elixir/Phoenix one. The nine principles' *intent* still
+holds; only the *examples* have drifted from reality and now mislead new contributors
+and agents reading the principles as ground truth.
+
+## Why now
+The Rust cutover shipped (`docs/architecture/rust-cutover-evidence-2026-06-06.md`), and
+`README.md` / `VISION.md` / Tech-Stack are already Rust+SQLite — but `PRINCIPLES.md` is
+the lone stale surface, still citing Elixir/OTP constructs:
+- **#5 Deep Modules** uses Elixir arity syntax: `Ingest.ingest/1`,
+  `StateMachine.transition/4`, `Grouping.compute_group_hash/1`.
+- **#8 Separation of Stateful and Stateless** references **GenServers + Oban**
+  (Elixir/OTP), not the Rust worker/runtime model.
+- **#9 Design for Migration** says "**Ecto** abstraction preserves the Postgres
+  migration path" — Ecto is Elixir; the Rust store is `canary-store` over SQLite (WAL,
+  one explicit writer boundary).
+
+## Oracle
+- [ ] `grep -niE "genserver|oban|ecto|\.(ingest|transition|compute_group_hash)/[0-9]" PRINCIPLES.md` returns nothing — or only inside an explicit "formerly, in the Elixir era" history note.
+- [ ] #5 / #8 / #9 examples reference real Rust modules/types (e.g. the `canary-store` single-writer boundary, the Rust worker model) — each verifiable against `crates/`.
+- [ ] The INTENT of all nine principles is unchanged; this is an examples refresh, not a principles rewrite.
+
+## Relationship to existing backlog
+Pure doc hygiene; follows the #032 live Rust write-path cutover. No runtime impact.
+Pairs with #054 (both are doc-truth fixes surfaced by the Habitat dogfooding pass).

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -48,6 +48,9 @@
 | 048 | Responder rich-context safety gate | P0 | pending | XL |
 | 049 | Integration evidence and capture gaps | P1 | pending | XL |
 | 050 | Cold-agent readiness proof | P1 | pending | M |
+| 051 | TypeScript SDK npm publish | P1 | pending | S |
+| 052 | Runnable MCP server | P1 | pending | M |
+| 053 | Human alert delivery (decision) | P2 | pending | M |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
 

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -51,6 +51,8 @@
 | 051 | TypeScript SDK npm publish | P1 | pending | S |
 | 052 | Runnable MCP server | P1 | pending | M |
 | 053 | Human alert delivery (decision) | P2 | pending | M |
+| 054 | Serving model: self-hosted, managed-later, not multi-tenant SaaS | P2 | pending | S |
+| 055 | Refresh PRINCIPLES.md examples to Rust+SQLite (post-cutover) | P3 | pending | S |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
 


### PR DESCRIPTION
## Backlog grooming — tickets 051–055

Pure docs/backlog; no code. Adds five groomed tickets surfaced by recent product and dogfooding work, and updates the priority map.

- **051** — Publish the TypeScript SDK (`@canary-obs/sdk`) to npm (P1/S)
- **052** — Ship a runnable Canary MCP server (P1/M)
- **053** — Human-facing alert delivery decision + optional bridge (P2/M)
- **054** — Serving model: self-hosted single-tenant binary is the product, managed hosting later, multi-tenant SaaS out by default (P2/S)
- **055** — Refresh `PRINCIPLES.md` examples from Elixir/Phoenix to Rust+SQLite, post-cutover (P3/S)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
