### PR TITLE
feat(report): add prior-window SLI trajectory (047 child #6)

### DIFF
--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -380,14 +380,63 @@ pub fn json_envelope(command: &str, endpoint: &str, response: Value) -> Value {
 
 /// Summarize a report response.
 pub fn summarize_report(value: &Value) -> Vec<String> {
-    vec![
+    let mut lines = vec![
         format!("summary: {}", string_field(value, "summary")),
         format!("status: {}", string_field(value, "status")),
         format!("targets: {}", array_len(value, "targets")),
         format!("monitors: {}", array_len(value, "monitors")),
         format!("incidents: {}", array_len(value, "incidents")),
         format!("error_groups: {}", array_len(value, "error_groups")),
-    ]
+    ];
+    if let Some(slis) = value.get("service_sli").and_then(Value::as_array) {
+        for sli in slis {
+            lines.extend(service_sli_lines(sli));
+        }
+    }
+    lines
+}
+
+/// Render one service SLI summary plus its prior-window trajectory.
+fn service_sli_lines(sli: &Value) -> Vec<String> {
+    let service = string_field(sli, "service");
+    let class = sli
+        .get("slo")
+        .map_or_else(|| "unknown".to_owned(), |slo| string_field(slo, "class"));
+    let mut lines = vec![format!(
+        "service {service}: slo={class} availability(targets)={} availability(monitors)={} errors={}",
+        ratio_text(sli.pointer("/targets/availability_ratio")),
+        ratio_text(sli.pointer("/monitors/availability_ratio")),
+        sli.pointer("/errors/total")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    )];
+    if let Some(trajectory) = sli.get("trajectory").filter(|value| !value.is_null()) {
+        lines.push(format!(
+            "service {service} trajectory: status={} availability_delta(targets)={} availability_delta(monitors)={} errors_delta={}",
+            string_field(trajectory, "status"),
+            signed_ratio_text(trajectory.pointer("/targets/availability_delta")),
+            signed_ratio_text(trajectory.pointer("/monitors/availability_delta")),
+            trajectory
+                .pointer("/errors/total_delta")
+                .and_then(Value::as_i64)
+                .map_or_else(|| "n/a".to_owned(), |delta| format!("{delta:+}")),
+        ));
+    }
+    lines
+}
+
+/// Format an availability ratio to three decimals, or `n/a` when null/absent.
+fn ratio_text(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_f64)
+        .map_or_else(|| "n/a".to_owned(), |ratio| format!("{ratio:.3}"))
+}
+
+/// Format a signed ratio delta to three decimals, or `n/a` when null/absent.
+fn signed_ratio_text(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_f64)
+        .map_or_else(|| "n/a".to_owned(), |delta| format!("{delta:+.3}"))
 }
 
 /// Summarize a status response as services.
