### PR TITLE
docs(ops): make cold-operator deploy explicit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,13 +12,14 @@ concurrency:
 
 jobs:
   core:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && (github.repository == 'misty-step/canary' || vars.CANARY_FLY_APP != '')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --app "$FLY_APP" --remote-only
         env:
+          FLY_APP: ${{ vars.CANARY_FLY_APP || 'canary-obs' }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -11,12 +11,14 @@ concurrency:
 
 jobs:
   witness:
+    if: github.repository == 'misty-step/canary' || vars.CANARY_WITNESS_ENDPOINT != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
     env:
-      CANARY_WITNESS_ENDPOINT: https://canary-obs.fly.dev
+      CANARY_WITNESS_ENDPOINT: ${{ vars.CANARY_WITNESS_ENDPOINT || 'https://canary-obs.fly.dev' }}
+      CANARY_FLY_APP: ${{ vars.CANARY_FLY_APP || 'canary-obs' }}
       CANARY_WITNESS_MONITOR: canary-watchman
       CANARY_WITNESS_TTL_MS: "7200000"
       CANARY_WITNESS_READ_KEY: ${{ secrets.CANARY_WITNESS_READ_KEY }}
@@ -125,8 +127,8 @@ jobs:
           ### Runbook
 
           1. Check the uploaded \`canary-witness-receipt.json\` artifact.
-          2. Check Fly.io machine status: \`flyctl status --app canary-obs\`
-          3. Check logs: \`flyctl logs --app canary-obs\`
+          2. Check Fly.io machine status: \`flyctl status --app $CANARY_FLY_APP\`
+          3. Check logs: \`flyctl logs --app $CANARY_FLY_APP\`
           4. Check recent self-errors: \`bin/canary errors canary --window 1h\`
           5. If DB corruption is suspected, see \`docs/backup-restore-dr.md\`.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ entrypoint. See [docs/ci-control-plane.md](docs/ci-control-plane.md).
 Canary's MCP surface is the CLI contract served over stdio:
 
 ```bash
-CANARY_ENDPOINT=https://canary-obs.fly.dev \
+CANARY_ENDPOINT="https://<your-fly-app>.fly.dev" \
 CANARY_READ_API_KEY=... \
 bin/canary mcp-server
 ```
@@ -204,6 +204,12 @@ The machine-readable contract lives at `GET /api/v1/openapi.json`. That
 endpoint, `/healthz`, and `/readyz` are public. The contract embeds the
 canonical agent replay guide in `info.x-agent-guide`.
 
+Set the instance endpoint before running API examples:
+
+```bash
+export CANARY_ENDPOINT="https://<your-fly-app>.fly.dev"
+```
+
 All other endpoints require a scoped API key:
 
 - `ingest-only` for `POST /api/v1/errors` and `POST /api/v1/check-ins`
@@ -215,7 +221,7 @@ Manual rotation steps live in [docs/api-key-rotation.md](docs/api-key-rotation.m
 ### Error Ingestion
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/errors \
+curl -X POST $CANARY_ENDPOINT/api/v1/errors \
   -H "Authorization: Bearer $CANARY_INGEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -237,18 +243,18 @@ Response: `201 Created`
 
 ```bash
 # Recent errors for a service
-curl "https://canary-obs.fly.dev/api/v1/query?service=cadence&window=1h" \
+curl "$CANARY_ENDPOINT/api/v1/query?service=cadence&window=1h" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 
 # Error detail
-curl "https://canary-obs.fly.dev/api/v1/errors/ERR-a1b2c3" \
+curl "$CANARY_ENDPOINT/api/v1/errors/ERR-a1b2c3" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 ```
 
 ### Health Status
 
 ```bash
-curl "https://canary-obs.fly.dev/api/v1/health-status" \
+curl "$CANARY_ENDPOINT/api/v1/health-status" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 ```
 
@@ -264,7 +270,7 @@ Response includes natural-language summary:
 ### Unified Report
 
 ```bash
-curl "https://canary-obs.fly.dev/api/v1/report?window=1h" \
+curl "$CANARY_ENDPOINT/api/v1/report?window=1h" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 ```
 
@@ -334,7 +340,7 @@ service binding, and is not advanced by `report.cursor`:
 ### Timeline
 
 ```bash
-curl "https://canary-obs.fly.dev/api/v1/timeline?service=volume&window=24h&limit=50" \
+curl "$CANARY_ENDPOINT/api/v1/timeline?service=volume&window=24h&limit=50" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 ```
 
@@ -344,7 +350,7 @@ timeline queries and outbound webhook deliveries.
 Optional free-text error search stays on the same endpoint:
 
 ```bash
-curl "https://canary-obs.fly.dev/api/v1/report?window=1h&q=timeout" \
+curl "$CANARY_ENDPOINT/api/v1/report?window=1h&q=timeout" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 ```
 
@@ -377,7 +383,7 @@ health target, generates a fresh ingest key, and returns exact copy/paste
 snippets for reporting errors and verifying the service in Canary.
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/service-onboarding \
+curl -X POST $CANARY_ENDPOINT/api/v1/service-onboarding \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"service": "my-api", "url": "https://my-api.fly.dev/health", "environment": "production"}'
@@ -406,7 +412,7 @@ check-in monitors managed separately from URL-backed targets.
 
 ```bash
 # Create a schedule-based monitor
-curl -X POST https://canary-obs.fly.dev/api/v1/monitors \
+curl -X POST $CANARY_ENDPOINT/api/v1/monitors \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -418,7 +424,7 @@ curl -X POST https://canary-obs.fly.dev/api/v1/monitors \
   }'
 
 # Report a healthy check-in
-curl -X POST https://canary-obs.fly.dev/api/v1/check-ins \
+curl -X POST $CANARY_ENDPOINT/api/v1/check-ins \
   -H "Authorization: Bearer $CANARY_INGEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -437,13 +443,13 @@ Crash or exception telemetry still belongs on `POST /api/v1/errors`.
 
 ```bash
 # Add target
-curl -X POST https://canary-obs.fly.dev/api/v1/targets \
+curl -X POST $CANARY_ENDPOINT/api/v1/targets \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "my-api", "service": "my-api", "url": "https://my-api.fly.dev/health", "interval_ms": 60000}'
 
 # List / pause / resume / delete
-curl https://canary-obs.fly.dev/api/v1/targets -H "Authorization: Bearer $CANARY_ADMIN_KEY"
+curl $CANARY_ENDPOINT/api/v1/targets -H "Authorization: Bearer $CANARY_ADMIN_KEY"
 curl -X POST .../targets/:id/pause
 curl -X POST .../targets/:id/resume
 curl -X DELETE .../targets/:id
@@ -453,8 +459,8 @@ curl -X DELETE .../targets/:id
 
 ```bash
 # List / create / delete monitors
