### PR TITLE
chore(backlog): archive 047 and file followups

### DIFF
--- a/backlog.d/052-mcp-server.md
+++ b/backlog.d/052-mcp-server.md
@@ -6,7 +6,12 @@ Priority: P1 · Status: pending · Estimate: M
 Let an agent connect to Canary over MCP (not just shell out to the CLI or hit the HTTP read API), exposing the read + remediation-claims surface as MCP tools — so agent operators get first-class "what's erroring / claim this incident" access from their own MCP client.
 
 ## Why now
-Habitat-dogfooding surfaced this. `canary mcp-manifest` emits a 15-tool manifest (`priv/mcp/canary-cli-tools.json`), but there is **no running MCP server** — agents currently shell out to the CLI or call the HTTP read API. For an agent-operated consumer (Habitat is run by the Olympus/Argus/Vulcan agents), MCP is the native control surface, and "is prod ok?" should be one tool call away.
+Habitat-dogfooding surfaced this. `canary mcp-manifest` emits a generated tool
+manifest, but there is **no running MCP server** — agents currently shell out to
+the CLI or call the HTTP read API. For an agent-operated consumer (Habitat is
+run by the Olympus/Argus/Vulcan agents), MCP is the native control surface, and
+"is prod ok?" should be one tool call away. Static manifest drift is tracked
+separately in #057.
 
 ## Oracle
 - [ ] An installable MCP server wraps the CLI manifest; an MCP client lists the tools and invokes one read-only/no-op tool end to end.

--- a/backlog.d/056-report-lock-and-owner-scope-followups.md
+++ b/backlog.d/056-report-lock-and-owner-scope-followups.md
@@ -43,5 +43,5 @@ security-sensitive path and should not be lost to a closed PR.
       pass; add one if a shared helper is introduced.
 
 ## Relationship to existing backlog
-Follow-up to #047 (alert-plane reliability; children 1–5 shipped, child #6
-burn-rate still open). Pure store-layer refactor + perf; no API/contract change.
+Follow-up to shipped #047 (alert-plane reliability and SLI trajectory). Pure
+store-layer refactor + perf; no API/contract change.

--- a/backlog.d/057-static-mcp-manifest-parity.md
+++ b/backlog.d/057-static-mcp-manifest-parity.md
@@ -1,0 +1,47 @@
+# Regenerate and gate the static MCP manifest snapshot
+
+Priority: P1 · Status: ready · Estimate: S
+
+## Goal
+Make the checked-in `priv/mcp/canary-cli-tools.json` snapshot either match
+`bin/canary mcp-manifest` exactly or stop existing as a parallel source of
+truth, so agents never read a stale MCP tool contract.
+
+## Why now
+PR #172 updated the live `canary_summary` MCP description and surfaced the
+final #047 SLI trajectory data, but left the static snapshot stale and ungated.
+A live check on 2026-06-26 showed:
+
+- checked-in `priv/mcp/canary-cli-tools.json`: 13 tools
+- generated `bin/canary mcp-manifest`: 23 tools
+
+Dagger currently validates the generated manifest shape during the
+doctor/MCP smoke, but it does not diff the checked-in snapshot. The stale file
+is agent-facing enough to become misleading, especially before #052 ships a
+runnable MCP server.
+
+## Oracle
+- [ ] Given `bin/canary mcp-manifest` runs in a clean checkout, then the
+      checked-in `priv/mcp/canary-cli-tools.json` is byte-for-byte equivalent
+      after stable JSON formatting, or the file is removed and all references
+      point to the generator.
+- [ ] Given `canary-cli::tool_manifest()` changes, then the canonical gate fails
+      if a retained static snapshot was not regenerated.
+- [ ] Given docs or backlog tickets mention MCP tool counts, then they do not
+      hardcode stale counts; they either derive from the generator or describe
+      the contract without a count.
+
+## Verification System
+- Claim: the static MCP manifest cannot drift from the CLI-generated manifest.
+- Falsifier: `bin/canary mcp-manifest` emits a different tool set than
+  `priv/mcp/canary-cli-tools.json` while `./bin/validate` still passes.
+- Driver: a focused CLI fixture/parity test plus the existing Dagger MCP smoke.
+- Grader: a stable JSON diff over generated vs checked-in manifest is empty, or
+  no checked-in snapshot remains to drift.
+- Evidence packet: test transcript plus the generated/diff output in the PR.
+- Cadence: every repo gate when the snapshot is retained.
+
+## Relationship to existing backlog
+Follow-up to #047 child #6 and prerequisite hygiene for #050/#052. This does
+not ship the runnable MCP server; #052 still owns server installation and one
+client invocation.