@@ -4071,7 +4120,7 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
     vec![
         ToolSpec {
             name: "canary_summary",
-            description: "Inspect global Canary status for a query window.",
+            description: "Inspect global Canary status for a query window, including per-service SLIs, SLO targets, and prior-window trajectory deltas.",
             input_schema: json!({"type":"object","properties":{"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]}}}),
         },
         ToolSpec {

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -17,6 +17,11 @@ fn parses_report_fixture() -> Result<(), Box<dyn std::error::Error>> {
     let lines = summarize_report(&value);
     assert!(lines.iter().any(|line| line == "targets: 1"));
     assert!(lines.iter().any(|line| line == "error_groups: 1"));
+    // The SLI block is surfaced (no longer dropped), with the prior-window trajectory.
+    assert!(lines.iter().any(|line| line
+        == "service chrondle: slo=standard availability(targets)=0.950 availability(monitors)=n/a errors=7"));
+    assert!(lines.iter().any(|line| line
+        == "service chrondle trajectory: status=ok availability_delta(targets)=-0.040 availability_delta(monitors)=n/a errors_delta=+3"));
     Ok(())
 }
 

--- a/crates/canary-cli/tests/fixtures/report.json
+++ b/crates/canary-cli/tests/fixtures/report.json
@@ -5,6 +5,43 @@
   "monitors": [],
   "incidents": [{"id": "INC-1", "service": "chrondle"}],
   "error_groups": [{"group_hash": "abc", "service": "chrondle", "count": 7}],
+  "service_sli": [
+    {
+      "service": "chrondle",
+      "window": "24h",
+      "slo": {
+        "class": "standard",
+        "source": "default_health_surface",
+        "availability_target": 0.995,
+        "latency_ms_average_target": 1000,
+        "error_budget_events_per_hour": 5
+      },
+      "targets": {
+        "configured": 1,
+        "checks": 120,
+        "successful_checks": 114,
+        "failed_checks": 6,
+        "availability_ratio": 0.95,
+        "latency_ms_average": 80.0
+      },
+      "monitors": {
+        "configured": 0,
+        "check_ins": 0,
+        "healthy_check_ins": 0,
+        "failed_check_ins": 0,
+        "availability_ratio": null
+      },
+      "errors": {"total": 7, "groups": 1},
+      "incidents": {"opened": 1, "resolved": 0, "active": 1},
+      "trajectory": {
+        "status": "ok",
+        "sample_basis": 120,
+        "targets": {"availability_delta": -0.04, "prior_availability_ratio": 0.99},
+        "monitors": {"availability_delta": null, "prior_availability_ratio": null},
+        "errors": {"total_delta": 3, "prior_total": 4}
+      }
+    }
+  ],
   "recent_transitions": [],
   "cursor": null,
   "truncated": false

--- a/crates/canary-core/src/query.rs
+++ b/crates/canary-core/src/query.rs
@@ -95,17 +95,20 @@ impl QueryWindow {
         }
     }
 
-    /// Return the RFC3339 cutoff string for this window at `now`.
-    pub fn cutoff_at(self, now: OffsetDateTime) -> String {
-        let seconds = match self {
+    /// Return the window length in seconds.
+    pub const fn duration_seconds(self) -> i64 {
+        match self {
             Self::OneHour => 3_600,
             Self::SixHours => 21_600,
             Self::TwentyFourHours => 86_400,
             Self::SevenDays => 604_800,
             Self::ThirtyDays => 2_592_000,
-        };
+        }
+    }
 
-        (now - Duration::seconds(seconds))
+    /// Return the RFC3339 cutoff string for this window at `now`.
+    pub fn cutoff_at(self, now: OffsetDateTime) -> String {
+        (now - Duration::seconds(self.duration_seconds()))
             .format(&Rfc3339)
             .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
     }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -6627,6 +6627,12 @@ mod tests {
         assert_eq!(api["monitors"]["healthy_check_ins"], 1);
         assert_eq!(api["errors"]["total"], 1);
         assert_eq!(api["incidents"]["active"], 1);
+        // One sample per window is below the trajectory sample floor, so the
+        // availability delta is nulled while the exact error-count delta stands.
+        assert_eq!(api["trajectory"]["status"], "insufficient_samples");
+        assert!(api["trajectory"]["targets"]["availability_delta"].is_null());
+        assert_eq!(api["trajectory"]["errors"]["total_delta"], 1);
+        assert_eq!(api["trajectory"]["errors"]["prior_total"], 0);
 
         let bound = router
             .oneshot(read_request(read_key, "/api/v1/report?window=1h")?)

--- a/crates/canary-server/src/report_routes.rs
+++ b/crates/canary-server/src/report_routes.rs
@@ -18,7 +18,7 @@ use canary_http::problem_details::{
 };
 use canary_store::{
     IncidentListOptions, QueryError, RecentTransition, SearchResult, ServiceSliSummary,
-    TimelineQueryError, TimelineQueryOptions,
+    ServiceSliTrajectory, TimelineQueryError, TimelineQueryOptions,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -278,6 +278,26 @@ fn service_sli_response(summary: &ServiceSliSummary) -> Value {
             "opened": summary.incidents.opened,
             "resolved": summary.incidents.resolved,
             "active": summary.incidents.active,
+        },
+        "trajectory": summary.trajectory.as_ref().map(trajectory_response),
+    })
+}
+
+fn trajectory_response(trajectory: &ServiceSliTrajectory) -> Value {
+    json!({
+        "status": trajectory.status.as_str(),
+        "sample_basis": trajectory.sample_basis,
+        "targets": {
+            "availability_delta": trajectory.targets_availability_delta,
+            "prior_availability_ratio": trajectory.prior_targets_availability_ratio,
+        },
+        "monitors": {
+            "availability_delta": trajectory.monitors_availability_delta,
+            "prior_availability_ratio": trajectory.prior_monitors_availability_ratio,
+        },
+        "errors": {
+            "total_delta": trajectory.error_total_delta,
+            "prior_total": trajectory.prior_error_total,
         },
     })
 }

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -67,7 +67,9 @@ pub use retention::{
     RetentionPrune, RetentionPruneBatch, RetentionPruneBatchReport, RetentionPruneReport,
     RetentionPruneTable,
 };
-pub use service_sli::ServiceSliSummary;
+pub use service_sli::{
+    MIN_TRAJECTORY_SAMPLES, ServiceSliSummary, ServiceSliTrajectory, TrajectoryStatus,
+};
 pub use telemetry::{TelemetryEventError, TelemetryEventInsert, TelemetryEventResult};
 pub use webhook_deliveries::{
     WebhookDeliveryInsert, WebhookDeliveryListOptions, WebhookDeliveryPageError,
@@ -682,6 +684,16 @@ impl Store {
         now: time::OffsetDateTime,
     ) -> QueryResult<Vec<ServiceSliSummary>> {
         service_sli::service_sli_at(&self.connection, window, now)
+    }
+
+    /// Query windowed service SLI aggregates with prior-window trajectory at a
+    /// deterministic evaluation time.
+    pub fn service_sli_with_trajectory_at(
+        &self,
+        window: &str,
+        now: time::OffsetDateTime,
+    ) -> QueryResult<Vec<ServiceSliSummary>> {
+        service_sli::service_sli_with_trajectory_at(&self.connection, window, now)
     }
 
     /// Query active error groups for the unified report.

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -32,6 +32,74 @@ pub struct ServiceSliSummary {
     pub errors: ErrorSliSummary,
     /// Incident pressure signals.
     pub incidents: IncidentSliSummary,
+    /// Direction of travel vs the prior equal-length window, when computed.
+    ///
+    /// `None` on read models that do not compute trajectory (e.g. the
+    /// `service_sli_at` test helper); `Some` on the report path.
+    pub trajectory: Option<ServiceSliTrajectory>,
+}
+
+/// Minimum check / check-in count, in both the current and prior window, before
+/// an availability delta is trusted. Below this floor a single failed probe
+/// would dominate the ratio, so the delta is nulled and the trajectory is
+/// marked `InsufficientSamples`.
+///
+/// This is a deliberately coarse, fixed first-pass floor. A cadence-aware floor
+/// (scaled to each target's probe interval) is a tracked follow-up on ticket
+/// 047, not part of this slice.
+pub const MIN_TRAJECTORY_SAMPLES: u64 = 20;
+
+/// Whether a service's availability trajectory is backed by enough samples to
+/// trust.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrajectoryStatus {
+    /// At least one availability delta cleared the sample floor, or the service
+    /// has no health surface to distrust (error-only services).
+    Ok,
+    /// The service has a configured health surface but every availability
+    /// window was below `MIN_TRAJECTORY_SAMPLES`, so availability deltas are
+    /// null.
+    InsufficientSamples,
+}
+
+impl TrajectoryStatus {
+    /// Wire value for this status.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::InsufficientSamples => "insufficient_samples",
+        }
+    }
+}
+
+/// Signed change in a service's SLIs vs the immediately preceding equal-length
+/// window (this window minus the prior window).
+///
+/// A delta is evidence — a fact about two adjacent windows — never a burn-rate
+/// budget claim or an urgency verdict. Consumers decide what is urgent.
+/// Availability deltas are nulled below the sample floor (see
+/// [`MIN_TRAJECTORY_SAMPLES`]); the error-count delta is always exact.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ServiceSliTrajectory {
+    /// HTTP-target availability ratio change (current − prior). `None` when
+    /// either window is below the sample floor or has no target checks.
+    pub targets_availability_delta: Option<f64>,
+    /// Prior-window HTTP-target availability ratio, when computable.
+    pub prior_targets_availability_ratio: Option<f64>,
+    /// Non-HTTP monitor availability ratio change (current − prior). `None`
+    /// when either window is below the sample floor or has no check-ins.
+    pub monitors_availability_delta: Option<f64>,
+    /// Prior-window monitor availability ratio, when computable.
+    pub prior_monitors_availability_ratio: Option<f64>,
+    /// Error-row count change vs the prior window (signed; current − prior).
+    pub error_total_delta: i64,
+    /// Prior-window error-row count.
+    pub prior_error_total: u64,
+    /// Smallest current/prior count backing a computed availability delta; 0
+    /// when no availability delta cleared the floor.
+    pub sample_basis: u64,
+    /// Whether the availability deltas are trustworthy.
+    pub status: TrajectoryStatus,
 }
 
 /// HTTP-target SLI aggregate for one service.
@@ -92,7 +160,7 @@ pub(crate) fn service_sli_scoped(
     tenant_id: &str,
     project_id: &str,
 ) -> QueryResult<Vec<ServiceSliSummary>> {
-    service_sli_at_scoped(
+    service_sli_with_trajectory_at_scoped(
         connection,
         window,
         OffsetDateTime::now_utc(),
@@ -106,6 +174,136 @@ pub(crate) fn service_sli_at(
     now: OffsetDateTime,
 ) -> QueryResult<Vec<ServiceSliSummary>> {
     service_sli_at_scoped(connection, window, now, None)
+}
+
+pub(crate) fn service_sli_with_trajectory_at(
+    connection: &Connection,
+    window: &str,
+    now: OffsetDateTime,
+) -> QueryResult<Vec<ServiceSliSummary>> {
+    service_sli_with_trajectory_at_scoped(connection, window, now, None)
+}
+
+/// Compute current-window SLIs and attach a trajectory delta vs the prior
+/// equal-length window.
+///
+/// The base read model filters `>= cutoff` with no upper bound, so we derive
+/// the prior window `[now-2d, now-d)` by subtracting current-window additive
+/// counts from a double-width window `[now-2d, ∞)`. Because the current window
+/// is a subset of the double-width window, the subtraction is exactly the prior
+/// window and cancels any future-dated rows the skew policy permits.
+fn service_sli_with_trajectory_at_scoped(
+    connection: &Connection,
+    window: &str,
+    now: OffsetDateTime,
+    owner: Option<(&str, &str)>,
+) -> QueryResult<Vec<ServiceSliSummary>> {
+    let parsed = QueryWindow::parse(window).ok_or(QueryError::InvalidWindow)?;
+    let mut current = service_sli_at_scoped(connection, window, now, owner)?;
+
+    let prior_anchor = now - time::Duration::seconds(parsed.duration_seconds());
+    let double_width = service_sli_at_scoped(connection, window, prior_anchor, owner)?;
+    let double_by_service: BTreeMap<&str, &ServiceSliSummary> = double_width
+        .iter()
+        .map(|summary| (summary.service.as_str(), summary))
+        .collect();
+
+    for summary in &mut current {
+        let wide = double_by_service.get(summary.service.as_str()).copied();
+        summary.trajectory = Some(build_trajectory(summary, wide));
+    }
+
+    Ok(current)
+}
+
+/// Build a [`ServiceSliTrajectory`] from a current-window summary and the
+/// matching double-width (`[now-2d, ∞)`) summary. Prior-window counts are
+/// `double_width − current`.
+///
+/// INVARIANT: only ADDITIVE, cutoff-bounded fields may be subtracted this way —
+/// target/monitor check counts and `errors.total`. Do NOT extend this to
+/// non-additive aggregates: `errors.groups` is `COUNT(DISTINCT ...)`,
+/// `latency_ms_average` is an `AVG`, and `incidents.active` is a point-in-time
+/// gauge whose query has an unbounded `OR state != 'resolved'` branch. For any
+/// of those, `double_width − current` is silently wrong.
+fn build_trajectory(
+    current: &ServiceSliSummary,
+    double_width: Option<&ServiceSliSummary>,
+) -> ServiceSliTrajectory {
+    let (targets_availability_delta, prior_targets_availability_ratio, targets_basis) =
+        availability_delta(
+            current.targets.successful_checks,
+            current.targets.checks,
+            double_width.map_or(0, |wide| wide.targets.successful_checks),
+            double_width.map_or(0, |wide| wide.targets.checks),
+        );
+    let (monitors_availability_delta, prior_monitors_availability_ratio, monitors_basis) =
+        availability_delta(
+            current.monitors.healthy_check_ins,
+            current.monitors.check_ins,
+            double_width.map_or(0, |wide| wide.monitors.healthy_check_ins),
+            double_width.map_or(0, |wide| wide.monitors.check_ins),
+        );
+
+    let prior_error_total = double_width
+        .map_or(0, |wide| wide.errors.total)
+        .saturating_sub(current.errors.total);
+    let error_total_delta = current.errors.total as i64 - prior_error_total as i64;
+
+    let sample_basis = [targets_basis, monitors_basis]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(0);
+
+    let has_health_surface = current.targets.configured > 0 || current.monitors.configured > 0;
+    let any_availability =
+        targets_availability_delta.is_some() || monitors_availability_delta.is_some();
+    let status = if has_health_surface && !any_availability {
+        TrajectoryStatus::InsufficientSamples
+    } else {
+        TrajectoryStatus::Ok
+    };
+
+    ServiceSliTrajectory {
+        targets_availability_delta,
+        prior_targets_availability_ratio,
+        monitors_availability_delta,
+        prior_monitors_availability_ratio,
+        error_total_delta,
+        prior_error_total,
+        sample_basis,
+        status,
+    }
+}
+
+/// Compute the availability delta for one signal: `(delta, prior_ratio,
+/// sample_basis)`. Returns `(None, None, None)` when either window is below the
+/// sample floor (prior counts are `double_width − current`).
+fn availability_delta(
+    current_successful: u64,
+    current_total: u64,
+    double_successful: u64,
+    double_total: u64,
+) -> (Option<f64>, Option<f64>, Option<u64>) {
+    let prior_total = double_total.saturating_sub(current_total);
+    let prior_successful = double_successful.saturating_sub(current_successful);
+
+    if current_total < MIN_TRAJECTORY_SAMPLES || prior_total < MIN_TRAJECTORY_SAMPLES {
+        return (None, None, None);
+    }
+
+    match (
+        ratio(current_successful, current_total),
+        ratio(prior_successful, prior_total),
+    ) {
+        (Some(current_ratio), Some(prior_ratio)) => (
+            Some(current_ratio - prior_ratio),
+            Some(prior_ratio),
+            Some(current_total.min(prior_total)),
+        ),
+        _ => (None, None, None),
+    }
 }
 
 fn service_sli_at_scoped(
@@ -144,6 +342,7 @@ fn service_sli_entry<'a>(
             monitors: MonitorSliSummary::default(),
             errors: ErrorSliSummary::default(),
             incidents: IncidentSliSummary::default(),
+            trajectory: None,
         })
 }
 
@@ -627,6 +826,149 @@ mod tests {
             Err(QueryError::InvalidWindow)
         ));
 
+        Ok(())
+    }
+
+    fn insert_traj_target(store: &mut Store, id: &str, service: &str) -> crate::Result<()> {
+        store.insert_target(TargetInsert {
+            id: id.to_owned(),
+            url: format!("https://{service}.example.test/health"),
+            name: service.to_owned(),
+            service: service.to_owned(),
+            method: "GET".to_owned(),
+            headers: None,
+            interval_ms: 60_000,
+            timeout_ms: 10_000,
+            expected_status: "200".to_owned(),
+            body_contains: None,
+            degraded_after: 2,
+            down_after: 3,
+            up_after: 1,
+            active: true,
+            created_at: "2026-05-28T18:00:00Z".to_owned(),
+        })
+    }
+
+    fn insert_check(
+        store: &Store,
+        target_id: &str,
+        checked_at: &str,
+        result: &str,
+    ) -> crate::Result<()> {
+        store.connection.execute(
+            "INSERT INTO target_checks (target_id, checked_at, status_code, latency_ms, result)
+             VALUES (?1, ?2, 200, 50, ?3)",
+            params![target_id, checked_at, result],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn service_sli_trajectory_reports_availability_and_error_deltas()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        insert_traj_target(&mut store, "TGT-traj", "traj")?;
+
+        // Current window [20:00, 21:00): 30 checks, 27 success -> 0.9 availability.
+        for minute in 0..30 {
+            let result = if minute < 27 { "success" } else { "error" };
+            insert_check(
+                &store,
+                "TGT-traj",
+                &format!("2026-05-28T20:{minute:02}:00Z"),
+                result,
+            )?;
+        }
+        // Prior window [19:00, 20:00): 25 checks, all success -> 1.0 availability.
+        for minute in 0..25 {
+            insert_check(
+                &store,
+                "TGT-traj",
+                &format!("2026-05-28T19:{minute:02}:00Z"),
+                "success",
+            )?;
+        }
+        // Errors: 5 in the current window, 2 in the prior window.
+        for (idx, created_at) in [
+            "2026-05-28T20:05:00Z",
+            "2026-05-28T20:10:00Z",
+            "2026-05-28T20:15:00Z",
+            "2026-05-28T20:20:00Z",
+            "2026-05-28T20:25:00Z",
+            "2026-05-28T19:05:00Z",
+            "2026-05-28T19:10:00Z",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            store.connection.execute(
+                "INSERT INTO errors (id, service, error_class, message, group_hash, created_at)
+                 VALUES (?1, 'traj', 'RuntimeError', 'boom', ?2, ?3)",
+                params![
+                    format!("ERR-traj{idx:08}"),
+                    format!("group-traj-{idx}"),
+                    created_at
+                ],
+            )?;
+        }
+
+        let now = OffsetDateTime::parse("2026-05-28T21:00:00Z", &Rfc3339)?;
+        let summaries = store.service_sli_with_trajectory_at("1h", now)?;
+        let traj = summaries
+            .iter()
+            .find(|summary| summary.service == "traj")
+            .and_then(|summary| summary.trajectory)
+            .ok_or("missing traj trajectory")?;
+
+        assert_eq!(traj.status, TrajectoryStatus::Ok);
+        assert_ratio(traj.prior_targets_availability_ratio, 1.0);
+        let delta = traj
+            .targets_availability_delta
+            .ok_or("missing availability delta")?;
+        assert!(
+            (delta - (-0.1)).abs() < 1e-9,
+            "expected -0.1 delta, got {delta}"
+        );
+        assert_eq!(traj.prior_error_total, 2);
+        assert_eq!(traj.error_total_delta, 3);
+        assert_eq!(traj.sample_basis, 25);
+        Ok(())
+    }
+
+    #[test]
+    fn service_sli_trajectory_marks_insufficient_samples_below_floor()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        insert_traj_target(&mut store, "TGT-thin", "thin")?;
+
+        // Ten checks per window, below MIN_TRAJECTORY_SAMPLES (20).
+        for minute in 0..10 {
+            insert_check(
+                &store,
+                "TGT-thin",
+                &format!("2026-05-28T20:{minute:02}:00Z"),
+                "success",
+            )?;
+            insert_check(
+                &store,
+                "TGT-thin",
+                &format!("2026-05-28T19:{minute:02}:00Z"),
+                "success",
+            )?;
+        }
+
+        let now = OffsetDateTime::parse("2026-05-28T21:00:00Z", &Rfc3339)?;
+        let summaries = store.service_sli_with_trajectory_at("1h", now)?;
+        let traj = summaries
+            .iter()
+            .find(|summary| summary.service == "thin")
+            .and_then(|summary| summary.trajectory)
+            .ok_or("missing thin trajectory")?;
+
+        assert_eq!(traj.status, TrajectoryStatus::InsufficientSamples);
+        assert!(traj.targets_availability_delta.is_none());
+        assert!(traj.prior_targets_availability_ratio.is_none());
+        assert_eq!(traj.sample_basis, 0);
         Ok(())
     }
 

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -5049,7 +5049,8 @@
           "targets",
           "monitors",
           "errors",