-curl https://canary-obs.fly.dev/api/v1/monitors -H "Authorization: Bearer $CANARY_ADMIN_KEY"
-curl -X POST https://canary-obs.fly.dev/api/v1/monitors \
+curl $CANARY_ENDPOINT/api/v1/monitors -H "Authorization: Bearer $CANARY_ADMIN_KEY"
+curl -X POST $CANARY_ENDPOINT/api/v1/monitors \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "desktop-active-timer", "mode": "ttl", "expected_every_ms": 60000, "grace_ms": 15000}'
@@ -464,19 +470,19 @@ curl -X DELETE .../monitors/:id
 ### Webhook Management
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/webhooks \
+curl -X POST $CANARY_ENDPOINT/api/v1/webhooks \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com/hook", "events": ["health_check.down", "error.new_class"]}'
 
-curl "https://canary-obs.fly.dev/api/v1/webhook-deliveries?webhook_id=WHK-abc123&limit=20" \
+curl "$CANARY_ENDPOINT/api/v1/webhook-deliveries?webhook_id=WHK-abc123&limit=20" \
   -H "Authorization: Bearer $CANARY_READ_KEY"
 ```
 
 ### API Key Management
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/keys \
+curl -X POST $CANARY_ENDPOINT/api/v1/keys \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "cadence-prod", "scope": "read-only"}'
@@ -515,11 +521,28 @@ All webhooks are HMAC-SHA256 signed. Secret returned on subscription creation.
 
 ## Deployment
 
-Deployed to Fly.io with SQLite persistence and a Fly Tigris-backed Litestream
-restore path.
+Deploy to Fly.io with SQLite persistence and a Fly Tigris-backed Litestream
+restore path. A full cold-operator runbook lives in
+[docs/self-host-fly.md](docs/self-host-fly.md).
 
 ```bash
