### PR TITLE
fix(server): bind production listener to IPv6

### DIFF
--- a/backlog.d/061-fleet-plumb-in.md
+++ b/backlog.d/061-fleet-plumb-in.md
@@ -37,6 +37,13 @@ reuses the existing integration engine and the future evidence hardening in
 `049`; it should not turn Canary into a repo mutation engine. Downstream app
 patches happen in those repos or through external agents.
 
+## Progress
+- 2026-07-01: Bastion lane verified `canary-obs.internal` resolution and route
+  path from the fleet, but connections to `canary-obs.internal:4000` were
+  refused because the production server was not listening on the Fly 6PN-facing
+  address family. Added a server bind fix to listen on `[::]:PORT`; deployment
+  proof must include a curl from outside the Fly machine.
+
 ## Children
 1. Define the active Factory app inventory and coverage statuses.
 2. Publish a 15-minute integration recipe that works through API, CLI, MCP, or

--- a/crates/canary-server/src/runtime_env.rs
+++ b/crates/canary-server/src/runtime_env.rs
@@ -4,7 +4,12 @@
 //! that compatibility at the process edge and returns a typed runtime config so
 //! the server boot path does not parse environment variables itself.
 
-use std::{collections::BTreeMap, fmt, net::SocketAddr, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    net::{Ipv6Addr, SocketAddr},
+    path::PathBuf,
+};
 
 use canary_workers::retention::RetentionPolicy;
 
@@ -72,7 +77,7 @@ impl ServerProcessConfig {
 
         Ok(Self {
             server,
-            listen_addr: SocketAddr::from(([0, 0, 0, 0], port)),
+            listen_addr: SocketAddr::from((Ipv6Addr::UNSPECIFIED, port)),
         })
     }
 }
@@ -160,7 +165,10 @@ mod tests {
             config.server.database_path,
             PathBuf::from("/data/canary.db")
         );
-        assert_eq!(config.listen_addr, SocketAddr::from(([0, 0, 0, 0], 4000)));
+        assert_eq!(
+            config.listen_addr,
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 4000))
+        );
         assert_eq!(config.server.retention_policy, RetentionPolicy::default());
         assert!(!config.server.target_probe_options.allow_private_targets);
         assert!(config.server.disclose_bootstrap_key);
@@ -179,7 +187,10 @@ mod tests {
         ])?;
 
         assert_eq!(config.server.database_path, PathBuf::from("/tmp/canary.db"));
-        assert_eq!(config.listen_addr, SocketAddr::from(([0, 0, 0, 0], 8080)));
+        assert_eq!(
+            config.listen_addr,
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 8080))
+        );
         assert_eq!(
             config.server.retention_policy,
             RetentionPolicy {


### PR DESCRIPTION
## Summary
- default the production listener to `[::]:PORT` so Fly 6PN/internal peers can reach `canary-obs.internal:4000`
- lock default and production `PORT` behavior in `runtime_env` tests
- record the bastion fleet-route finding and required outside-machine curl proof in `backlog.d/061-fleet-plumb-in.md`

## Verification
- red before implementation: `cargo test -p canary-server runtime_env::tests::process_config_uses_phoenix_compatible_defaults --locked` failed with `0.0.0.0:4000` vs `[::]:4000`
- `cargo test -p canary-server runtime_env::tests --locked`
- `cargo fmt --check`
- `git diff --check`
- `./bin/validate`
- pre-commit `./bin/validate --fast`
- pre-push `./bin/validate --strict`
- hosted Dagger strict CI for #179
- CodeRabbit review for #179
- production image smoke in full/strict gates logged `canary-server listening on [::]:4000`, then passed `/healthz` and `/readyz`

Post-merge proof still required: deploy `canary-obs` and curl `http://canary-obs.internal:4000/healthz` from another Fly machine.

Agent: canary factory lane
Agent-Surface: Codex
Agent-Runner: Codex API
Agent-Model: openai/gpt-5
Agent-Task: backlog.d/061-fleet-plumb-in.md
Agent-Context: /Users/phaedrus/Development/canary
