### PR TITLE
feat(cli): ship MCP stdio server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [master]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Landmark
+        uses: misty-step/landmark@v1
+        with:
+          mode: full
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          node-version: "24"
+          synthesis: "true"
+          synthesis-required: "false"
+          healthcheck: "true"
+          product-description: "Canary is a self-hosted, agent-first production health ledger for errors, uptime, incidents, timelines, webhooks, and remediation claims."

--- a/README.md
+++ b/README.md
@@ -181,6 +181,23 @@ plus the candidate snapshot separately, and executes `dagger call strict
 definition outside the candidate diff while preserving the same strict Dagger
 entrypoint. See [docs/ci-control-plane.md](docs/ci-control-plane.md).
 
+### Agent MCP Server
+
+Canary's MCP surface is the CLI contract served over stdio:
+
+```bash
+CANARY_ENDPOINT=https://canary-obs.fly.dev \
+CANARY_READ_API_KEY=... \
+bin/canary mcp-server
+```
+
+MCP clients can list and call the same generated tools exposed by
+`bin/canary mcp-manifest`: summary, services, errors, incidents, timeline,
+targets, monitors, doctor, dogfood, event capture, remediation claims, and
+integration helpers. The server returns MCP `inputSchema` fields at the wire
+boundary while the checked CLI manifest remains gated in
+`priv/mcp/canary-cli-tools.json`.
+
 ## API
 
 The machine-readable contract lives at `GET /api/v1/openapi.json`. That

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -49,12 +49,12 @@
 | 049 | Integration evidence and capture gaps | P1 | pending | XL |
 | 050 | Cold-agent readiness proof | P1 | pending | M |
 | 051 | TypeScript SDK npm publish | P1 | pending | S |
-| 052 | Runnable MCP server | P1 | pending | M |
+| 052 | Runnable MCP server | P1 | done | M |
 | 053 | Human alert delivery (decision) | P2 | pending | M |
 | 054 | Serving model: self-hosted, managed-later, not multi-tenant SaaS | P2 | pending | S |
 | 055 | Refresh PRINCIPLES.md examples to Rust+SQLite (post-cutover) | P3 | pending | S |
 | 056 | Lower /api/v1/report store-lock contention + dedup SLI owner-scope | P2 | pending | M |
-| 057 | Static MCP manifest parity | P1 | ready | S |
+| 057 | Static MCP manifest parity | P1 | done | S |
 | 058 | Cadence-aware SLI trajectory sample floor | P2 | pending | M |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
@@ -97,14 +97,15 @@
 048 (responder rich-context safety gate) — narrows responder authority, enforces minimized/audited rich context, defines safe browser/public-ingest authority, and aligns HTTP/CLI/MCP responder privileges before arbitrary-user auto-triage
 049 (integration evidence/capture gaps) — closes residual post-040 overclaiming gaps: synthetic service-specific readback, service-specific webhooks, stale-evidence failure, safe browser capture after 048, platform env parity, integrate apply, and MCP wrapper
 050 (cold-agent readiness proof) — codifies a one-entrypoint proof that a cold agent can inspect Canary, discover MCP/CLI surfaces, run fast validation, and leave a redacted readiness receipt
-057 (static MCP manifest parity) — makes the checked-in MCP manifest match `bin/canary mcp-manifest` or removes the stale parallel snapshot before agents rely on it
+052 (runnable MCP server) — shipped; `canary mcp-server` serves the CLI-backed tool surface over MCP stdio
+057 (static MCP manifest parity) — shipped; the checked-in MCP manifest is gated against `tool_manifest()`
 058 (cadence-aware SLI trajectory floor) — follows shipped 047 by replacing the fixed sample floor with cadence-aware sufficiency for low-frequency but complete target/monitor windows
 
 022 (contract hygiene) ──── ships independently; restores summary invariant + supervision-tree collapse
 023 (incident detail API) ──→ Canary-side substrate for the Bitterblossom responder workload (and thus 010 ramp pattern)
 024 (signal-agnostic annotations) ──→ blocked on 023; completes the Ramp-loop writable-metadata primitive
 046 ──→ 047 (shipped) ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
-049 + 052 + 057 ──→ 050 (readiness proof consumes the integration and MCP surfaces; 047 alert-plane surface is already real)
+049 + shipped 052/057 ──→ 050 (readiness proof consumes the integration and MCP surfaces; 047 alert-plane surface is already real)
 058 follows 047 as quality tuning; it does not block 048/049/050 unless trajectory sufficiency becomes a readiness proof requirement
 ```
 
@@ -118,7 +119,7 @@
 **Lane 5 (dogfood coverage):** 020 (Adminifi HTTP surface verification) · **033 (deployed service registry lifecycle)** shipped the managed registry substrate · **035 (deployed app Canary coverage)** makes every active owned deployment covered or explicitly blocked · **036 (agent-native inspection surface)** gives agents the operating view · **037 (watch the watchmen)** proves Canary externally · **038 (one-command integration agent)** removes setup friction
 **Lane 6 (arbitrary-app productization):** 039 (external-user security/privacy foundation) → 041 (live integration verification harness) + 042 (runtime pressure/freshness ops) → 040 (universal integration/enrollment engine) → 043 (agentic remediation claim protocol) + 044 (telemetry/analytics signal model) → **048 (responder rich-context safety gate)** → Bitterblossom **055 (canary/incident responder template)** → **049 (integration evidence/capture gaps)** → 010 (Ramp pattern)
 **Lane 7 (product feedback loop):** 045 (self-watch operator verdict) shipped → 046 (dogfood value receipts) shipped → 047 (alert-plane reliability/SLI trajectory) shipped — Canary dogfooding now has value, alertability, and operator-action proof; 056/058 are quality followups
-**Lane 8 (cold-agent readiness):** 057 + 052 + 049 → 050 — after stale MCP manifest parity, the runnable MCP surface, and integration proof harden, package the cold-agent verification path into one discoverable proof and receipt
+**Lane 8 (cold-agent readiness):** shipped 057 + shipped 052 + 049 → 050 — after integration proof hardens, package the cold-agent verification path into one discoverable proof and receipt
 
 ### Active order (2026-06-26)
 
@@ -138,13 +139,12 @@ cross-repo pickup is Bitterblossom
 `/Users/phaedrus/Development/bitterblossom/backlog.d/055-workload-template-portfolio.md`
 child 2, the canary/incident responder template. 049 follows that responder
 template and closes residual integration evidence gaps without redoing shipped
-040 enrollment work. 057 is a small ready hygiene pickup before MCP/cold-agent
-work: the checked-in MCP snapshot currently has 13 tools while the generator
-emits 23. 058 is a quality followup for the fixed #047 trajectory sample floor.
-050 should not preempt 048/049/052/057; it packages the agent-facing
-verification proof once the surfaces it proves are real. 020 stays blocked on
-Adminifi URLs. 010 stays blocked on the downstream Bitterblossom responder
-workload.
+040 enrollment work. 052/057 shipped on 2026-07-01: the runnable MCP server and
+snapshot parity gate are real. 058 is a quality followup for the fixed #047
+trajectory sample floor. 050 should not preempt 048/049; it packages the
+agent-facing verification proof once the remaining integration surfaces it
+proves are real. 020 stays blocked on Adminifi URLs. 010 stays blocked on the
+downstream Bitterblossom responder workload.
 
 022 + 023 landed on 2026-04-21. 024 landed on 2026-04-22. 026 landed on
 2026-04-23 — Ramp