-flyctl deploy --app canary-obs
+export CANARY_FLY_APP="<your-fly-app>"
+export CANARY_ENDPOINT="https://${CANARY_FLY_APP}.fly.dev"
+flyctl deploy --app "$CANARY_FLY_APP" --remote-only
+```
+
+On first boot, capture the one-time bootstrap admin key from Fly logs:
+
+```bash
+flyctl logs --app "$CANARY_FLY_APP" --no-tail | rg 'Bootstrap API key:'
+```
+
+If the first boot log was missed, mint a replacement admin key without data
+loss:
+
+```bash
+flyctl ssh console --app "$CANARY_FLY_APP" \
+  -C '/app/bin/canary-server mint-key --scope admin --name operator-recovery'
 ```
 
 DR verification and restore procedures live in [docs/backup-restore-dr.md](docs/backup-restore-dr.md).
@@ -527,7 +550,7 @@ Use `bin/dr-status` for a read-only Litestream preflight and
 `bin/dr-restore-check` for a non-destructive restore drill against the running
 Fly app.
 On a fresh Fly app, enable the same path with
-`flyctl storage create --app canary-obs --name canary-obs-backups --yes`, then
+`flyctl storage create --app "$CANARY_FLY_APP" --name "$CANARY_FLY_APP-backups" --yes`, then
 re-run the two verification commands. See the DR runbook for the latest live
 verification status.
 

--- a/backlog.d/060-cold-operator-deploy-path.md
+++ b/backlog.d/060-cold-operator-deploy-path.md
@@ -51,6 +51,14 @@ only when the Adminifi/R90 deployment proof supersedes it with concrete
 evidence. Historical `canary-obs` evidence files can remain historical; product
 defaults and current docs should not require that instance.
 
+## Progress
+- 2026-07-01: Added the first cold-operator docs/script slice: public Fly
+  self-host guide, README bootstrap-key recovery path, fork-safe deploy and
+  witness workflow guards, and explicit endpoint/app requirements for witness,
+  DR, and write-path rehearsal scripts. The epic remains open; Rust CLI
+  compiled defaults, `fly.toml`, dogfood instance data, and clean-room
+  deployment evidence still need follow-up.
+
 ## Children
 1. Document first-key and lost-key recovery in README and key-rotation docs.
 2. Add a fresh Fly deploy guide covering app creation, volume, Tigris, secrets,

--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_ENDPOINT="https://canary-obs.fly.dev"
-ENDPOINT="${CANARY_WITNESS_ENDPOINT:-${CANARY_ENDPOINT:-$DEFAULT_ENDPOINT}}"
+ENDPOINT="${CANARY_WITNESS_ENDPOINT:-${CANARY_ENDPOINT:-}}"
 READ_API_KEY="${CANARY_WITNESS_READ_KEY:-${CANARY_READ_API_KEY:-${CANARY_READ_KEY:-${CANARY_API_KEY:-}}}}"
 INGEST_API_KEY="${CANARY_WITNESS_INGEST_KEY:-${CANARY_INGEST_API_KEY:-${CANARY_API_KEY:-}}}"
 MONITOR="${CANARY_WITNESS_MONITOR:-canary-watchman}"
@@ -118,6 +117,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 validate_positive_millis "ttl-ms" "$CHECK_IN_TTL_MS"
+if [[ -z "$ENDPOINT" ]]; then
+  printf 'canary-witness: missing endpoint: pass --endpoint or set CANARY_WITNESS_ENDPOINT/CANARY_ENDPOINT\n' >&2
+  exit 2
+fi
 require_command jq
 require_command "$CURL_BIN"
 

--- a/bin/canary-write-path-rehearsal
+++ b/bin/canary-write-path-rehearsal
@@ -7,7 +7,7 @@ ENDPOINT="${CANARY_ENDPOINT:-}"
 API_KEY="${CANARY_API_KEY:-}"
 WEBHOOK_URL="${CANARY_REHEARSAL_WEBHOOK_URL:-https://httpbingo.org/status/204}"
 TARGET_URL="${CANARY_REHEARSAL_TARGET_URL:-}"
-APP="${FLY_APP:-canary-obs}"
+APP="${CANARY_FLY_APP:-${FLY_APP:-}}"
 PREFIX=""
 JSON_OUTPUT=0
 RUN_DR_STATUS=1
@@ -626,6 +626,9 @@ require_command date
 
 [[ -n "$ENDPOINT" ]] || fail "Missing Canary endpoint. Set CANARY_ENDPOINT or pass --endpoint."
 [[ -n "$API_KEY" ]] || fail "Missing Canary API key. Set CANARY_API_KEY or pass --api-key."
+if ((RUN_DR_STATUS == 1)) && [[ -z "$APP" ]]; then
+  fail "Missing Fly app. Set CANARY_FLY_APP/FLY_APP, pass --app, or pass --no-dr-status."
+fi
 [[ "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || fail "--poll-attempts must be a positive integer."
 [[ "$POLL_SLEEP" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail "--poll-sleep must be a non-negative number."
 

--- a/bin/dr-restore-check
+++ b/bin/dr-restore-check
@@ -47,6 +47,7 @@ while (($#)); do
   esac
 done
 
+APP="$(dr_require_app "$APP")"
 dr_require_command flyctl
 
 dr_fly_ssh "$APP" "$(dr_restore_remote_command "$DB_PATH")"

--- a/bin/dr-status
+++ b/bin/dr-status
@@ -38,6 +38,7 @@ while (($#)); do
   esac
 done
 
+APP="$(dr_require_app "$APP")"
 dr_require_command flyctl
 
 dr_fly_ssh "$APP" "$(dr_status_remote_command)"

--- a/bin/lib/dr.sh
+++ b/bin/lib/dr.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
 dr_default_app() {
-  printf '%s\n' "${FLY_APP:-canary-obs}"
+  printf '%s\n' "${CANARY_FLY_APP:-${FLY_APP:-}}"
+}
+
+dr_require_app() {
+  local app="$1"
+
+  if [ -z "$app" ]; then
+    printf 'Missing Fly app: pass --app or set CANARY_FLY_APP/FLY_APP\n' >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$app"
 }
 
 dr_default_db_path() {

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -3488,11 +3488,23 @@ fn run_dr_status(repo_root: &Path) -> Value {
             "reason": "bin/dr-status not found"
         });
     }
+    let Some(app) = env::var("CANARY_FLY_APP")
+        .ok()
+        .or_else(|| env::var("FLY_APP").ok())
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return json!({
+            "ok": false,
+            "reason": "CANARY_FLY_APP/FLY_APP not configured",
+            "command": "NO_COLOR=1 bin/dr-status --app <fly-app>"
+        });
+    };
+    let command_display = format!("NO_COLOR=1 bin/dr-status --app {app}");
     match Command::new(&program)
         .current_dir(repo_root)
         .env("NO_COLOR", "1")
         .arg("--app")
-        .arg("canary-obs")
+        .arg(&app)
         .output()
     {
         Ok(output) => json!({
@@ -3501,14 +3513,14 @@ fn run_dr_status(repo_root: &Path) -> Value {
                 .status
                 .code()
                 .map_or_else(|| "signal".to_owned(), |code| code.to_string()),
-            "command": "NO_COLOR=1 bin/dr-status --app canary-obs",
+            "command": command_display,
             "stdout": redact_text(&String::from_utf8_lossy(&output.stdout)),
             "stderr": redact_text(&String::from_utf8_lossy(&output.stderr))
         }),
         Err(error) => json!({
             "ok": false,
             "reason": error.to_string(),
-            "command": "NO_COLOR=1 bin/dr-status --app canary-obs"
+            "command": command_display
         }),
     }
 }

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -10,7 +10,8 @@ inventory command; it does not create a second semantic API.
 
 The CLI reads:
 
-- `CANARY_ENDPOINT`, defaulting to `https://canary-obs.fly.dev`
+- `CANARY_ENDPOINT` for the target Canary instance. Self-hosted operators
+  should set this explicitly and should not rely on compiled legacy defaults.
 - `CANARY_ADMIN_API_KEY`, `CANARY_ADMIN_KEY`, `CANARY_READ_API_KEY`,
   `CANARY_READ_KEY`, or `CANARY_API_KEY`
 - `CANARY_CONFIG`, or `~/.config/canary/config.json`
@@ -19,7 +20,7 @@ Config JSON:
 
 ```json
 {
-  "endpoint": "https://canary-obs.fly.dev",
+  "endpoint": "https://<your-fly-app>.fly.dev",
   "admin_api_key": "sk_live_...",
   "read_api_key": "sk_live_..."
 }
@@ -58,7 +59,7 @@ Every command supports `--json`. JSON output is wrapped in a stable envelope:
 {
   "schema_version": 1,
   "command": "summary",
-  "endpoint": "https://canary-obs.fly.dev",
+  "endpoint": "$CANARY_ENDPOINT",
   "response": {}
 }
 ```
@@ -166,7 +167,7 @@ dr: litestream ok, restore_receipt_missing: no architecture DR receipt found, fa
 ```
 
 The `dr` line is data, not a request-path dependency. It runs the operator
-`bin/dr-status --app canary-obs` check when available and points to the latest
+`bin/dr-status --app "$CANARY_FLY_APP"` check when available and points to the latest
 checked-in restore-specific receipt when one exists. Production startup can be
 made fail-closed on backup configuration with `CANARY_REQUIRE_LITESTREAM=1`.
 
@@ -247,7 +248,7 @@ the CLI:
   "command": "/path/to/canary",
   "args": ["mcp-server"],
   "env": {
-    "CANARY_ENDPOINT": "https://canary-obs.fly.dev",
+    "CANARY_ENDPOINT": "https://<your-fly-app>.fly.dev",
     "CANARY_READ_API_KEY": "redacted"
   }
 }

--- a/docs/api-key-rotation.md
+++ b/docs/api-key-rotation.md
@@ -11,14 +11,19 @@ Manual rotation is the supported path for now.
 ## Prerequisites
 
 - An existing `admin` key with permission to create and revoke keys
+- `CANARY_ENDPOINT` set to the operator's Canary instance, for example
+  `https://<your-fly-app>.fly.dev`
 - A confirmed inventory of the services or operators using the key you want to rotate