--- a/backlog.d/058-cadence-aware-sli-trajectory-floor.md
+++ b/backlog.d/058-cadence-aware-sli-trajectory-floor.md
@@ -1,0 +1,52 @@
+# Make SLI trajectory sample floors cadence-aware
+
+Priority: P2 · Status: pending · Estimate: M
+
+## Goal
+Replace the fixed `MIN_TRAJECTORY_SAMPLES` availability floor with a
+cadence-aware policy so low-frequency but complete target/monitor windows can
+produce trustworthy trajectory deltas, while genuinely thin windows still
+return `insufficient_samples`.
+
+## Why now
+#047 child #6 deliberately shipped a conservative fixed floor of 20 samples per
+current/prior window. That is safe for common 30-60s probes, but it can null a
+complete 1h trajectory for a target probed every 5 minutes (about 12 expected
+samples), and it can be too permissive or too strict as monitor/check-in
+cadence varies. The shape packet accepted this as a follow-up rather than
+blocking the final #047 slice.
+
+## Oracle
+- [ ] Given a 60s target or monitor cadence with complete current and prior 1h
+      windows, then trajectory availability deltas clear the floor as they do
+      today.
+- [ ] Given a lower-frequency target such as a 5m probe with complete current
+      and prior 1h windows, then the floor scales to expected cadence and emits
+      a real availability delta instead of `insufficient_samples`.
+- [ ] Given either current or prior windows miss enough expected samples for the
+      configured cadence, then availability deltas remain null and trajectory
+      status is `insufficient_samples`.
+- [ ] Given a service has both targets and monitors with different cadences,
+      then `sample_basis` or its replacement exposes enough basis metadata for
+      an agent to understand which signal cleared or failed the floor.
+
+## Verification System
+- Claim: trajectory sample sufficiency reflects expected observation cadence,
+  not a one-size-fits-all count.
+- Falsifier: a complete low-frequency target stays `insufficient_samples`, or a
+  sparse high-frequency target emits a non-null availability delta.
+- Driver: `canary-store` trajectory unit tests with explicit target intervals
+  and monitor cadence/TTL fixtures; report serialization tests if the wire
+  metadata changes.
+- Grader: deltas and `insufficient_samples` match cadence-specific expectations
+  without adding a server-side burn-rate or urgency verdict.
+- Evidence packet: focused test transcript plus one report JSON fixture showing
+  floor basis for low-frequency and high-frequency services.
+- Cadence: store tests on every gate; revisit when new monitor cadence modes are
+  added.
+
+## Relationship to existing backlog
+Follow-up to #047 child #6. This keeps the #047 evidence-vs-policy boundary:
+Canary may improve whether a trajectory delta is statistically trustworthy, but
+it still does not compute burn-rate severity, page/ticket routing, or responder
+urgency.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -1,6 +1,6 @@
 # Canary Backlog
 
-`backlog.d/` is the source of truth for active backlog work as of 2026-06-11.
+`backlog.d/` is the source of truth for active backlog work as of 2026-06-26.
 
 ## Priority Order
 
@@ -44,7 +44,7 @@
 | 044 | Telemetry and analytics signal model | P1 | done | XL |
 | 045 | Self-watch operator verdict | P0 | done | L |
 | 046 | Dogfood value receipts | P0 | done | L |