@@ -298,6 +298,10 @@ Bitterblossom workload. 020 stays blocked on Adminifi URLs.
   snapshot had 13 tools while `bin/canary mcp-manifest` emitted 23, and filed
   #058 for cadence-aware SLI trajectory sample floors. 048 is the next product
   pickup; do not reopen 047 for these followups.
+- 2026-07-01: Archived 052 and 057 after shipping `canary mcp-server`, a real
+  MCP stdio adapter over the generated CLI tool contract, and a fixture parity
+  test that fails when `priv/mcp/canary-cli-tools.json` drifts from
+  `tool_manifest()`.
 
 ## Status
 

--- a/backlog.d/_done/052-mcp-server.md
+++ b/backlog.d/_done/052-mcp-server.md
@@ -1,6 +1,6 @@
 # Ship a runnable Canary MCP server
 
-Priority: P1 · Status: pending · Estimate: M
+Priority: P1 · Status: done · Estimate: M
 
 ## Goal
 Let an agent connect to Canary over MCP (not just shell out to the CLI or hit the HTTP read API), exposing the read + remediation-claims surface as MCP tools — so agent operators get first-class "what's erroring / claim this incident" access from their own MCP client.
@@ -14,9 +14,21 @@ run by the Olympus/Argus/Vulcan agents), MCP is the native control surface, and
 separately in #057.
 
 ## Oracle
-- [ ] An installable MCP server wraps the CLI manifest; an MCP client lists the tools and invokes one read-only/no-op tool end to end.
-- [ ] Tool schemas stay **generated from the CLI** (no separate semantic API) — preserves the #036 invariant.
-- [ ] A smoke proof covers install + one tool invocation through the wrapper.
+- [x] An installable MCP server wraps the CLI manifest; an MCP client lists the tools and invokes one read-only/no-op tool end to end.
+- [x] Tool schemas stay **generated from the CLI** (no separate semantic API) — preserves the #036 invariant.
+- [x] A smoke proof covers install + one tool invocation through the wrapper.
 
 ## Relationship to existing backlog
 ELEVATES the MCP-wrapper requirement currently embedded as one P1 bullet inside #049 ("ship an installable MCP wrapper over the CLI manifest with a smoke proof"); #050's cold-agent readiness proof depends on it. Filed as a focused, standalone deliverable for discoverability — fold back into #049 if you'd rather keep it bundled.
+
+## Completion
+
+Shipped 2026-07-01 on branch `factory/mcp-server-triage-landmark`.
+`canary mcp-server` now serves the generated CLI tool surface over MCP stdio:
+`initialize`, `notifications/initialized`, `ping`, `tools/list`, and
+`tools/call`. The server translates generated `input_schema` values to MCP
+`inputSchema` at the wire boundary and returns CLI JSON envelopes as
+`structuredContent`.
+
+Proof: `cargo test -p canary-cli --test mcp_stdio --test fixtures mcp --locked`
+covered a real stdio JSON-RPC session plus manifest parity.

--- a/backlog.d/_done/057-static-mcp-manifest-parity.md
+++ b/backlog.d/_done/057-static-mcp-manifest-parity.md
@@ -1,6 +1,6 @@
 # Regenerate and gate the static MCP manifest snapshot
 
-Priority: P1 · Status: ready · Estimate: S
+Priority: P1 · Status: done · Estimate: S
 
 ## Goal
 Make the checked-in `priv/mcp/canary-cli-tools.json` snapshot either match
@@ -21,13 +21,13 @@ is agent-facing enough to become misleading, especially before #052 ships a
 runnable MCP server.
 
 ## Oracle
-- [ ] Given `bin/canary mcp-manifest` runs in a clean checkout, then the
+- [x] Given `bin/canary mcp-manifest` runs in a clean checkout, then the
       checked-in `priv/mcp/canary-cli-tools.json` is byte-for-byte equivalent
       after stable JSON formatting, or the file is removed and all references
       point to the generator.
-- [ ] Given `canary-cli::tool_manifest()` changes, then the canonical gate fails
+- [x] Given `canary-cli::tool_manifest()` changes, then the canonical gate fails
       if a retained static snapshot was not regenerated.
-- [ ] Given docs or backlog tickets mention MCP tool counts, then they do not
+- [x] Given docs or backlog tickets mention MCP tool counts, then they do not
       hardcode stale counts; they either derive from the generator or describe
       the contract without a count.
 
@@ -42,6 +42,16 @@ runnable MCP server.
 - Cadence: every repo gate when the snapshot is retained.
 
 ## Relationship to existing backlog
-Follow-up to #047 child #6 and prerequisite hygiene for #050/#052. This does
-not ship the runnable MCP server; #052 still owns server installation and one
-client invocation.
+Follow-up to #047 child #6 and prerequisite hygiene for #050/#052. This shipped
+with #052 so the static manifest parity gate and runnable MCP server landed as
+one agent-facing surface.
+
+## Completion
+
+Shipped 2026-07-01 with #052. The checked-in snapshot was regenerated from
+`bin/canary mcp-manifest`, and
+`checked_in_mcp_manifest_matches_generated_manifest` now fails if
+`tool_manifest()` changes without a snapshot update.
+
+Proof: `cargo test -p canary-cli --test fixtures checked_in_mcp_manifest_matches_generated_manifest --locked`
+failed before regeneration and passed after regeneration.

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -4115,6 +4115,492 @@ pub struct ToolSpec {
     pub input_schema: Value,
 }
 
