### PR TITLE
feat: version Canary incident events

### DIFF
--- a/crates/canary-store/src/incidents.rs
+++ b/crates/canary-store/src/incidents.rs
@@ -19,6 +19,7 @@ use crate::Result;
 const ACTIVE_WINDOW_SECONDS: i64 = 300;
 const OPEN_STATE: &str = "investigating";
 const RESOLVED_STATE: &str = "resolved";
+const INCIDENT_EVENT_SCHEMA_VERSION: &str = "canary.incident_event.v1";
 
 /// One incident-correlation command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -509,9 +510,21 @@ fn incident_payload(
     now: &str,
 ) -> serde_json::Value {
     json!({
+        "schema_version": INCIDENT_EVENT_SCHEMA_VERSION,
         "event": event,
         "tenant_id": incident.tenant_id,
         "project_id": incident.project_id,
+        "subject": {
+            "type": "incident",
+            "id": incident.id,
+            "service": incident.service,
+        },
+        "signal": incident_signal_payload(incident, signals, now),
+        "replay": {
+            "timeline_url": format!("/api/v1/timeline?service={}&window=1h", incident.service),
+            "report_url": "/api/v1/report?window=1h",
+            "incident_url": format!("/api/v1/incidents/{}", incident.id),
+        },
         "incident": {
             "id": incident.id,
             "service": incident.service,
@@ -531,6 +544,27 @@ fn incident_payload(
         },
         "timestamp": now,
     })
+}
+
+fn incident_signal_payload(
+    incident: &IncidentRow,
+    signals: &[SignalRow],
+    now: &str,
+) -> serde_json::Value {
+    match signals.first() {
+        Some(signal) => json!({
+            "kind": signal.signal_type,
+            "fingerprint": signal.signal_ref,
+            "severity": incident.severity,
+            "observed_at": signal.attached_at,
+        }),
+        None => json!({
+            "kind": "incident",
+            "fingerprint": incident.id,
+            "severity": incident.severity,
+            "observed_at": now,
+        }),
+    }
 }
 
 fn title_for(service: &str) -> String {

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -3131,7 +3131,18 @@ mod tests {
         assert_eq!(event.id, "EVT-abcdefghijkl");
         let payload: Value =
             serde_json::from_str(&event.payload_json).map_err(|_| rusqlite::Error::InvalidQuery)?;
+        assert_eq!(payload["schema_version"], "canary.incident_event.v1");
         assert_eq!(payload["event"], "incident.opened");
+        assert_eq!(payload["subject"]["type"], "incident");
+        assert_eq!(payload["subject"]["id"], "INC-123456789abc");
+        assert_eq!(payload["subject"]["service"], "cadence");
+        assert_eq!(payload["signal"]["kind"], "error_group");
+        assert_eq!(payload["signal"]["fingerprint"], "group-incident-a");
+        assert_eq!(payload["signal"]["observed_at"], "2026-05-28T20:00:05Z");
+        assert_eq!(
+            payload["replay"]["incident_url"],
+            "/api/v1/incidents/INC-123456789abc"
+        );
         assert_eq!(payload["incident"]["id"], "INC-123456789abc");
         assert_eq!(
             payload["incident"]["signals"][0]["signal_ref"],

--- a/docs/architecture/canary-bitterblossom-triage-contract-2026-07-01.md
+++ b/docs/architecture/canary-bitterblossom-triage-contract-2026-07-01.md
@@ -43,7 +43,7 @@ replay:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": "canary.incident_event.v1",
   "event": "incident.opened",
   "subject": {
     "type": "incident",

--- a/docs/schemas/canary.incident_event.v1.schema.json
+++ b/docs/schemas/canary.incident_event.v1.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/misty-step/canary/blob/master/docs/schemas/canary.incident_event.v1.schema.json",
+  "title": "Canary Incident Event v1",
+  "description": "Signed Canary webhook body for incident wake-up hints consumed by Bitterblossom triage workloads. The webhook is a hint; consumers must replay Canary state before acting.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event",
+    "subject",
+    "signal",
+    "replay"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "canary.incident_event.v1"
+    },
+    "event": {
+      "type": "string",
+      "enum": [
+        "incident.opened",
+        "incident.updated",
+        "incident.resolved"
+      ]
+    },
+    "tenant_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "project_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subject": {
+      "type": "object",
+      "required": [
+        "type",
+        "id",
+        "service"
+      ],
+      "properties": {
+        "type": {
+          "const": "incident"
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^INC-[A-Za-z0-9_-]+$"
+        },
+        "service": {
+          "type": "string",
+          "minLength": 1
+        },
+        "environment": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "signal": {
+      "type": "object",
+      "required": [
+        "kind",
+        "fingerprint",
+        "severity",
+        "observed_at"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "error_group",
+            "target",
+            "monitor",
+            "telemetry_event",
+            "health_transition",
+            "incident"
+          ]
+        },
+        "fingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "warning",
+            "error",
+            "high",
+            "critical"
+          ]
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "replay": {
+      "type": "object",
+      "required": [
+        "timeline_url",
+        "report_url",
+        "incident_url"
+      ],
+      "properties": {
+        "timeline_url": {
+          "type": "string",
+          "pattern": "^/api/v1/timeline"
+        },
+        "report_url": {
+          "type": "string",
+          "pattern": "^/api/v1/report"
+        },
+        "incident_url": {
+          "type": "string",
+          "pattern": "^/api/v1/incidents/INC-[A-Za-z0-9_-]+$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "incident": {
+      "description": "Backward-compatible incident detail object retained for existing webhook consumers."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- Stamp Canary incident webhook payloads with `canary.incident_event.v1`.
- Add typed `subject`, `signal`, and `replay` fields while preserving the existing `incident` object.
- Add the committed JSON Schema and update the dated Canary-to-BB prose contract.

## Verification
- `cargo test -p canary-store correlate_incident_opens_error_group_incident_and_records_timeline`
- `./bin/validate`
- push-time `Ci.strict` pre-push hook

## Agent
- Agent: Codex
- Agent-Surface: Codex CLI
- Agent-Model: GPT-5
- Agent-Task: seam-contracts factory lane