+
+If the original bootstrap admin key was missed, recover a replacement with the
+no-data-loss path in [docs/self-host-fly.md](self-host-fly.md#deploy-and-capture-the-first-admin-key).
 
 ## Rotate An Ingest Key
 
 1. Create a replacement key with the same scope:
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/keys \
+curl -X POST $CANARY_ENDPOINT/api/v1/keys \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "billing-api-ingest-2026-04", "scope": "ingest-only"}'
@@ -29,7 +34,7 @@ curl -X POST https://canary-obs.fly.dev/api/v1/keys \
 4. Revoke the old key after the new key is live everywhere:
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/keys/KEY-old/revoke \
+curl -X POST $CANARY_ENDPOINT/api/v1/keys/KEY-old/revoke \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY"
 ```
 
@@ -38,7 +43,7 @@ curl -X POST https://canary-obs.fly.dev/api/v1/keys/KEY-old/revoke \
 1. Create the replacement with the same scope:
 
 ```bash
-curl -X POST https://canary-obs.fly.dev/api/v1/keys \
+curl -X POST $CANARY_ENDPOINT/api/v1/keys \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "ops-read-2026-04", "scope": "read-only"}'

--- a/docs/backup-restore-dr.md
+++ b/docs/backup-restore-dr.md
@@ -1,9 +1,16 @@
 # Backup, Restore, and DR
 
-This runbook covers Litestream backup verification and manual recovery for the
-Fly app `canary-obs`.
+This runbook covers Litestream backup verification and manual recovery for a
+Fly-hosted Canary app.
 
-## Current State
+Set the target instance before running commands:
+
+```bash
+export CANARY_FLY_APP="<your-fly-app>"
+export CANARY_ENDPOINT="https://${CANARY_FLY_APP}.fly.dev"
+```
+
+## Historical Production Evidence
 
 Initial live inspection on `2026-04-16` found that `canary-obs` was not
 actively backing up:
@@ -26,14 +33,17 @@ recovery work.
 
 The shell tests in this repo verify wrapper command composition and
 restore-on-missing-DB behavior. They do not replace a live Fly/Litestream
-verification run against `canary-obs`.
+verification run against the operator's own app.
 
 ## Enable Fly Tigris Backups
 
-Provision a Fly-managed Tigris bucket for `canary-obs`:
+Provision a Fly-managed Tigris bucket for the app:
 
 ```bash
-flyctl storage create --app canary-obs --name canary-obs-backups --yes
+flyctl storage create \
+  --app "$CANARY_FLY_APP" \
+  --name "${CANARY_FLY_APP}-backups" \
+  --yes
 ```
 
 `flyctl storage create` provisions the bucket and stages or deploys the app
@@ -45,14 +55,14 @@ backup contract stays Fly-specific and small.
 Confirm the secrets are present:
 
 ```bash
-flyctl secrets list --app canary-obs
+flyctl secrets list --app "$CANARY_FLY_APP"
 ```
 
 If Fly reports them as `Staged`, deploy the current release with the new
 secrets without rebuilding:
 
 ```bash
-flyctl secrets deploy --app canary-obs
+flyctl secrets deploy --app "$CANARY_FLY_APP"
 ```
 
 `bin/dr-status` is still the authoritative verification step because it checks
@@ -63,7 +73,7 @@ the running container's effective Litestream configuration.
 Check Litestream replication status on the running machine:
 
 ```bash
-bin/dr-status
+bin/dr-status --app "$CANARY_FLY_APP"
 ```
 
 The wrapper owns the exact `flyctl ssh console` contract through
@@ -92,7 +102,7 @@ Restore the Tigris replica to a temporary file on the running machine without
 touching the live database:
 
 ```bash
-bin/dr-restore-check
+bin/dr-restore-check --app "$CANARY_FLY_APP"
 ```
 
 The wrapper builds the remote restore command through
@@ -123,7 +133,7 @@ Use this only after `bin/dr-status` and `bin/dr-restore-check` succeed.
 ```bash
 set -euo pipefail
 
-MACHINE_JSON=$(flyctl machines list --app canary-obs --json | jq -ce 'map(select(.config.env.FLY_PROCESS_GROUP == "app")) | .[0]')
+MACHINE_JSON=$(flyctl machines list --app "$CANARY_FLY_APP" --json | jq -ce 'map(select(.config.env.FLY_PROCESS_GROUP == "app")) | .[0]')
 MACHINE_ID=$(printf '%s' "$MACHINE_JSON" | jq -er '.id')
 VOLUME_ID=$(printf '%s' "$MACHINE_JSON" | jq -er '.config.mounts[0].volume')
 IMAGE=$(printf '%s' "$MACHINE_JSON" | jq -er '.config.image')
@@ -132,32 +142,32 @@ MAINT_NAME="cdrm_$(date +%s | tail -c 7)"
 
 printf 'Recovering Fly machine: %s (volume %s)\n' "$MACHINE_ID" "$VOLUME_ID"
 
-flyctl machines stop "$MACHINE_ID" --app canary-obs
+flyctl machines stop "$MACHINE_ID" --app "$CANARY_FLY_APP"
 
-flyctl machine run --app canary-obs --region "$REGION" --detach \
+flyctl machine run --app "$CANARY_FLY_APP" --region "$REGION" --detach \
   --skip-dns-registration --restart no --name "$MAINT_NAME" \
   --entrypoint sleep --volume "$VOLUME_ID":/data "$IMAGE" infinity
 
 MAINT_ID=
 for _ in $(seq 1 30); do
-  MAINT_ID=$(flyctl machines list --app canary-obs --json | jq -er --arg name "$MAINT_NAME" '.[] | select(.name == $name) | .id' 2>/dev/null || true)
+  MAINT_ID=$(flyctl machines list --app "$CANARY_FLY_APP" --json | jq -er --arg name "$MAINT_NAME" '.[] | select(.name == $name) | .id' 2>/dev/null || true)
   [ -n "$MAINT_ID" ] && break
   sleep 2
 done
 test -n "$MAINT_ID"
 
 cleanup_maint() {
-  flyctl machine destroy "$MAINT_ID" --app canary-obs --force
+  flyctl machine destroy "$MAINT_ID" --app "$CANARY_FLY_APP" --force
 }
 trap cleanup_maint EXIT
 
-flyctl machine wait "$MAINT_ID" --app canary-obs --state started
-flyctl machine exec "$MAINT_ID" "sh -eu -c 'rm -f /data/canary.db /data/canary.db-wal /data/canary.db-shm && for path in /data/canary.db /data/canary.db-wal /data/canary.db-shm; do [ ! -e \"$path\" ] || { echo \"$path still present\" >&2; exit 1; }; done'" --app canary-obs
+flyctl machine wait "$MAINT_ID" --app "$CANARY_FLY_APP" --state started
+flyctl machine exec "$MAINT_ID" "sh -eu -c 'rm -f /data/canary.db /data/canary.db-wal /data/canary.db-shm && for path in /data/canary.db /data/canary.db-wal /data/canary.db-shm; do [ ! -e \"$path\" ] || { echo \"$path still present\" >&2; exit 1; }; done'" --app "$CANARY_FLY_APP"
 
-flyctl machine destroy "$MAINT_ID" --app canary-obs --force
+flyctl machine destroy "$MAINT_ID" --app "$CANARY_FLY_APP" --force
 trap - EXIT
 
-flyctl machines start "$MACHINE_ID" --app canary-obs
+flyctl machines start "$MACHINE_ID" --app "$CANARY_FLY_APP"
 ```
 
 Why the stop/maintenance/start sequence exists:
