### PR TITLE
chore(backlog): track anyhow RustSec bump

### DIFF
--- a/backlog.d/059-rustsec-anyhow-bump.md
+++ b/backlog.d/059-rustsec-anyhow-bump.md
@@ -1,0 +1,33 @@
+# Bump anyhow after RUSTSEC-2026-0190
+
+Priority: P2 · Status: pending · Estimate: S
+
+## Goal
+Curate the dependency bump that clears `RUSTSEC-2026-0190` for `anyhow`
+without turning the advisory fix into an unreviewed lockfile churn pile.
+
+## Why now
+The 2026-07-01 strict gate reports `RUSTSEC-2026-0190` as an allowed warning
+for `anyhow 1.0.102`: unsoundness in `Error::downcast_mut()`. It is currently
+allowed by the advisory lane, but the warning should not become permanent
+background noise.
+
+## Oracle
+- [ ] `cargo update -p anyhow` or the smallest equivalent curated update clears
+      `RUSTSEC-2026-0190`.
+- [ ] `./bin/validate --advisories` no longer reports the warning.
+- [ ] `./bin/validate` passes after the lockfile change.
+- [ ] The PR body names the advisory id and the exact dependency delta.
+
+## Verification System
+- Claim: the advisory is resolved by a narrow dependency update.
+- Falsifier: the update leaves the advisory present, pulls unrelated major
+  dependency churn, or requires lowering gates.
+- Driver: advisory scan before/after plus the normal Canary validation gate.
+- Grader: advisory absent, lockfile diff reviewed, and strict gate green.
+- Evidence packet: `cargo update` transcript, advisory scan output, and
+  `./bin/validate` transcript.
+
+## Notes
+This is deliberately separate from feature work. Dependency upgrades ride as
+one curated, risk-assessed commit.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -56,6 +56,7 @@
 | 056 | Lower /api/v1/report store-lock contention + dedup SLI owner-scope | P2 | pending | M |
 | 057 | Static MCP manifest parity | P1 | done | S |
 | 058 | Cadence-aware SLI trajectory sample floor | P2 | pending | M |
+| 059 | Bump anyhow after RUSTSEC-2026-0190 | P2 | pending | S |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
 | 010 | Ramp pattern (north star) | high | blocked | XL |
 
@@ -107,6 +108,7 @@
 046 ──→ 047 (shipped) ──→ 048 ──→ Bitterblossom 055 ──→ 049 ──→ 010
 049 + shipped 052/057 ──→ 050 (readiness proof consumes the integration and MCP surfaces; 047 alert-plane surface is already real)
 058 follows 047 as quality tuning; it does not block 048/049/050 unless trajectory sufficiency becomes a readiness proof requirement
+059 tracks the allowed `RUSTSEC-2026-0190` advisory for `anyhow`; keep it as a curated dependency bump, not mixed into feature work
 ```
 
 ## Execution Lanes


### PR DESCRIPTION
## Summary
- record `RUSTSEC-2026-0190` for `anyhow 1.0.102` as a later curated dependency bump
- add the item to the backlog priority map without changing dependencies in the live triage lane

## Verification
- `./bin/validate --fast`
- pre-push `./bin/validate --strict` completed in 5m44s
- strict surfaced the expected allowed advisory warning for `RUSTSEC-2026-0190`, now tracked by this backlog note