+/// Tool metadata in MCP `tools/list` wire shape.
+#[derive(Debug, Serialize)]
+pub struct McpToolSpec {
+    /// Tool name.
+    pub name: &'static str,
+    /// Tool description.
+    pub description: &'static str,
+    /// JSON schema for arguments.
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+/// Return the CLI-backed tool manifest in MCP wire shape.
+pub fn mcp_tool_manifest() -> Vec<McpToolSpec> {
+    tool_manifest()
+        .into_iter()
+        .map(|tool| McpToolSpec {
+            name: tool.name,
+            description: tool.description,
+            input_schema: tool.input_schema,
+        })
+        .collect()
+}
+
+/// Context used to invoke CLI-backed MCP tools.
+#[derive(Debug, Clone)]
+pub struct McpToolContext {
+    endpoint: Option<String>,
+    api_key: Option<String>,
+    config_path: Option<PathBuf>,
+    repo_root: PathBuf,
+}
+
+impl McpToolContext {
+    /// Create a reusable MCP tool invocation context.
+    pub fn new(
+        endpoint: Option<String>,
+        api_key: Option<String>,
+        config_path: Option<PathBuf>,
+        repo_root: PathBuf,
+    ) -> Self {
+        Self {
+            endpoint,
+            api_key,
+            config_path,
+            repo_root,
+        }
+    }
+
+    /// Invoke one CLI-backed tool and return the standard JSON command envelope.
+    pub fn invoke(&self, name: &str, arguments: &Value) -> Result<Value> {
+        let arguments = arguments
+            .as_object()
+            .ok_or_else(|| CliError::Message("tool arguments must be a JSON object".to_owned()))?;
+
+        match name {
+            "canary_summary" => {
+                let client = self.read_client()?;
+                let window = window_argument(arguments, "window", "24h")?;
+                let response =
+                    client.get_auth_json(&format!("/api/v1/report?window={}", window.as_str()))?;
+                Ok(json_envelope("canary_summary", client.endpoint(), response))
+            }
+            "canary_errors" => {
+                let client = self.read_client()?;
+                let service = required_string(arguments, "service")?;
+                let window = window_argument(arguments, "window", "24h")?;
+                let response = client.get_auth_json(&format!(
+                    "/api/v1/query?service={}&window={}",
+                    encode(&service),
+                    window.as_str()
+                ))?;
+                Ok(json_envelope("canary_errors", client.endpoint(), response))
+            }
+            "canary_services" => {
+                let client = self.read_client()?;
+                let window = window_argument(arguments, "window", "24h")?;
+                let mut response =
+                    client.get_auth_json(&format!("/api/v1/status?window={}", window.as_str()))?;
+                if let Some(state) = optional_string(arguments, "state")?
+                    && let Some(object) = response.as_object_mut()
+                {
+                    object.insert("state_filter".to_owned(), json!(state));
+                }
+                Ok(json_envelope(
+                    "canary_services",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_incidents" => {
+                let client = self.read_client()?;
+                let response = client.get_auth_json("/api/v1/incidents")?;
+                Ok(json_envelope(
+                    "canary_incidents",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_timeline" => {
+                let client = self.read_client()?;
+                let window = window_argument(arguments, "window", "24h")?;
+                let limit = optional_u16(arguments, "limit")?.unwrap_or(20);
+                let mut path = format!("/api/v1/timeline?window={}&limit={limit}", window.as_str());
+                if let Some(service) = optional_string(arguments, "service")? {
+                    path.push_str("&service=");
+                    path.push_str(&encode(&service));
+                }
+                let response = client.get_auth_json(&path)?;
+                Ok(json_envelope(
+                    "canary_timeline",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_targets" => {
+                let client = self.read_client()?;
+                let response = client.get_auth_json("/api/v1/targets")?;
+                Ok(json_envelope("canary_targets", client.endpoint(), response))
+            }
+            "canary_monitors" => {
+                let client = self.read_client()?;
+                let response = client.get_auth_json("/api/v1/monitors")?;
+                Ok(json_envelope(
+                    "canary_monitors",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_doctor" => {
+                let client = self.read_client()?;
+                let response = doctor_report(&client, &self.repo_root);
+                Ok(json_envelope("canary_doctor", client.endpoint(), response))
+            }
+            "canary_witness" => {
+                let client = self.read_client()?;
+                let doctor = doctor_report(&client, &self.repo_root);
+                let response = json!({
+                    "schema_version": 1,
+                    "witness": doctor.get("witness").cloned().unwrap_or(Value::Null),
+                    "receipt_run_references": doctor
+                        .pointer("/verdict/receipt_run_references")
+                        .cloned()
+                        .unwrap_or(Value::Null)
+                });
+                Ok(json_envelope("canary_witness", client.endpoint(), response))
+            }
+            "canary_dr_status" => {
+                let client = self.read_client()?;
+                let doctor = doctor_report(&client, &self.repo_root);
+                let response = json!({
+                    "schema_version": 1,
+                    "dr": doctor.get("dr").cloned().unwrap_or(Value::Null)
+                });
+                Ok(json_envelope(
+                    "canary_dr_status",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_dogfood_audit" => {
+                let strict = optional_bool(arguments, "strict")?.unwrap_or(false);
+                let response = run_dogfood_inventory(&self.repo_root, strict)?;
+                let strict_failures = dogfood_strict_failure_count(&response);
+                if strict && strict_failures > 0 {
+                    return Err(CliError::Message(format!(
+                        "dogfood strict failures: {strict_failures}"
+                    )));
+                }
+                Ok(json_envelope(
+                    "canary_dogfood_audit",
+                    &self.local_endpoint(),
+                    response,
+                ))
+            }
+            "canary_dogfood_value" => {
+                let client = self.read_client()?;
+                let service = required_string(arguments, "service")?;
+                let window = window_argument(arguments, "window", "24h")?;
+                let response = dogfood_value_report(&client, &self.repo_root, &service, window)?;
+                Ok(json_envelope(
+                    "canary_dogfood_value",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_event_capture" => {
+                let client = self.ingest_client()?;
+                let response = client.post_auth_json(
+                    "/api/v1/events",
+                    &json!({
+                        "service": required_string(arguments, "service")?,
+                        "name": required_string(arguments, "name")?,
+                        "summary": required_string(arguments, "summary")?,
+                        "severity": optional_string(arguments, "severity")?.unwrap_or_else(|| "info".to_owned()),
+                        "attributes": optional_object(arguments, "attributes")?.unwrap_or_default(),
+                        "retention_class": optional_string(arguments, "retention_class")?.unwrap_or_else(|| "standard".to_owned()),
+                        "privacy_policy": optional_string(arguments, "privacy_policy")?.unwrap_or_else(|| "redacted".to_owned()),
+                        "sampling_policy": optional_string(arguments, "sampling_policy")?.unwrap_or_else(|| "unsampled".to_owned()),
+                    }),
+                )?;
+                Ok(json_envelope(
+                    "canary_event_capture",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_claims_list" => {
+                let client = self.read_client()?;
+                let mut path = format!(
+                    "/api/v1/claims?subject_type={}&subject_id={}",
+                    encode(&required_string(arguments, "subject_type")?),
+                    encode(&required_string(arguments, "subject_id")?)
+                );
+                if let Some(limit) = optional_u16(arguments, "limit")? {
+                    path.push_str(&format!("&limit={limit}"));
+                }
+                if let Some(cursor) = optional_string(arguments, "cursor")? {
+                    path.push_str("&cursor=");
+                    path.push_str(&encode(&cursor));
+                }
+                let response = client.get_auth_json(&path)?;
+                Ok(json_envelope(
+                    "canary_claims_list",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_claim_get" => {
+                let client = self.read_client()?;
+                let claim_id = required_string(arguments, "claim_id")?;
+                let response =
+                    client.get_auth_json(&format!("/api/v1/claims/{}", encode(&claim_id)))?;
+                Ok(json_envelope(
+                    "canary_claim_get",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_claim_create" => {
+                let client = self.read_client()?;
+                let response = client.post_auth_json(
+                    "/api/v1/claims",
+                    &json!({
+                        "subject_type": required_string(arguments, "subject_type")?,
+                        "subject_id": required_string(arguments, "subject_id")?,
+                        "owner": required_string(arguments, "owner")?,
+                        "purpose": required_string(arguments, "purpose")?,
+                        "idempotency_key": required_string(arguments, "idempotency_key")?,
+                        "ttl_ms": required_i64(arguments, "ttl_ms")?,
+                        "evidence_links": optional_string_array(arguments, "evidence_links")?.unwrap_or_default(),
+                    }),
+                )?;
+                Ok(json_envelope(
+                    "canary_claim_create",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_claim_transition" => {
+                let client = self.read_client()?;
+                let claim_id = required_string(arguments, "claim_id")?;
+                let response = client.post_auth_json(
+                    &format!("/api/v1/claims/{}/transition", encode(&claim_id)),
+                    &json!({
+                        "owner": required_string(arguments, "owner")?,
+                        "state": required_string(arguments, "state")?,
+                        "evidence_links": optional_string_array(arguments, "evidence_links")?.unwrap_or_default(),
+                    }),
+                )?;
+                Ok(json_envelope(
+                    "canary_claim_transition",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_claim_release" => {
+                let client = self.read_client()?;
+                let claim_id = required_string(arguments, "claim_id")?;
+                let response = client.post_auth_json(
+                    &format!("/api/v1/claims/{}/release", encode(&claim_id)),
+                    &json!({"owner": required_string(arguments, "owner")?}),
+                )?;
+                Ok(json_envelope(
+                    "canary_claim_release",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_integrate_discover" => {
+                let endpoint = self.local_endpoint();
+                let input = integration_input_from_tool(arguments, endpoint.clone())?;
+                let response = integration_discover(&input)?;
+                Ok(json_envelope(
+                    "canary_integrate_discover",
+                    &endpoint,
+                    response,
+                ))
+            }
+            "canary_integrate_status" => {
+                let client = self.read_client()?;
+                let input = integration_input_from_tool(arguments, client.endpoint().to_owned())?;
+                let response = integration_status(&client, &input, &self.repo_root)?;
+                Ok(json_envelope(
+                    "canary_integrate_status",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_integrate_plan" => {
+                let endpoint = self.local_endpoint();
+                let input = integration_input_from_tool(arguments, endpoint.clone())?;
+                let response = integration_plan(&input)?;
+                Ok(json_envelope("canary_integrate_plan", &endpoint, response))
+            }
+            "canary_integrate_patch" => {
+                let endpoint = self.local_endpoint();
+                let input = integration_input_from_tool(arguments, endpoint.clone())?;
+                let response = integration_patch(&input)?;
+                Ok(json_envelope("canary_integrate_patch", &endpoint, response))
+            }
+            "canary_integrate_enroll" => {
+                let client = self.read_client()?;
+                let request = IntegrationEnrollRequest {
+                    service: required_string(arguments, "service")?,
+                    url: required_string(arguments, "url")?,
+                    environment: optional_string(arguments, "environment")?
+                        .unwrap_or_else(|| "production".to_owned()),
+                    interval_ms: optional_i64(arguments, "interval_ms")?,
+                    redact: !optional_bool(arguments, "show_secret")?.unwrap_or(false),
+                    receipt_root: optional_string(arguments, "project_root")?.map(PathBuf::from),
+                };
+                let response = integration_enroll(&client, &request)?;
+                Ok(json_envelope(
+                    "canary_integrate_enroll",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            _ => Err(CliError::Message(format!(
+                "unknown Canary MCP tool: {name}"
+            ))),
+        }
+    }
+
+    fn read_client(&self) -> Result<ApiClient> {
+        ApiClient::new(Config::resolve(
+            self.endpoint.clone(),
+            self.api_key.clone(),
+            self.config_path.clone(),
+        )?)
+    }
+
+    fn ingest_client(&self) -> Result<ApiClient> {
+        ApiClient::new(Config::resolve_for_ingest(
+            self.endpoint.clone(),
+            self.api_key.clone(),
+            self.config_path.clone(),
+        )?)
+    }
+
+    fn local_endpoint(&self) -> String {
+        resolve_endpoint_without_config(self.endpoint.as_deref())
+    }
+}
+
+fn integration_input_from_tool(
+    arguments: &serde_json::Map<String, Value>,
+    endpoint: String,
+) -> Result<IntegrationInput> {
+    Ok(IntegrationInput {
+        target: PathBuf::from(required_string(arguments, "path_or_project")?),
+        service: optional_string(arguments, "service")?,
+        production_url: optional_string(arguments, "production_url")?,
+        platform_project: optional_string(arguments, "platform_project")?,
+        endpoint,
+    })
+}
+
+fn window_argument(
+    arguments: &serde_json::Map<String, Value>,
+    key: &str,
+    default: &str,
+) -> Result<Window> {
+    let value = optional_string(arguments, key)?.unwrap_or_else(|| default.to_owned());
+    Window::parse(&value)
+}
+
+fn required_string(arguments: &serde_json::Map<String, Value>, key: &str) -> Result<String> {
+    optional_string(arguments, key)?
+        .ok_or_else(|| CliError::Message(format!("missing required tool argument: {key}")))
+}
+
+fn optional_string(
+    arguments: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<String>> {
+    match arguments.get(key) {
+        Some(Value::String(value)) => Ok(Some(value.to_owned())),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(CliError::Message(format!(
+            "tool argument `{key}` must be a string"
+        ))),
+    }
+}
+
+fn required_i64(arguments: &serde_json::Map<String, Value>, key: &str) -> Result<i64> {
+    optional_i64(arguments, key)?
+        .ok_or_else(|| CliError::Message(format!("missing required tool argument: {key}")))
+}
+
+fn optional_i64(arguments: &serde_json::Map<String, Value>, key: &str) -> Result<Option<i64>> {
+    match arguments.get(key) {
+        Some(Value::Number(value)) => value.as_i64().map(Some).ok_or_else(|| {
+            CliError::Message(format!("tool argument `{key}` must be a signed integer"))
+        }),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(CliError::Message(format!(
+            "tool argument `{key}` must be an integer"
+        ))),
+    }
+}
+
+fn optional_u16(arguments: &serde_json::Map<String, Value>, key: &str) -> Result<Option<u16>> {
+    match arguments.get(key) {
+        Some(Value::Number(value)) => {
+            let Some(value) = value.as_u64() else {
+                return Err(CliError::Message(format!(
+                    "tool argument `{key}` must be a positive integer"
+                )));
+            };
+            u16::try_from(value)
+                .map(Some)
+                .map_err(|_| CliError::Message(format!("tool argument `{key}` must fit in u16")))
+        }
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(CliError::Message(format!(
+            "tool argument `{key}` must be an integer"
+        ))),
+    }
+}
+
+fn optional_bool(arguments: &serde_json::Map<String, Value>, key: &str) -> Result<Option<bool>> {
+    match arguments.get(key) {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(CliError::Message(format!(
+            "tool argument `{key}` must be a boolean"
+        ))),
+    }
+}
+
+fn optional_object(
+    arguments: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<serde_json::Map<String, Value>>> {
+    match arguments.get(key) {
+        Some(Value::Object(value)) => Ok(Some(value.clone())),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(CliError::Message(format!(
+            "tool argument `{key}` must be an object"
+        ))),
+    }
+}
+
+fn optional_string_array(
+    arguments: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<Vec<String>>> {
+    match arguments.get(key) {
+        Some(Value::Array(values)) => values
+            .iter()
+            .map(|value| {
+                value.as_str().map(ToOwned::to_owned).ok_or_else(|| {
+                    CliError::Message(format!("tool argument `{key}` must be an array of strings"))
+                })
+            })
+            .collect::<Result<Vec<_>>>()
+            .map(Some),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(CliError::Message(format!(
+            "tool argument `{key}` must be an array"
+        ))),
+    }
+}
+
 /// Return the CLI-backed tool manifest.
 pub fn tool_manifest() -> Vec<ToolSpec> {
     vec![

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -1,19 +1,26 @@
 //! Command-line entrypoint for agent-native Canary inspection.
 
-use std::{env, path::PathBuf, process::ExitCode};
+use std::{
+    env,
+    io::{self, BufRead, Write},
+    path::PathBuf,
+    process::ExitCode,
+};
 
 use canary_cli::{
-    ApiClient, CliError, Config, IntegrationEnrollRequest, IntegrationInput, RenderMode, Result,
-    Window, doctor_report, dogfood_strict_failure_count, dogfood_value_report, encode,
-    find_repo_root, integration_discover, integration_enroll, integration_patch, integration_plan,
-    integration_status, json_envelope, print_json, print_lines, resolve_endpoint_without_config,
-    run_dogfood_inventory, summarize_claims, summarize_doctor, summarize_dogfood,
-    summarize_dogfood_value, summarize_event, summarize_incidents, summarize_integration,
-    summarize_monitors, summarize_query, summarize_report, summarize_services, summarize_targets,
-    summarize_timeline, tool_manifest,
+    ApiClient, CliError, Config, IntegrationEnrollRequest, IntegrationInput, McpToolContext,
+    RenderMode, Result, Window, doctor_report, dogfood_strict_failure_count, dogfood_value_report,
+    encode, find_repo_root, integration_discover, integration_enroll, integration_patch,
+    integration_plan, integration_status, json_envelope, mcp_tool_manifest, print_json,
+    print_lines, resolve_endpoint_without_config, run_dogfood_inventory, summarize_claims,
+    summarize_doctor, summarize_dogfood, summarize_dogfood_value, summarize_event,
+    summarize_incidents, summarize_integration, summarize_monitors, summarize_query,
+    summarize_report, summarize_services, summarize_targets, summarize_timeline, tool_manifest,
 };
 use clap::{Args, Parser, Subcommand};
-use serde_json::json;
+use serde_json::{Value, json};
+
+const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 
 #[derive(Debug, Parser)]
 #[command(name = "canary")]
@@ -59,6 +66,8 @@ enum Commands {
     Doctor,
     /// Emit the CLI-backed MCP tool manifest.
     McpManifest,
+    /// Run the CLI-backed MCP stdio server.
+    McpServer,
 }
 
 #[derive(Debug, Args)]
@@ -352,6 +361,7 @@ fn run() -> Result<()> {
             "schema_version": 1,
             "tools": tool_manifest()
         })),
+        Commands::McpServer => run_mcp_server(endpoint, api_key, config),
         command => run_http_command(command, endpoint, api_key, config, mode),
     }
 }
@@ -563,10 +573,159 @@ fn run_http_command(
                 summarize_doctor,
             )
         }
-        Commands::Dogfood(_) | Commands::Integrate(_) | Commands::McpManifest => {
+        Commands::Dogfood(_)
+        | Commands::Integrate(_)
+        | Commands::McpManifest
+        | Commands::McpServer => {
             unreachable!("handled before HTTP setup")
         }
     }
+}
+
+fn run_mcp_server(
+    endpoint: Option<String>,
+    api_key: Option<String>,
+    config_path: Option<PathBuf>,
+) -> Result<()> {
+    let cwd = env::current_dir().map_err(|source| CliError::Io {
+        path: PathBuf::from("."),
+        source,
+    })?;
+    let repo_root = find_repo_root(&cwd).unwrap_or(cwd);
+    let context = McpToolContext::new(endpoint, api_key, config_path, repo_root);
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+
+    for line in stdin.lock().lines() {
+        let line = line.map_err(|source| CliError::Io {
+            path: PathBuf::from("<stdin>"),
+            source,
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Value>(&line) {
+            Ok(message) => handle_mcp_message(&context, &message),
+            Err(error) => Some(jsonrpc_error(Value::Null, -32700, &error.to_string())),
+        };
+        if let Some(response) = response {
+            writeln!(stdout, "{response}").map_err(|source| CliError::Io {
+                path: PathBuf::from("<stdout>"),
+                source,
+            })?;
+            stdout.flush().map_err(|source| CliError::Io {
+                path: PathBuf::from("<stdout>"),
+                source,
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_mcp_message(context: &McpToolContext, message: &Value) -> Option<Value> {
+    let method = message.get("method").and_then(Value::as_str).unwrap_or("");
+    let id = message.get("id").cloned()?;
+
+    match method {
+        "initialize" => Some(jsonrpc_result(
+            id,
+            json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": {
+                        "listChanged": false
+                    }
+                },
+                "serverInfo": {
+                    "name": "canary",
+                    "title": "Canary",
+                    "version": env!("CARGO_PKG_VERSION")
+                },
+                "instructions": "Use Canary tools for agent-first production health inspection and remediation claims. Webhooks are wake-up hints; timeline/report replay is the correctness path."
+            }),
+        )),
+        "ping" => Some(jsonrpc_result(id, json!({}))),
+        "tools/list" => Some(jsonrpc_result(
+            id,
+            json!({
+                "tools": mcp_tool_manifest()
+            }),
+        )),
+        "tools/call" => Some(handle_mcp_tool_call(context, id, message)),
+        _ => Some(jsonrpc_error(
+            id,
+            -32601,
+            &format!("method not found: {method}"),
+        )),
+    }
+}
+
+fn handle_mcp_tool_call(context: &McpToolContext, id: Value, message: &Value) -> Value {
+    let Some(params) = message.get("params").and_then(Value::as_object) else {
+        return jsonrpc_error(id, -32602, "tools/call params must be an object");
+    };
+    let Some(name) = params.get("name").and_then(Value::as_str) else {
+        return jsonrpc_error(id, -32602, "tools/call params.name must be a string");
+    };
+    let empty_arguments = json!({});
+    let arguments = params.get("arguments").unwrap_or(&empty_arguments);
+
+    let result = match context.invoke(name, arguments) {
+        Ok(value) => mcp_tool_result(value),
+        Err(error) => mcp_tool_error(error.to_string()),
+    };
+    jsonrpc_result(id, result)
+}
+
+fn mcp_tool_result(value: Value) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": value_to_pretty_text(&value)
+        }],
+        "structuredContent": value
+    })
+}
+
+fn mcp_tool_error(message: String) -> Value {
+    let structured_content = json!({
+        "schema_version": 1,
+        "error": {
+            "message": message.clone()
+        }
+    });
+    json!({
+        "content": [{
+            "type": "text",
+            "text": message
+        }],
+        "structuredContent": structured_content,
+        "isError": true
+    })
+}
+
+fn value_to_pretty_text(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn jsonrpc_result(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn jsonrpc_error(id: Value, code: i64, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message
+        }
+    })
 }
 
 fn run_events_command(args: EventsArgs, client: &ApiClient, mode: RenderMode) -> Result<()> {

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -334,3 +334,16 @@ fn mcp_manifest_exposes_operator_drilldowns() {
         assert!(names.contains(name), "missing {name}");
     }
 }
+
+#[test]
+fn checked_in_mcp_manifest_matches_generated_manifest() -> Result<(), Box<dyn std::error::Error>> {
+    let checked_in: Value =
+        serde_json::from_str(include_str!("../../../priv/mcp/canary-cli-tools.json"))?;
+    let generated = json!({
+        "schema_version": 1,
+        "tools": tool_manifest()
+    });
+
+    assert_eq!(checked_in, generated);
+    Ok(())
+}

--- a/crates/canary-cli/tests/mcp_stdio.rs
+++ b/crates/canary-cli/tests/mcp_stdio.rs
@@ -1,0 +1,142 @@
+//! Stdio MCP smoke tests for the Canary CLI adapter.
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use serde_json::{Value, json};
+
+#[test]
+fn mcp_stdio_lists_and_calls_cli_backed_tools() -> Result<(), Box<dyn std::error::Error>> {
+    let repo_root = repo_root()?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .arg("mcp-server")
+        .current_dir(&repo_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("child stdin unavailable"))?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "canary-test", "version": "0"}
+            }
+        })
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_integrate_discover",
+                "arguments": {"path_or_project": "."}
+            }
+        })
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_not_a_tool",
+                "arguments": {}
+            }
+        })
+    )?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let responses = String::from_utf8(output.stdout)?
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        responses.len(),
+        4,
+        "initialized notification has no response"
+    );
+
+    assert_eq!(responses[0]["id"], json!(1));
+    assert_eq!(
+        responses[0]["result"]["protocolVersion"],
+        json!("2025-11-25")
+    );
+    assert_eq!(
+        responses[0]["result"]["capabilities"]["tools"]["listChanged"],
+        json!(false)
+    );
+
+    let tools = responses[1]["result"]["tools"]
+        .as_array()
+        .ok_or_else(|| std::io::Error::other("tools/list did not return a tools array"))?;
+    let discover = tools
+        .iter()
+        .find(|tool| tool["name"] == "canary_integrate_discover")
+        .ok_or_else(|| std::io::Error::other("discover tool not listed"))?;
+    assert!(discover.get("input_schema").is_none());
+    assert_eq!(discover["inputSchema"]["type"], json!("object"));
+
+    assert_eq!(responses[2]["id"], json!(3));
+    assert_eq!(responses[2]["result"]["isError"], Value::Null);
+    assert_eq!(responses[2]["result"]["content"][0]["type"], json!("text"));
+    assert_eq!(
+        responses[2]["result"]["structuredContent"]["command"],
+        json!("canary_integrate_discover")
+    );
+    assert_eq!(
+        responses[2]["result"]["structuredContent"]["response"]["schema_version"],
+        json!(1)
+    );
+    assert_eq!(responses[3]["id"], json!(4));
+    assert_eq!(responses[3]["result"]["isError"], json!(true));
+    assert_eq!(
+        responses[3]["result"]["structuredContent"]["error"]["message"],
+        json!("unknown Canary MCP tool: canary_not_a_tool")
+    );
+
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| std::io::Error::other("repo root not found").into())
+}

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -423,6 +423,19 @@ jq -e '
   and (.tools | length) >= 4
   and all(.tools[]; (.name | type == "string") and (.description | type == "string") and .input_schema.type == "object" and (.input_schema.properties | type == "object"))
 ' /tmp/canary-mcp-manifest.json
+
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"dagger-smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | bin/canary mcp-server >/tmp/canary-mcp-server.jsonl
+jq -s -e '
+  length == 2
+  and .[0].result.protocolVersion == "2025-11-25"
+  and .[0].result.capabilities.tools.listChanged == false
+  and (.[1].result.tools | type == "array")
+  and any(.[1].result.tools[]; .name == "canary_summary" and .inputSchema.type == "object")
+' /tmp/canary-mcp-server.jsonl
 `
   }
 

--- a/docs/agent-first-identity.md
+++ b/docs/agent-first-identity.md
@@ -110,7 +110,9 @@ knowing internal table names, raw route trivia, or chat-only instructions.
 - `POST /api/v1/annotations`: evidence and decisions after work.
 - `bin/canary integrate status/plan/patch/enroll`: setup loop for deployed
   services.
-- `bin/canary mcp-manifest`: machine-readable tool contract for MCP wrappers.
+- `bin/canary mcp-manifest`: machine-readable CLI tool contract snapshot.
+- `bin/canary mcp-server`: stdio MCP server over the generated CLI tool
+  contract.
 
 ## Value To Consuming Applications
 

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -49,6 +49,7 @@ bin/canary integrate patch /path/to/app --service app --json
 bin/canary integrate enroll --service app --url https://app.example.com/api/health --project-root /path/to/app --json
 bin/canary doctor --json
 bin/canary mcp-manifest
+bin/canary mcp-server
 ```
 
 Every command supports `--json`. JSON output is wrapped in a stable envelope:
@@ -237,13 +238,44 @@ secret-manager handoff.
 
 ## MCP Shape
 
-`bin/canary mcp-manifest` emits the generated tool manifest. MCP tools should shell
-out to the CLI and reuse the same JSON schemas rather than reimplementing route
-semantics.
+`bin/canary mcp-server` runs the generated CLI tool surface as a stdio MCP
+server. MCP clients should configure the command with the same environment as
+the CLI:
+
+```json
+{
+  "command": "/path/to/canary",
+  "args": ["mcp-server"],
+  "env": {
+    "CANARY_ENDPOINT": "https://canary-obs.fly.dev",
+    "CANARY_READ_API_KEY": "redacted"
+  }
+}
+```
+
+The server supports the MCP lifecycle and tool methods an agent needs for
+Canary inspection:
+
+- `initialize`
+- `notifications/initialized`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+`tools/list` is translated from the same generated CLI manifest but uses the
+MCP wire field `inputSchema`. Tool call results return a text content block and
+the CLI JSON envelope as `structuredContent`. Runtime failures, such as missing
+credentials or a Canary HTTP error, are returned as MCP tool results with
+`isError: true` so agents can self-correct without confusing tool failures with
+protocol failures.
+
+`bin/canary mcp-manifest` still emits the checked CLI manifest snapshot shape
+with `input_schema`. The checked-in snapshot at `priv/mcp/canary-cli-tools.json`
+is gated against `tool_manifest()` so it cannot drift from the runtime list.
 
 The manifest covers the drill-down surfaces an agent needs after
 `canary_doctor`: summary, services, errors, incidents, timeline, targets,
 monitors, dogfood audit, dogfood value receipts, witness, DR status, event
 capture, remediation claims, and integration discovery/status/plan/patch/enroll.
-If a future MCP server does not implement a tool directly, it must preserve the
-manifest replacement command so agents can shell out to the CLI.
+The MCP server implements those tools directly through the CLI-backed adapter;
+it does not define separate route semantics.

--- a/docs/architecture/canary-bitterblossom-triage-contract-2026-07-01.md
+++ b/docs/architecture/canary-bitterblossom-triage-contract-2026-07-01.md
@@ -1,0 +1,145 @@
+# Canary -> Bitterblossom Triage Contract
+
+Status: scoped contract for the Factory Canary lane on 2026-07-01. This
+supports Bitterblossom backlog `080` (report-only Canary triage) and `081`
+(authority ladder) without moving remediation authority into Canary.
+
+## Boundary
+
+Canary remains the observability substrate. It owns signal ingest, incident
+correlation, timeline replay, signed webhook delivery, remediation claims, and
+annotations. Bitterblossom owns the responder workload: materializing repo and
+infra context, dispatching an agent, producing `REPORT.json`, and later staging
+authority through its own policy gates.
+
+The webhook is a wake-up hint, not the context source of truth. The responder
+must query Canary before acting.
+
+## Event To Trigger Flow
+
+1. Canary records or updates a durable subject: `incident`, `error_group`,
+   `target`, or `monitor`.
+2. Canary sends the existing signed webhook payload with stable
+   `X-Delivery-Id` and timestamped HMAC headers.
+3. Bitterblossom verifies the signature and timestamp, dedupes by delivery id,
+   and writes a run-ledger row before returning success to the webhook.
+4. The `canary-triage` workload replays Canary state through MCP or CLI:
+   `canary_incidents`, `canary_timeline`, `canary_errors`,
+   `canary_services`, `canary_targets`, `canary_monitors`, and
+   `canary_claims_list`.
+5. The responder creates or observes a remediation claim before investigation:
+   `canary_claim_create` with an idempotency key derived from the BB run id and
+   Canary subject.
+6. The report-only agent investigates outside Canary and writes `REPORT.json`.
+7. The workload writes back an annotation/evidence link. At report-only
+   authority, claim changes are limited to releasing Bitterblossom's own claim
+   as a handoff marker; verification, incident resolution, branch/PR work, and
+   deploys require a higher authority level.
+
+## Minimum Trigger Payload
+
+The webhook payload must be enough to route and replay, not enough to replace
+replay:
+
+```json
+{
+  "schema_version": 1,
+  "event": "incident.opened",
+  "subject": {
+    "type": "incident",
+    "id": "INC-example",
+    "service": "canary",
+    "environment": "production"
+  },
+  "signal": {
+    "kind": "error_group|target|monitor|telemetry_event",
+    "fingerprint": "sha256-or-stable-id",
+    "severity": "info|warning|error",
+    "observed_at": "2026-07-01T00:00:00Z"
+  },
+  "replay": {
+    "timeline_url": "/api/v1/timeline?service=canary&window=1h",
+    "report_url": "/api/v1/report?window=1h",
+    "incident_url": "/api/v1/incidents/INC-example"
+  }
+}
+```
+
+If the current generic webhook payload lacks one of those fields, the
+Bitterblossom workload should treat that as a report-only setup gap and query
+the missing value by subject id. Canary should not add repo mutation commands,
+branch names, PR policy, or deployment instructions to the event.
+
+## Service To Repo Mapping
+
+Canary should carry only stable service and project identifiers. The first
+Bitterblossom implementation can use its `canary-services.toml` mapping:
+
+- `service` or `project/service` selects the target repository.
+- `environment` scopes infrastructure probes and secret-free deploy context.
+- unmapped services halt as `mapping_missing` and produce a report-only
+  artifact rather than guessing.
+
+Canary may later expose a read-only service metadata field, but it should not
+become a repo mutation router.
+
+## Authority Levels
+
+The Canary payload does not grant mutation authority. Bitterblossom controls
+the authority ladder:
+
+| Level | Name | Allowed |
+|---|---|---|
+| 0 | observe | verify webhook, replay Canary, inspect repo/infra context |
+| 1 | report_only | write `REPORT.json`, annotations, and claim evidence |
+| 2 | branch_pr | create a branch/PR after report-only scorecard is green |
+| 3 | guarded_land | merge only with CI, fresh review, Canary sanity, and policy gate |
+| 4 | own_change_rollback | revert only the responder's own last known change after sanity failure |
+
+Automatic promotion is forbidden. Canary evidence can make the next authority
+level eligible; it cannot approve it.
+
+## Report-Only `REPORT.json`
+
+The first workload must produce:
+
+```json
+{
+  "schema_version": 1,
+  "canary_subject": {"type": "incident", "id": "INC-example"},
+  "delivery_id": "WHK-delivery",
+  "bb_run_id": "run-example",
+  "service": "canary",
+  "repo": "misty-step/canary",
+  "summary": "what happened",
+  "evidence": [
+    {"source": "canary_timeline", "ref": "timeline cursor or URL"},
+    {"source": "canary_errors", "ref": "ERR or group hash"}
+  ],
+  "hypotheses": [
+    {"claim": "likely cause", "confidence": "low|medium|high", "why": "bounded rationale"}
+  ],
+  "suspected_files_or_services": [],
+  "recommended_next_commands": [],
+  "residual_uncertainty": []
+}
+```
+
+The report is invalid if the run changed code, pushed a branch, deployed, or
+resolved the incident.
+
+## Verification
+
+- Replay fixture Canary payload through Bitterblossom manual run:
+  `bb run canary-triage --payload-file <fixture> --json`.
+- Confirm the BB run ledger has one accepted run and no duplicate run for the
+  same delivery id.
+- Confirm `REPORT.json` links the Canary subject, delivery id, service, repo,
+  evidence sources, hypotheses, and residual uncertainty.
+- Confirm the target repo has no diff and no outward side effects except
+  Canary claim/annotation evidence.
+- Confirm Canary timeline can replay the claim and evidence write-back.
+
+This contract should be revisited when Canary backlog `048` defines narrower
+responder-write authority. Until then, report-only dogfood should use existing
+read/admin credentials with explicit containment in Bitterblossom.

--- a/docs/architecture/canary-mcp-server-triage-landmark-plan-2026-07-01.html
+++ b/docs/architecture/canary-mcp-server-triage-landmark-plan-2026-07-01.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Canary 052 Plan</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f7f4ec;
+      --ink: #191714;
+      --muted: #625d53;
+      --panel: #fffaf0;
+      --line: #ded4c2;
+      --accent: #255c75;
+      --warn: #9b4d2c;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #121418;
+        --ink: #ece5d7;
+        --muted: #aaa295;
+        --panel: #1b1f26;
+        --line: #303742;
+        --accent: #76b7d1;
+        --warn: #e08a65;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      width: min(76rem, calc(100% - 2rem));
+      margin: 0 auto;
+      padding: 2rem 0 4rem;
+    }
+    h1, h2, h3 { line-height: 1.15; margin: 0; }
+    h1 { font-size: clamp(2rem, 5vw, 4rem); letter-spacing: 0; }
+    h2 { font-size: 0.78rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); }
+    h3 { font-size: 1rem; margin-top: 1rem; }
+    p { margin: 0.55rem 0 0; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9em; }
+    .hero {
+      min-height: 52vh;
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(22rem, 0.8fr);
+      gap: 2rem;
+      align-items: end;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 2rem;
+    }
+    .lede { color: var(--muted); font-size: 1.12rem; max-width: 58rem; }
+    .panel, .cell {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      padding: 1rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1px;
+      background: var(--line);
+      border: 1px solid var(--line);
+      margin-top: 1.5rem;
+    }
+    .grid .cell { border: 0; }
+    .two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .warn { color: var(--warn); font-weight: 650; }
+    ul { margin: 0.5rem 0 0; padding-left: 1.1rem; }
+    li { margin: 0.35rem 0; }
+    @media (max-width: 860px) {
+      .hero, .grid, .two { grid-template-columns: 1fr; }
+      .hero { min-height: auto; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <div>
+      <h2>Backlog 052 + 057 / Factory Canary Lane</h2>
+      <h1>Ship a real Canary MCP server without creating a second semantic API.</h1>
+      <p class="lede">
+        Canary already owns the agent contract in the Rust CLI: <code>tool_manifest()</code>,
+        JSON envelopes, scoped HTTP operations, and deterministic summaries. The chosen
+        design is a stdio MCP adapter inside <code>canary</code> that translates the generated
+        CLI manifest into MCP <code>tools/list</code> shape and dispatches <code>tools/call</code>
+        through the same CLI-backed functions.
+      </p>
+    </div>
+    <aside class="panel">
+      <h2>Quality System</h2>
+      <p><strong>Outcome:</strong> an MCP client can initialize, list Canary tools, and call a read-only tool.</p>
+      <p><strong>Standards:</strong> one generated tool source, no LLM on request path, no new responder authority, no stale manifest.</p>
+      <p><strong>Proof:</strong> MCP JSON-RPC smoke, manifest parity test, focused Rust tests, repo gate.</p>
+      <p><strong>Critic:</strong> fresh diff-only review focused on protocol drift, auth leakage, and shallow adapters.</p>
+      <p><strong>Stop:</strong> halt if the wrapper needs a parallel tool registry or claims responder safety beyond current scopes.</p>
+    </aside>
+  </section>
+
+  <section class="grid">
+    <article class="cell">
+      <h2>Current State</h2>
+      <p><code>bin/canary mcp-manifest</code> emits a CLI-backed manifest, but the checked-in snapshot is stale and no MCP server runs.</p>
+    </article>
+    <article class="cell">
+      <h2>Change Shape</h2>
+      <p>Add <code>canary mcp-server</code>, a smokeable stdio JSON-RPC server, generated <code>tools/list</code>, dispatch for existing manifest tools, docs, and snapshot parity.</p>
+    </article>
+    <article class="cell">
+      <h2>Out Of Scope</h2>
+      <p>No new responder-write scope, no browser capture authority, no autonomous repo mutation, no separate MCP-only business logic.</p>
+    </article>
+  </section>
+
+  <section class="grid two">
+    <article class="cell">
+      <h2>Verification System</h2>
+      <ul>
+        <li><strong>Claim:</strong> Canary exposes a runnable MCP surface over the CLI contract.</li>
+        <li><strong>Falsifier:</strong> <code>tools/list</code> differs from the generated manifest or <code>tools/call</code> cannot invoke a read-only command.</li>
+        <li><strong>Driver:</strong> feed initialize, initialized, <code>tools/list</code>, and <code>tools/call</code> JSON-RPC lines into <code>canary mcp-server</code>.</li>
+        <li><strong>Grader:</strong> MCP result has <code>inputSchema</code>, text content, structured content, and no secret leakage.</li>
+        <li><strong>Evidence:</strong> checked test fixture and command transcript in closeout.</li>
+      </ul>
+    </article>
+    <article class="cell">
+      <h2>Landmark Integration</h2>
+      <p>Add a release workflow that waits for Canary CI success on <code>master</code>, checks out full history, and runs <code>misty-step/landmark@v1</code> with <code>GH_RELEASE_TOKEN</code>, optional <code>OPENROUTER_API_KEY</code>, Node 24, and synthesis enabled but non-blocking.</p>
+    </article>
+  </section>
+
+  <section class="grid two">
+    <article class="cell">
+      <h2>Bitterblossom Trigger Contract</h2>
+      <p>Document the event path: signed Canary webhook is wake-up only; responder verifies signature and delivery id, queries Canary for timeline/report/context, creates a remediation claim, acts outside Canary, then writes annotations and claim evidence back.</p>
+    </article>
+    <article class="cell">
+      <h2>Risk Focus</h2>
+      <p class="warn">MCP is allowed to be an adapter, not an excuse to widen authority.</p>
+      <p>Tool errors should be MCP tool results with <code>isError</code>; protocol errors should stay JSON-RPC errors. Secret-bearing config values must never appear in responses or docs.</p>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "tools": [
     {
-      "description": "Inspect global Canary status for a query window.",
+      "description": "Inspect global Canary status for a query window, including per-service SLIs, SLO targets, and prior-window trajectory deltas.",
       "input_schema": {
         "properties": {
           "window": {
@@ -46,12 +46,203 @@
       "name": "canary_errors"
     },
     {
+      "description": "List target and monitor service states from `bin/canary services`.",
+      "input_schema": {
+        "properties": {
+          "state": {
+            "enum": [
+              "up",
+              "degraded",
+              "down",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "window": {
+            "enum": [
+              "1h",
+              "6h",
+              "24h",
+              "7d",
+              "30d"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "name": "canary_services"
+    },
+    {
+      "description": "Inspect active incidents from `bin/canary incidents`; use this after doctor reports an open Canary incident.",
+      "input_schema": {
+        "properties": {
+          "open": {
+            "default": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "name": "canary_incidents"
+    },
+    {
+      "description": "Inspect timeline events globally or for one service.",
+      "input_schema": {
+        "properties": {
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "service": {
+            "type": "string"
+          },
+          "window": {
+            "enum": [
+              "1h",
+              "6h",
+              "24h",
+              "7d",
+              "30d"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "name": "canary_timeline"
+    },
+    {
+      "description": "List configured HTTP uptime targets.",
+      "input_schema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "canary_targets"
+    },
+    {
+      "description": "List configured non-HTTP monitors and check-in watchers.",
+      "input_schema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "canary_monitors"
+    },
+    {
       "description": "Run the agent-oriented Canary doctor check.",
       "input_schema": {
         "properties": {},
         "type": "object"
       },
       "name": "canary_doctor"
+    },
+    {
+      "description": "Inspect the external `canary-watchman` state and GitHub Actions receipt refs; replacement command: `bin/canary doctor --json | jq '.response.witness,.response.verdict.receipt_run_references'`.",
+      "input_schema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "canary_witness"
+    },
+    {
+      "description": "Inspect DR/Litestream evidence surfaced by doctor; replacement command: `bin/canary doctor --json | jq '.response.dr'`.",
+      "input_schema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "canary_dr_status"
+    },
+    {
+      "description": "Run deployed-service dogfood coverage audit; strict mode exits nonzero after printing JSON gaps.",
+      "input_schema": {
+        "properties": {
+          "strict": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "name": "canary_dogfood_audit"
+    },
+    {
+      "description": "Build one per-service dogfood value receipt from coverage, health, errors, incidents, claims, annotations, telemetry, and verification evidence.",
+      "input_schema": {
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "window": {
+            "enum": [
+              "1h",
+              "6h",
+              "24h",
+              "7d",
+              "30d"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "service"
+        ],
+        "type": "object"
+      },
+      "name": "canary_dogfood_value"
+    },
+    {
+      "description": "Capture one bounded analytics event as a telemetry.event timeline row.",
+      "input_schema": {
+        "properties": {
+          "attributes": {
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "privacy_policy": {
+            "enum": [
+              "redacted",
+              "public",
+              "sensitive"
+            ],
+            "type": "string"
+          },
+          "retention_class": {
+            "enum": [
+              "ephemeral",
+              "standard",
+              "audit"
+            ],
+            "type": "string"
+          },
+          "sampling_policy": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "info",
+              "warning",
+              "error"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "service",
+          "name",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "name": "canary_event_capture"
     },
     {
       "description": "List remediation claims for one Canary subject.",


### PR DESCRIPTION
## Summary
- Ships `canary mcp-server`, a JSON-RPC stdio MCP server over the generated Canary CLI tool manifest.
- Dispatches MCP `tools/call` through the same CLI/API logic used by the static manifest, returning structured success and error content.
- Regenerates and gates the checked-in MCP manifest snapshot, adds a Dagger MCP smoke, and documents the Bitterblossom report-only triage contract.
- Integrates Landmark release automation via `misty-step/landmark@v1`, gated to successful push CI on `master` or manual dispatch.

## Verification
- Red first: `cargo test -p canary-cli --test mcp_stdio mcp_stdio_lists_and_calls_cli_backed_tools --locked` failed before implementation because `mcp-server` did not exist.
- Red first: `cargo test -p canary-cli --test fixtures checked_in_mcp_manifest_matches_generated_manifest --locked` failed before manifest regeneration because the checked-in snapshot lagged generated tools.
- `cargo test -p canary-cli --test mcp_stdio --locked`
- `cargo test -p canary-cli --test mcp_stdio --test fixtures mcp --locked`
- `cargo test -p canary-cli --locked`
- `cargo clippy -p canary-cli --all-targets --locked -- -D warnings`
- Live stdio smoke through `./bin/canary mcp-server` verified initialize, `tools/list`, `inputSchema`, and response count.
- `./bin/validate`
- Commit hook `Ci.fast`
- Push hook `./bin/validate --strict`
- Fresh critic reviewed the diff and found a Landmark workflow gating issue; the workflow condition was fixed and the targeted re-review returned no blocking findings.

## Notes
- The advisory gate still reports the existing allowed `RUSTSEC-2026-0190` warning for `anyhow`.
- Local branch is clean and synced with `origin/factory/mcp-server-triage-landmark` before PR creation.

## Agent Attribution
Agent: Codex
Agent-Surface: Codex CLI
Agent-Runner: Codex API
Agent-Model: GPT-5
Agent-Task: factory/canary-mcp-server-triage-landmark
Agent-Context: branch factory/mcp-server-triage-landmark