@@ -177,25 +187,25 @@ disposable forked volume using the same image and `flyctl machine run` /
 Re-run the backup checks after the machine comes back:
 
 ```bash
-bin/dr-status
-bin/dr-restore-check
+bin/dr-status --app "$CANARY_FLY_APP"
+bin/dr-restore-check --app "$CANARY_FLY_APP"
 ```
 
 Check recent logs for the restore message:
 
 ```bash
-flyctl logs --app canary-obs --no-tail | rg "Restoring database from Litestream"
+flyctl logs --app "$CANARY_FLY_APP" --no-tail | rg "Restoring database from Litestream"
 ```
 
 Treat this as a failed recovery and stop immediately if it appears:
 
 ```bash
-flyctl logs --app canary-obs --no-tail | rg "did not materialize /data/canary.db"
+flyctl logs --app "$CANARY_FLY_APP" --no-tail | rg "did not materialize /data/canary.db"
 ```
 
 Then verify the service itself:
 
 ```bash
-curl -fsS https://canary-obs.fly.dev/healthz
-curl -fsS https://canary-obs.fly.dev/readyz
+curl -fsS "$CANARY_ENDPOINT/healthz"
+curl -fsS "$CANARY_ENDPOINT/readyz"
 ```

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -3,7 +3,7 @@
 Canary monitors itself from two directions:
 
 - Inside Canary, the `canary-self` HTTP target checks
-  `https://canary-obs.fly.dev/healthz`.
+  `$CANARY_ENDPOINT/healthz`.
 - Outside Canary, the scheduled GitHub Actions witness asks to run every five
   minutes and preserves a JSON receipt as a workflow artifact. GitHub cron is
   best-effort, so the production workflow sends a two-hour `ttl_ms` check-in
@@ -59,6 +59,11 @@ Required repository secrets:
 - `CANARY_WITNESS_INGEST_KEY`: ingest-scoped or admin-scoped key for the
   `canary-watchman` check-in.
 