-          "incidents"
+          "incidents",
+          "trajectory"
         ],
         "properties": {
           "service": {
@@ -5081,6 +5082,112 @@
           },
           "incidents": {
             "$ref": "#/components/schemas/IncidentSliSummary"
+          },
+          "trajectory": {
+            "description": "Direction of travel vs the prior equal-length window. Null only on read models that do not compute trajectory.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ServiceSliTrajectory"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "ServiceSliTrajectory": {
+        "type": "object",
+        "description": "Signed change in a service's SLIs vs the immediately preceding equal-length window (current minus prior). A delta is evidence about two adjacent windows, not a burn-rate budget claim or an urgency verdict. Availability deltas are null below the sample floor so a single failed probe cannot fake a swing; the error-count delta is always exact.",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "sample_basis",
+          "targets",
+          "monitors",
+          "errors"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Whether the availability deltas are backed by enough samples to trust.",
+            "enum": [
+              "ok",
+              "insufficient_samples"
+            ]
+          },
+          "sample_basis": {
+            "type": "integer",
+            "description": "Smallest current/prior count backing a computed availability delta; 0 when no availability delta cleared the floor."
+          },
+          "targets": {
+            "type": "object",
+            "description": "HTTP-target availability trajectory.",
+            "additionalProperties": false,
+            "required": [
+              "availability_delta",
+              "prior_availability_ratio"
+            ],
+            "properties": {
+              "availability_delta": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Target availability ratio change (current minus prior); null below the sample floor or with no target checks."
+              },
+              "prior_availability_ratio": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Prior-window target availability ratio, when computable."
+              }
+            }
+          },
+          "monitors": {
+            "type": "object",
+            "description": "Non-HTTP monitor availability trajectory.",
+            "additionalProperties": false,
+            "required": [
+              "availability_delta",
+              "prior_availability_ratio"
+            ],
+            "properties": {
+              "availability_delta": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Monitor availability ratio change (current minus prior); null below the sample floor or with no check-ins."
+              },
+              "prior_availability_ratio": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Prior-window monitor availability ratio, when computable."
+              }
+            }
+          },
+          "errors": {
+            "type": "object",
+            "description": "Error-count trajectory.",
+            "additionalProperties": false,
+            "required": [
+              "total_delta",
+              "prior_total"
+            ],
+            "properties": {
+              "total_delta": {
+                "type": "integer",
+                "description": "Error-row count change vs the prior window (signed; current minus prior)."
+              },
+              "prior_total": {
+                "type": "integer",
+                "description": "Prior-window error-row count."
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Final slice of ticket 047 (child #6). Implements the council-reshaped scope (#171): surface the windowed service SLIs and add a **low-N-safe trajectory delta** — explicitly *not* an MWMBR burn-rate ratio and *not* a page/ticket severity verdict.

## What changed
- **canary-store**: `ServiceSliTrajectory` — signed delta of each service's availability ratio and error count vs the immediately preceding equal-length window. The prior window is derived with **zero SQL change** by differencing a double-width window against the current one (`[now-2d, ∞) − [now-d, ∞) = [now-2d, now-d)`); the subset relationship makes this exact and cancels skew-permitted future-dated rows. Availability deltas null out below `MIN_TRAJECTORY_SAMPLES` (20) → `status: insufficient_samples`, so a single failed probe can't fake a swing. The two budget signals stay separate raw facts.
- **canary-server**: report serializer emits the `trajectory` block.
- **canary-cli**: `summarize_report` now surfaces the SLI block (previously dropped) plus the trajectory; `canary_summary` MCP description updated.
- **OpenAPI**: `ServiceSliTrajectory` schema + `ServiceSliSummary.trajectory`.

## Verification
- Store unit tests (trajectory math + floor boundary), server end-to-end router test (real handler+store, asserts trajectory + low-N), CLI fixture test, OpenAPI test — all green.
- `cargo +1.94.0 clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; strict dagger gate (incl. Docker prod-image smoke) green.
- **Live binary readback**: booted `canary-server`, ingested errors via the real API, `GET /api/v1/report?window=1h` returned `trajectory.errors.total_delta: 2, prior_total: 0` with null availability deltas + `status: ok` for the error-only service.
- Fresh-context adversarial review (artifact-only): no blocking bug; its top safeguard (an additive-only invariant comment on `build_trajectory`) is included.

## Out of scope / follow-ups
- No burn-rate ratio, no severity/page/ticket field, no webhook routing change (per the reshape).
- Stale `priv/mcp/canary-cli-tools.json` snapshot (13 vs ~25 live tools, ungated) — left untouched; candidate for regen-or-delete.
- Cadence-aware sample floor; current-window unbounded-future quirk (pre-existing in the base read model).

Closes child #6 of `backlog.d/047-alert-plane-slo-burn-rate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)