-| 047 | Alert-plane reliability and SLO burn-rate | P0 | ready | XL |
+| 047 | Alert-plane reliability and SLI trajectory | P0 | done | XL |
 | 048 | Responder rich-context safety gate | P0 | pending | XL |
 | 049 | Integration evidence and capture gaps | P1 | pending | XL |
 | 050 | Cold-agent readiness proof | P1 | pending | M |
@@ -54,6 +54,8 @@
 | 054 | Serving model: self-hosted, managed-later, not multi-tenant SaaS | P2 | pending | S |
 | 055 | Refresh PRINCIPLES.md examples to Rust+SQLite (post-cutover) | P3 | pending | S |
 | 056 | Lower /api/v1/report store-lock contention + dedup SLI owner-scope | P2 | pending | M |
+| 057 | Static MCP manifest parity | P1 | ready | S |
+| 058 | Cadence-aware SLI trajectory sample floor | P2 | pending | M |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
 
@@ -91,16 +93,19 @@
 043 (agentic remediation claim protocol) — shipped; typed claims now add deterministic ownership/claim state for downstream triage agents
 045 (self-watch operator verdict) — makes Canary's own watchman state one actionable agent-readable verdict, including witness, worker pressure, incidents, dogfood gaps, and next operator action
 046 (dogfood value receipts) — turns coverage into per-service value proof: current signal, owner/claim, action, outcome, stale evidence, and verification receipt
-047 (alert-plane reliability/SLO burn-rate) — separates route readiness from alerting ability, adds check-in skew safety, and introduces SLO/error-budget feedback after an induced impairment rehearsal proves the alert-plane verdict
+047 (alert-plane reliability/SLI trajectory) — shipped; separates route readiness from alerting ability, adds check-in skew safety, proves induced impairment rehearsal, and exposes windowed SLI + prior-window trajectory evidence without burn-rate severity routing
 048 (responder rich-context safety gate) — narrows responder authority, enforces minimized/audited rich context, defines safe browser/public-ingest authority, and aligns HTTP/CLI/MCP responder privileges before arbitrary-user auto-triage
 049 (integration evidence/capture gaps) — closes residual post-040 overclaiming gaps: synthetic service-specific readback, service-specific webhooks, stale-evidence failure, safe browser capture after 048, platform env parity, integrate apply, and MCP wrapper
 050 (cold-agent readiness proof) — codifies a one-entrypoint proof that a cold agent can inspect Canary, discover MCP/CLI surfaces, run fast validation, and leave a redacted readiness receipt
+057 (static MCP manifest parity) — makes the checked-in MCP manifest match `bin/canary mcp-manifest` or removes the stale parallel snapshot before agents rely on it
+058 (cadence-aware SLI trajectory floor) — follows shipped 047 by replacing the fixed sample floor with cadence-aware sufficiency for low-frequency but complete target/monitor windows
 
 022 (contract hygiene) ──── ships independently; restores summary invariant + supervision-tree collapse
 023 (incident detail API) ──→ Canary-side substrate for the Bitterblossom responder workload (and thus 010 ramp pattern)
 024 (signal-agnostic annotations) ──→ blocked on 023; completes the Ramp-loop writable-metadata primitive