+Forks can leave the witness workflow unconfigured. Upstream Misty Step runs the
+workflow against its production instance by default; forks run it only after
+setting the `CANARY_WITNESS_ENDPOINT` repository variable. See
+[`docs/self-host-fly.md`](self-host-fly.md#configure-fork-workflows).
+
 Production monitor configuration:
 
 ```bash
@@ -102,6 +107,6 @@ false` before the alert plane is healthy. A pressured worker is still
 route-ready evidence; it is not healthy alert-plane evidence.
 
 `doctor` also prints a `dr:` line. That line reflects the operator
-`bin/dr-status --app canary-obs` Litestream check when available and points to
+`bin/dr-status --app "$CANARY_FLY_APP"` Litestream check when available and points to
 the latest checked-in restore-specific receipt when one exists; otherwise it
 reports `restore_receipt_missing` and the fallback runbook path.

--- a/docs/self-host-fly.md
+++ b/docs/self-host-fly.md
@@ -1,0 +1,134 @@
+# Self-Host Canary On Fly
+
+This is the cold-operator path for a fresh Canary instance. It does not depend
+on Misty Step's production app, private secrets, or checked-in dogfood data.
+
+## Prerequisites
+
+- `flyctl` authenticated to the operator's Fly organization
+- Docker-compatible builder access for `flyctl deploy --remote-only`
+- `jq`, `curl`, Rust, Node.js, and Dagger for local validation
+- A unique Fly app name owned by the operator
+
+Use explicit env vars throughout the run:
+
+```bash
+export CANARY_FLY_APP="<your-fly-app>"
+export CANARY_ENDPOINT="https://${CANARY_FLY_APP}.fly.dev"
+```
+
+Do not run deploy, DR, or witness commands without setting
+`CANARY_FLY_APP`/`FLY_APP` or passing `--app`.
+
+## Create The Fly App
+
+```bash
+flyctl apps create "$CANARY_FLY_APP"
+flyctl volumes create canary_data \
+  --app "$CANARY_FLY_APP" \
+  --region iad \
+  --size 1
+```
+
+The checked-in `fly.toml` describes the process, mount, and health checks.
+Always pass `--app "$CANARY_FLY_APP"` so a fork or local checkout does not
+target another operator's instance.
+
+## Configure Tigris Backups
+
+Create the Fly Tigris bucket and verify Litestream secrets exist:
+
+```bash
+flyctl storage create \
+  --app "$CANARY_FLY_APP" \
+  --name "${CANARY_FLY_APP}-backups" \
+  --yes
+
+flyctl secrets list --app "$CANARY_FLY_APP" | rg 'BUCKET_NAME|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY'
+flyctl secrets set --app "$CANARY_FLY_APP" CANARY_REQUIRE_LITESTREAM=1
+```
+
+`bin/entrypoint.sh` refuses startup when `CANARY_REQUIRE_LITESTREAM=1` and the
+backup configuration is incomplete.
+
+## Deploy And Capture The First Admin Key
+
+```bash
+flyctl deploy --app "$CANARY_FLY_APP" --remote-only
+flyctl logs --app "$CANARY_FLY_APP" --no-tail | rg 'Bootstrap API key:'
+```
+
+The first boot seed logs the bootstrap admin key once. Store it in the
+operator's secret manager and do not paste it into receipts or issues:
+
+```bash
+export CANARY_ADMIN_KEY="<store-the-bootstrap-key-securely>"
+```
+
+If the first boot log was missed, mint a replacement admin key directly against
+the existing SQLite store. This does not delete or reset data:
+
+```bash
+CANARY_ADMIN_KEY="$(
+  flyctl ssh console --app "$CANARY_FLY_APP" \
+    -C '/app/bin/canary-server mint-key --scope admin --name operator-recovery' \
+    2>/dev/null | tail -n 1
+)"
+```
+
+Store the recovered key securely. The command prints the raw key once.
+
+## Smoke The Instance
+
+```bash
+curl -fsS "$CANARY_ENDPOINT/healthz"
+curl -fsS "$CANARY_ENDPOINT/readyz"
+curl -fsS "$CANARY_ENDPOINT/api/v1/report?window=1h" \
+  -H "Authorization: Bearer $CANARY_ADMIN_KEY"
+```
+
+Create scoped keys for callers instead of sharing the admin key:
+
+```bash
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/keys" \
+  -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "first-service-ingest", "scope": "ingest-only"}'
+
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/keys" \
+  -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "operator-read", "scope": "read-only"}'
+```
+
+## Verify DR And Write Paths
+
+```bash
+NO_COLOR=1 bin/dr-status --app "$CANARY_FLY_APP"
+NO_COLOR=1 bin/dr-restore-check --app "$CANARY_FLY_APP"
+
+bin/canary-write-path-rehearsal \
+  --endpoint "$CANARY_ENDPOINT" \
+  --api-key "$CANARY_ADMIN_KEY" \
+  --app "$CANARY_FLY_APP" \
+  --json
+```
+
+For a local or non-Fly rehearsal, pass `--no-dr-status` instead of letting the
+script guess an app.
+
+## Configure Fork Workflows
+
+Forks are safe to leave unconfigured. The deploy workflow runs for upstream
+Misty Step by default, and in forks only when `vars.CANARY_FLY_APP` is set.
+The witness workflow runs for upstream by default, and in forks only when
+`vars.CANARY_WITNESS_ENDPOINT` is set.
+
+For a fork-owned production instance, configure:
+
+- Repository variables: `CANARY_FLY_APP`, `CANARY_WITNESS_ENDPOINT`
+- Repository secrets: `FLY_API_TOKEN`, `CANARY_WITNESS_READ_KEY`,
+  `CANARY_WITNESS_INGEST_KEY`
+
+Then run the witness once manually and confirm it uploads
+`canary-witness-receipt.json` for the operator's own endpoint.

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -178,6 +178,16 @@ assert_json_equals() {
   fi
 }
 
+assert_stderr_contains() {
+  local expected="$1" message="$2"
+  if grep -qF -- "$expected" "$TMPDIR_TEST/canary-witness-test.err"; then
+    record_pass "$message"
+  else
+    record_fail "$message"
+    cat "$TMPDIR_TEST/canary-witness-test.err" >&2 || true
+  fi
+}
+
 run_success() {
   local message="$1"
   shift
@@ -204,6 +214,19 @@ run_failure() {
 }
 
 setup_fake_curl
+
+run_failure "missing endpoint exits nonzero" \
+  env \
+    -u CANARY_ENDPOINT \
+    -u CANARY_WITNESS_ENDPOINT \
+    STUB_SCENARIO=healthy \
+    "${WITNESS[@]}" \
+    --read-api-key read-key \
+    --receipt "$TMPDIR_TEST/missing-endpoint.json" \
+    --json
+assert_stderr_contains \
+  "canary-witness: missing endpoint: pass --endpoint or set CANARY_WITNESS_ENDPOINT/CANARY_ENDPOINT" \
+  "missing endpoint names configuration"
 
 receipt="$TMPDIR_TEST/healthy.json"
 run_success "healthy witness exits zero" \

--- a/test/bin/canary_write_path_rehearsal_test.sh
+++ b/test/bin/canary_write_path_rehearsal_test.sh
@@ -396,13 +396,24 @@ echo "Test 3: missing curl fails clearly"
 NO_CURL_PATH="$TMPDIR_TEST/no-curl-path"
 rm -rf "$NO_CURL_PATH"
 mkdir -p "$NO_CURL_PATH"
-OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin PATH="$NO_CURL_PATH" "$BASH_BIN" "$SCRIPT" --json)
+OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin PATH="$NO_CURL_PATH" "$BASH_BIN" "$SCRIPT" --app canary-test --json)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "missing curl exits non-zero"
 assert_contains "$BODY" "Missing required command: curl" "missing curl names dependency"
 
-echo "Test 4: stubbed rehearsal emits sanitized JSON receipt"
+echo "Test 4: missing Fly app fails clearly when DR status is enabled"
+setup_stubs
+OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin "$SCRIPT" --prefix test --webhook-url https://example.com/hook --no-dr-status --json)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+assert_exit_code "$STATUS" "0" "no-dr-status allows missing app"
+OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin "$SCRIPT" --prefix test --webhook-url https://example.com/hook --json)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "missing app exits non-zero"
+assert_contains "$BODY" "Missing Fly app" "missing app names configuration"
+
+echo "Test 5: stubbed rehearsal emits sanitized JSON receipt"
 setup_stubs
 OUTPUT=$(env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin EXPECT_TARGET_URL=http://127.0.0.1:4000/healthz "$SCRIPT" --prefix test --webhook-url https://example.com/hook --target-url http://127.0.0.1:4000/healthz --app canary-test --json)
 assert_jq "$OUTPUT" '.status == "ok"' "receipt status ok"
@@ -435,7 +446,7 @@ assert_file_contains "$CURL_LOG" "DELETE /api/v1/monitors/MON-test" "deletes mon
 assert_file_contains "$CURL_LOG" "DELETE /api/v1/webhooks/WHK-test" "deletes webhook"
 assert_file_contains "$CURL_LOG" "POST /api/v1/keys/KEY-test/revoke" "revokes key"
 
-echo "Test 5: non-delivered webhook rows fail and clean up"
+echo "Test 6: non-delivered webhook rows fail and clean up"
 setup_stubs
 OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin CURL_DELIVERY_STATUS=pending "$SCRIPT" --prefix test --webhook-url https://example.com/hook --app canary-test --poll-attempts 1 --poll-sleep 0 --json)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
@@ -447,7 +458,7 @@ assert_file_contains "$CURL_LOG" "DELETE /api/v1/monitors/MON-test" "pending fai
 assert_file_contains "$CURL_LOG" "DELETE /api/v1/webhooks/WHK-test" "pending failure deletes webhook"
 assert_file_contains "$CURL_LOG" "POST /api/v1/keys/KEY-test/revoke" "pending failure revokes key"
 
-echo "Test 6: unexpected credential-bearing mutation status redacts and cleans up"
+echo "Test 7: unexpected credential-bearing mutation status redacts and cleans up"
 setup_stubs
 OUTPUT=$(run_failure env CANARY_ENDPOINT=http://canary.test CANARY_API_KEY=admin CURL_KEY_CREATE_STATUS=500 "$SCRIPT" --prefix test --webhook-url https://example.com/hook --app canary-test --json)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)

--- a/test/bin/dr_test.sh
+++ b/test/bin/dr_test.sh
@@ -119,64 +119,78 @@ echo "Test 1: dr-status help"
 OUTPUT=$(run_and_capture "$DR_STATUS" --help)
 assert_contains "$OUTPUT" "Usage: bin/dr-status" "shows dr-status usage"
 
-echo "Test 2: dr-status uses default app and status command"
+echo "Test 2: dr-status requires an explicit app"
+OUTPUT=$(run_failure "$DR_STATUS")
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "status wrapper exits non-zero without app"
+assert_contains "$BODY" "Missing Fly app: pass --app or set CANARY_FLY_APP/FLY_APP" "status wrapper names app configuration"
+
+echo "Test 3: dr-status honors CANARY_FLY_APP env default"
 setup_stubs
-run_and_capture "$DR_STATUS" >/dev/null
+CANARY_FLY_APP=canary-env run_and_capture "$DR_STATUS" >/dev/null
 assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=ssh$' "invokes flyctl ssh"
-assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-obs$' "uses default app"
+assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-env$' "uses configured app"
 assert_file_matches "$FLYCTL_LOG" \
   "^arg[0-9]+=sh -eu -c 'litestream status -config /etc/litestream\\.yml'\$" \
   "uses remote litestream status command"
 
-echo "Test 3: dr-status honors FLY_APP env default"
+echo "Test 4: dr-status honors FLY_APP env default"
 setup_stubs
 FLY_APP=canary-env run_and_capture "$DR_STATUS" >/dev/null
 assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-env$' "status wrapper uses env app default"
 
-echo "Test 4: dr-status accepts --app override"
+echo "Test 5: dr-status accepts --app override"
 setup_stubs
 run_and_capture "$DR_STATUS" --app canary-staging >/dev/null
 assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-staging$' "uses overridden app"
 
-echo "Test 5: dr-status rejects unknown arguments"
+echo "Test 6: dr-status rejects unknown arguments"
 OUTPUT=$(run_failure "$DR_STATUS" --bogus)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "status wrapper exits non-zero on unknown argument"
 assert_contains "$BODY" "Usage: bin/dr-status" "status wrapper prints usage on unknown argument"
 
-echo "Test 6: dr-status rejects --app without a value"
+echo "Test 7: dr-status rejects --app without a value"
 OUTPUT=$(run_failure "$DR_STATUS" --app)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "status wrapper exits non-zero on missing app value"
 assert_contains "$BODY" "Usage: bin/dr-status" "status wrapper prints usage on missing app value"
 
-echo "Test 7: dr-status fails cleanly when flyctl is unavailable"
-OUTPUT=$(PATH="$MISSING_FLYCTL_PATH" run_failure "$BASH_BIN" "$DR_STATUS")
+echo "Test 8: dr-status fails cleanly when flyctl is unavailable"
+OUTPUT=$(PATH="$MISSING_FLYCTL_PATH" run_failure "$BASH_BIN" "$DR_STATUS" --app canary-staging)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "status wrapper exits non-zero when flyctl is missing"
 assert_contains "$BODY" "Missing required command: flyctl" "status wrapper names the missing dependency"
 
-echo "Test 8: dr-status propagates flyctl failures"
+echo "Test 9: dr-status propagates flyctl failures"
 setup_stubs
 export FLYCTL_STUB_EXIT=23
 set +e
-"$DR_STATUS" >/dev/null 2>&1
+"$DR_STATUS" --app canary-staging >/dev/null 2>&1
 STATUS=$?
 set -e
 unset FLYCTL_STUB_EXIT
 assert_equals "$STATUS" "23" "propagates flyctl exit status"
 
-echo "Test 9: dr-restore-check help"
+echo "Test 10: dr-restore-check help"
 OUTPUT=$(run_and_capture "$DR_RESTORE_CHECK" --help)
 assert_contains "$OUTPUT" "Usage: bin/dr-restore-check" "shows dr-restore-check usage"
 
-echo "Test 10: dr-restore-check uses default app and db path"
+echo "Test 11: dr-restore-check requires an explicit app"
+OUTPUT=$(run_failure "$DR_RESTORE_CHECK")
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "restore check exits non-zero without app"
+assert_contains "$BODY" "Missing Fly app: pass --app or set CANARY_FLY_APP/FLY_APP" "restore check names app configuration"
+
+echo "Test 12: dr-restore-check uses configured app and db path"
 setup_stubs
-run_and_capture "$DR_RESTORE_CHECK" >/dev/null
-assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-obs$' "restore check uses default app"
+CANARY_FLY_APP=canary-env run_and_capture "$DR_RESTORE_CHECK" >/dev/null
+assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-env$' "restore check uses configured app"
 assert_file_contains "$FLYCTL_LOG" "restore_path=\$(mktemp /tmp/canary-restore.XXXXXX);" \
   "restore check creates a temporary restore path"
 assert_file_contains "$FLYCTL_LOG" \
@@ -189,13 +203,13 @@ assert_file_matches "$FLYCTL_LOG" \
   "^arg[0-9]+=.* sh /data/canary\\.db\$" \
   "restore check targets the default database path"
 
-echo "Test 11: dr-restore-check uses the remote DB default even when local CANARY_DB_PATH is set"
+echo "Test 13: dr-restore-check uses the remote DB default even when local CANARY_DB_PATH is set"
 setup_stubs
 FLY_APP=canary-env CANARY_DB_PATH=/data/env.db run_and_capture "$DR_RESTORE_CHECK" >/dev/null
 assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-env$' "restore check uses env app default"
 assert_file_matches "$FLYCTL_LOG" "^arg[0-9]+=.* sh /data/canary\\.db\$" "restore check ignores local db env default"
 
-echo "Test 12: dr-restore-check accepts overrides"
+echo "Test 14: dr-restore-check accepts overrides"
 setup_stubs
 run_and_capture "$DR_RESTORE_CHECK" --app canary-staging --db-path /data/restore.db >/dev/null
 assert_file_matches "$FLYCTL_LOG" '^arg[0-9]+=canary-staging$' "restore check uses overridden app"
@@ -203,53 +217,53 @@ assert_file_matches "$FLYCTL_LOG" \
   "^arg[0-9]+=.* sh /data/restore\\.db\$" \
   "restore check uses overridden db path"
 
-echo "Test 13: dr-restore-check rejects unknown arguments"
+echo "Test 15: dr-restore-check rejects unknown arguments"
 OUTPUT=$(run_failure "$DR_RESTORE_CHECK" --bogus)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "restore check exits non-zero on unknown argument"
 assert_contains "$BODY" "Usage: bin/dr-restore-check" "restore check prints usage on unknown argument"
 
-echo "Test 14: dr-restore-check safely quotes apostrophes in db paths"
+echo "Test 16: dr-restore-check safely quotes apostrophes in db paths"
 setup_stubs
-run_and_capture "$DR_RESTORE_CHECK" --db-path "/data/o'brien.db" >/dev/null
+run_and_capture "$DR_RESTORE_CHECK" --app canary-staging --db-path "/data/o'brien.db" >/dev/null
 assert_file_matches "$FLYCTL_LOG" \
   "^arg[0-9]+=.* sh /data/o\\\\'brien\\.db\$" \
   "restore check shell-quotes db paths"
 
-echo "Test 15: dr-restore-check safely quotes spaces in db paths"
+echo "Test 17: dr-restore-check safely quotes spaces in db paths"
 setup_stubs
-run_and_capture "$DR_RESTORE_CHECK" --db-path "/data/restore copy.db" >/dev/null
+run_and_capture "$DR_RESTORE_CHECK" --app canary-staging --db-path "/data/restore copy.db" >/dev/null
 assert_file_matches "$FLYCTL_LOG" \
   '^arg[0-9]+=.* sh /data/restore\\ copy\.db$' \
   "restore check shell-quotes paths with spaces"
 
-echo "Test 16: dr-restore-check rejects --db-path without a value"
+echo "Test 18: dr-restore-check rejects --db-path without a value"
 OUTPUT=$(run_failure "$DR_RESTORE_CHECK" --db-path)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "restore check exits non-zero on missing db path"
 assert_contains "$BODY" "Usage: bin/dr-restore-check" "restore check prints usage on missing db path"
 
-echo "Test 17: dr-restore-check rejects --app without a value"
+echo "Test 19: dr-restore-check rejects --app without a value"
 OUTPUT=$(run_failure "$DR_RESTORE_CHECK" --app)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "restore check exits non-zero on missing app value"
 assert_contains "$BODY" "Usage: bin/dr-restore-check" "restore check prints usage on missing app value"
 
-echo "Test 18: dr-restore-check fails cleanly when flyctl is unavailable"
-OUTPUT=$(PATH="$MISSING_FLYCTL_PATH" run_failure "$BASH_BIN" "$DR_RESTORE_CHECK")
+echo "Test 20: dr-restore-check fails cleanly when flyctl is unavailable"
+OUTPUT=$(PATH="$MISSING_FLYCTL_PATH" run_failure "$BASH_BIN" "$DR_RESTORE_CHECK" --app canary-staging)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
 BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "restore check exits non-zero when flyctl is missing"
 assert_contains "$BODY" "Missing required command: flyctl" "restore check names the missing dependency"
 
-echo "Test 19: dr-restore-check propagates flyctl failures"
+echo "Test 21: dr-restore-check propagates flyctl failures"
 setup_stubs
 export FLYCTL_STUB_EXIT=29
 set +e
-"$DR_RESTORE_CHECK" >/dev/null 2>&1
+"$DR_RESTORE_CHECK" --app canary-staging >/dev/null 2>&1
 STATUS=$?
 set -e
 unset FLYCTL_STUB_EXIT


### PR DESCRIPTION
## Summary
- Add a self-host Fly runbook with app creation, volume/Tigris setup, first bootstrap key capture, lost-key recovery, smoke, DR, write-path rehearsal, and fork workflow configuration.
- Remove implicit Misty Step production fallbacks from witness, DR, write-path rehearsal, and CLI doctor DR probing so cold operators must name their own endpoint/app.
- Guard deploy and uptime-monitor workflows so forks only run them after configuring Canary instance variables, and record this first slice in backlog item 060.

## Verification
- bash -n bin/canary-witness bin/dr-status bin/dr-restore-check bin/canary-write-path-rehearsal test/bin/canary_witness_test.sh test/bin/dr_test.sh test/bin/canary_write_path_rehearsal_test.sh
- git diff --check
- bash test/bin/dr_test.sh
- bash test/bin/canary_witness_test.sh
- bash test/bin/canary_write_path_rehearsal_test.sh
- cargo fmt --check
- cargo test -p canary-cli --locked
- ./bin/validate
- pre-commit ./bin/validate --fast
- pre-push ./bin/validate --strict

## Residual 060 work
- Rust CLI compiled endpoint default still needs a follow-up slice.
- fly.toml and dogfood instance data/docs still reference the production app and need product-vs-instance cleanup.
- The epic remains open until Adminifi/R90 clean-room deployment evidence exists.

Agent: canary factory lane
Agent-Surface: Codex
Agent-Runner: Codex API
Agent-Model: openai/gpt-5
Agent-Task: backlog.d/060-cold-operator-deploy-path.md
Agent-Context: /Users/phaedrus/Development/canary