-046 ──→ 047 ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
-047 + 049 ──→ 050 (readiness proof consumes the real alert and MCP/integration surfaces)
+046 ──→ 047 (shipped) ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
+049 + 052 + 057 ──→ 050 (readiness proof consumes the integration and MCP surfaces; 047 alert-plane surface is already real)
+058 follows 047 as quality tuning; it does not block 048/049/050 unless trajectory sufficiency becomes a readiness proof requirement
 ```
 
 ## Execution Lanes
@@ -112,33 +117,34 @@
 **Lane 4 (hardening):** 008, 014, 016, 017, 018, 019 (independent, small, can ship anytime) · **034 (worker lifecycle readiness oracle)** hardens the Rust background-worker proof surface
 **Lane 5 (dogfood coverage):** 020 (Adminifi HTTP surface verification) · **033 (deployed service registry lifecycle)** shipped the managed registry substrate · **035 (deployed app Canary coverage)** makes every active owned deployment covered or explicitly blocked · **036 (agent-native inspection surface)** gives agents the operating view · **037 (watch the watchmen)** proves Canary externally · **038 (one-command integration agent)** removes setup friction
 **Lane 6 (arbitrary-app productization):** 039 (external-user security/privacy foundation) → 041 (live integration verification harness) + 042 (runtime pressure/freshness ops) → 040 (universal integration/enrollment engine) → 043 (agentic remediation claim protocol) + 044 (telemetry/analytics signal model) → **048 (responder rich-context safety gate)** → Bitterblossom **055 (canary/incident responder template)** → **049 (integration evidence/capture gaps)** → 010 (Ramp pattern)
-**Lane 7 (product feedback loop):** 045 (self-watch operator verdict) shipped → 046 (dogfood value receipts) shipped → **047 (alert-plane reliability/SLO burn-rate)** — turns Canary dogfooding from coverage checks into value, alertability, and operator-action proof
-**Lane 8 (cold-agent readiness):** 050 — after the alert-plane and integration/MCP surfaces harden, package the cold-agent verification path into one discoverable proof and receipt
+**Lane 7 (product feedback loop):** 045 (self-watch operator verdict) shipped → 046 (dogfood value receipts) shipped → 047 (alert-plane reliability/SLI trajectory) shipped — Canary dogfooding now has value, alertability, and operator-action proof; 056/058 are quality followups
+**Lane 8 (cold-agent readiness):** 057 + 052 + 049 → 050 — after stale MCP manifest parity, the runnable MCP surface, and integration proof harden, package the cold-agent verification path into one discoverable proof and receipt
 
-### Active order (2026-06-17)
+### Active order (2026-06-26)
 
-045 shipped in PR #163 (commit b0c43b5). 046 shipped the per-service dogfood
-value receipt loop. `bin/canary dogfood value --service <name> --json` now
-answers what Canary proves for one service, and `doctor --json` includes
-aggregate dogfood value counts. 047 is still the best next pickup, but the
-first slice is now the induced alert-plane impairment proof: make doctor and
-the external witness degrade on alertability failure before implementing
-broader SLO/error-budget math.
+045, 046, and 047 are shipped and archived. 047 landed in slices across PR
+#167, PR #168, PR #171, and PR #172: alert-plane health is distinct from route
+readiness, future check-ins cannot defer overdue alerts beyond the skew policy,
+strict includes an induced impairment rehearsal, windowed service SLI/default
+SLO data is exposed, and report/CLI/OpenAPI now carry a prior-window
+`trajectory` block without server-computed burn-rate severity or page/ticket
+routing.
 
-048 stays pending until the self-watch/value/SLO loops settle, because
-arbitrary-user rich-context responders need those contracts to avoid
-over-authorizing. 048 now also owns the public-ingest or relay boundary for
-browser capture and the HTTP/CLI/MCP authority parity that arbitrary responders
-need. After 048, the cross-repo pickup is Bitterblossom
+048 is now the next product pickup because arbitrary-user rich-context
+responders need the safety contract before browser capture, integration apply,
+or downstream responder templates widen authority. 048 owns public-ingest or
+relay browser boundaries and HTTP/CLI/MCP authority parity. After 048, the
+cross-repo pickup is Bitterblossom
 `/Users/phaedrus/Development/bitterblossom/backlog.d/055-workload-template-portfolio.md`
 child 2, the canary/incident responder template. 049 follows that responder
 template and closes residual integration evidence gaps without redoing shipped
-040 enrollment work. 050 should not preempt 047/048/049; it packages the
-agent-facing verification proof once the surfaces it proves are real. 020 stays
-blocked on Adminifi URLs. 010 stays blocked on that downstream Bitterblossom
-responder workload, but the Lane 7 alertability proof, responder-safety
-foundation, and cold-agent proof now precede any claim that Canary is ready for
-arbitrary external users.
+040 enrollment work. 057 is a small ready hygiene pickup before MCP/cold-agent
+work: the checked-in MCP snapshot currently has 13 tools while the generator
+emits 23. 058 is a quality followup for the fixed #047 trajectory sample floor.
+050 should not preempt 048/049/052/057; it packages the agent-facing
+verification proof once the surfaces it proves are real. 020 stays blocked on
+Adminifi URLs. 010 stays blocked on the downstream Bitterblossom responder
+workload.
 
 022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
 2026-04-23 — Ramp
@@ -287,6 +293,11 @@ Bitterblossom workload. 020 stays blocked on Adminifi URLs.
   048 into the arbitrary-responder safety gate including public-ingest/relay
   and authority parity, keep 049 pending behind 048 while hardening its
   anti-overclaim receipt oracle, and add 050 for a cold-agent readiness proof.
+- 2026-06-26: Archived 047 after PR #172 shipped the final trajectory slice.
+  Filed #057 for static MCP manifest parity after observing the checked-in
+  snapshot had 13 tools while `bin/canary mcp-manifest` emitted 23, and filed
+  #058 for cadence-aware SLI trajectory sample floors. 048 is the next product
+  pickup; do not reopen 047 for these followups.
 
 ## Status
 

--- a/backlog.d/_done/047-alert-plane-slo-burn-rate.md
+++ b/backlog.d/_done/047-alert-plane-slo-burn-rate.md
@@ -1,6 +1,6 @@
 # Prove alert-plane health separately from route readiness
 
-Priority: P0 · Status: in_progress · Estimate: XL
+Priority: P0 · Status: done · Estimate: XL
 
 ## PRD Summary
 - User: agent responders and operators deciding whether Canary can be trusted to wake them up.
@@ -40,11 +40,11 @@ before adding SLO configuration or burn-rate math. Include an induced
 impairment driver that can be run in strict or as a dedicated ops gate.
 
 ## Oracle
-- [ ] Given webhook delivery, monitor overdue, target probe, retention, or TLS workers report sustained pressure, circuit-open suppression, stale due work, or fanout failures, when the external witness runs, then it fails or degrades with an alert-plane impairment reason even if `/readyz` is route-ready.
-- [ ] Given a monitor check-in contains a future `observed_at` beyond an allowed skew, then Canary rejects or clamps it with RFC 9457 Problem Details and a regression test proves future check-ins cannot defer overdue alerts.
-- [ ] Given a service with checks/check-ins/errors over a window, when `/api/v1/report?window=W` and `bin/canary summary --json` are queried, then each service SLI carries the windowed availability/latency/error/incident facts **plus** a `trajectory` block holding the signed delta vs the prior equal-length window, with sub-floor windows marked `insufficient_samples` (null delta) so a single failed probe cannot fake a swing.
-- [ ] Given the change, when the surfaces are inspected, then **no** server-computed severity verdict and **no** `page`/`ticket` field is emitted on report, CLI, webhook payload, or manifest, and webhook fanout stays severity-agnostic (negative oracle); the regenerated `priv/mcp/canary-cli-tools.json` matches the generator (parity test green) and the runnable MCP server stays deferred to ticket 052.
-- [ ] Given an induced rehearsal creates alert-plane impairment, then a live or production-image rehearsal proves the witness and doctor catch it before declaring Canary healthy.
+- [x] Given webhook delivery, monitor overdue, target probe, retention, or TLS workers report sustained pressure, circuit-open suppression, stale due work, or fanout failures, when the external witness runs, then it fails or degrades with an alert-plane impairment reason even if `/readyz` is route-ready.
+- [x] Given a monitor check-in contains a future `observed_at` beyond an allowed skew, then Canary rejects or clamps it with RFC 9457 Problem Details and a regression test proves future check-ins cannot defer overdue alerts.
+- [x] Given a service with checks/check-ins/errors over a window, when `/api/v1/report?window=W` and `bin/canary summary --json` are queried, then each service SLI carries the windowed availability/latency/error/incident facts **plus** a `trajectory` block holding the signed delta vs the prior equal-length window, with sub-floor windows marked `insufficient_samples` (null delta) so a single failed probe cannot fake a swing.
+- [x] Given the change, when the surfaces are inspected, then **no** server-computed severity verdict and **no** `page`/`ticket` field is emitted on report, CLI, webhook payload, or manifest, and webhook fanout stays severity-agnostic (negative oracle); the regenerated `priv/mcp/canary-cli-tools.json` matches the generator (parity test green) and the runnable MCP server stays deferred to ticket 052.
+- [x] Given an induced rehearsal creates alert-plane impairment, then a live or production-image rehearsal proves the witness and doctor catch it before declaring Canary healthy.
 
 ## Verification System
 - Claim: Canary can be route-ready while still refusing to claim alert-plane health.
@@ -120,3 +120,21 @@ Full context packet + alternatives + verification:
 4. Add windowed SLI read models for targets, monitors, errors, and incidents.
 5. Add service SLO configuration with default classes.
 6. Surface windowed SLIs + SLO targets + a low-N-safe **trajectory delta** (vs the prior equal-length window) on report/CLI; regenerate the MCP manifest snapshot. **No** server-computed burn-rate ratio, **no** page/ticket severity verdict (reshaped 2026-06-25 — see Notes).
+
+## Closure
+Archived on 2026-06-26 after the final child shipped in PR #172
+(`467ea85`, `feat(report): add prior-window SLI trajectory to report, CLI, and
+OpenAPI`). Earlier slices shipped alert-plane health separate from route
+readiness in PR #167 (`c322168`) and check-in skew safety, production-image
+induced impairment rehearsal, windowed service SLIs, and default SLO classes in
+PR #168 (`ab348e1`). The child #6 reshape landed in PR #171 (`42ffd8f`).
+
+The final implementation exposes per-service windowed SLI summaries plus a
+prior-window `trajectory` block on report/CLI/OpenAPI, preserves the negative
+oracle of no burn-rate ratio and no page/ticket severity verdict, and keeps the
+runnable MCP server deferred to #052.
+
+Residuals deliberately filed as follow-up backlog instead of keeping 047 open:
+#056 tracks report lock/owner-scope store debt from review, #057 tracks stale
+static MCP manifest snapshot parity, and #058 tracks the cadence-aware
+trajectory sample floor.

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -45,8 +45,7 @@ pub struct ServiceSliSummary {
 /// marked `InsufficientSamples`.
 ///
 /// This is a deliberately coarse, fixed first-pass floor. A cadence-aware floor
-/// (scaled to each target's probe interval) is a tracked follow-up on ticket
-/// 047, not part of this slice.
+/// (scaled to each target's probe interval) is tracked by backlog ticket 058.
 pub const MIN_TRAJECTORY_SAMPLES: u64 = 20;
 
 /// Whether a service's availability trajectory is backed by enough samples to


### PR DESCRIPTION
## What changed
- archived backlog ticket 047 as done with shipped PR/commit evidence
- filed #057 for stale static MCP manifest parity and #058 for cadence-aware SLI trajectory sample floors
- refreshed backlog routing and stale references so #047 stays closed and #052/#056 point at the right followups

## Verification
- `PATH="/tmp/canary-dagger-v0.20.5:$HOME/.cargo/bin:$HOME/.bun/bin:/opt/homebrew/bin:$PATH" ./bin/validate`
- pre-push `./bin/validate --strict` via `git push -u origin chore/047-closeout`
- fresh-context Pi critic on the branch diff; live grep verified its only blocker was a stale/deleted-line false positive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog planning notes to reflect the latest priorities, dependencies, and status changes.
  * Marked a completed backlog item as archived and added closure details.
  * Added new follow-up items covering MCP manifest parity and cadence-aware SLI sample floors.
  * Adjusted related implementation notes to point to the new follow-up tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->