### PR TITLE
feat(governance): add canary-deploy repo-local skill

### DIFF
--- a/.agents/skills/canary-deploy/SKILL.md
+++ b/.agents/skills/canary-deploy/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: canary-deploy
+description: |
+  Operate Canary's deploy and disaster-recovery runbook: verify Litestream
+  backup status before touching anything, deploy to the Fly app
+  (`canary-obs`), and run non-destructive restore drills. Canary is a
+  self-hosted Rust service on Fly with a single-writer SQLite DB replicated
+  to Tigris via Litestream. Use when: "deploy canary", "check canary
+  backups", "is canary backed up", "restore drill", "DR check", "canary
+  disaster recovery". Trigger: /canary-deploy.
+argument-hint: "[status|deploy|restore-check|nuclear-reset]"
+---
+
+<!--
+Generated via harness-kit's repo-local skill generation pattern
+(skills/harness-engineering/references/repo-local-skill-generation.md).
+Source repo: misty-step/canary @ c8e281b. Generated: 2026-07-01.
+Generator ref: harness-kit@cbe82137.
+Facts below are repo-derived at generation time, not invented. Re-verify
+commands against the live repo before trusting this if it has aged — a
+generated skill is a snapshot, not a live view.
+-->
+
+# canary-deploy
+
+Deploy is auto-triggered on green `master` (`.github/workflows/deploy.yml`
+runs `flyctl deploy` after CI's `workflow_run` succeeds); the manual path
+exists for out-of-band redeploys. The load-bearing discipline here is DR
+verification, not the deploy command itself — `bin/dr-status` and
+`bin/dr-restore-check` are read-only/non-destructive checks that must both
+pass before any destructive recovery is even considered. Full narrative
+runbook: `docs/backup-restore-dr.md`.
+
+## Surfaces
+
+| Changed area | Surface | Verification path |
+|---|---|---|
+| Deploy config (`fly.toml`, `Dockerfile`, `.github/workflows/deploy.yml`) | Fly app `canary-obs` | `flyctl deploy --app canary-obs --remote-only`, then `/healthz` + `/readyz` |
+| Backup/replication (`litestream.yml`, `bin/entrypoint.sh`, `bin/lib/dr.sh`) | Litestream → Fly Tigris | `bin/dr-status`, `bin/dr-restore-check` |
+
+## Commands
+
+Set the target app once (both DR scripts read `CANARY_FLY_APP`/`FLY_APP`;
+neither has a hardcoded default — see `bin/lib/dr.sh:dr_default_app`):
+
+```sh
+export CANARY_FLY_APP=canary-obs
+```
+
+Read-only backup preflight (run this before anything else — exits non-zero
+if Litestream config is missing):
+
+```sh
+bin/dr-status
+# equivalent: bin/dr-status --app canary-obs
+```
+
+Non-destructive restore drill (restores the Tigris replica to a temp file on
+the running machine; never touches the live DB; needs outbound egress from
+the Fly machine):
+
+```sh
+bin/dr-restore-check
+# equivalent: bin/dr-restore-check --app canary-obs --db-path /data/canary.db
+```
+
+Manual deploy (normally automatic on green master via the `Deploy` workflow):
+
+```sh
+flyctl deploy --app canary-obs --remote-only
+```
+
+Provision Tigris backups on a fresh app (one-time; `flyctl storage create`
+stages/deploys the `BUCKET_NAME`/`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
+secrets Canary reads):
+
+```sh
+flyctl storage create --app canary-obs --name canary-obs-backups --yes
+flyctl secrets list --app canary-obs   # confirm secrets present, not "Staged"
+```
+
+## Gotchas
+
+- **`bin/dr-status`/`bin/dr-restore-check` need `flyctl ssh console` access**
+  to the real Fly app — they are live production preflights, not local
+  fixtures. Both are safe to run against `canary-obs` at any time (read-only
+  / temp-file-only), but they are not sandboxed.
+- **Neither DR script has a hardcoded app default.** Forgetting
+  `CANARY_FLY_APP`/`--app` fails loud with "Missing Fly app" rather than
+  silently targeting the wrong instance — do not work around that by
+  guessing an app name.
+- **`bin/dr-restore-check` needs outbound egress** from the Fly machine to
+  reach Tigris; failure here means the replica cannot be trusted for
+  recovery, not just that the drill script is broken.
+- **`CANARY_REQUIRE_LITESTREAM=1`** makes `bin/entrypoint.sh` fail-closed on
+  boot if the DB is missing and Litestream can't restore it — relevant when
+  diagnosing a boot failure after a volume issue.
+- **Never skip straight to Destructive Recovery** (`docs/backup-restore-dr.md`,
+  stop-machine → mount elsewhere → delete `/data/canary.db*` → restart)
+  without both `bin/dr-status` and `bin/dr-restore-check` passing first — that
+  sequence is explicitly human-gated and must not be automated.
+- **`bin/dr.sh`'s quoting contract is single-sourced** — do not hand-write
+  the equivalent `flyctl ssh console` command; use the wrapper so quoting
+  changes stay in one place.
+
+## Report
+
+Return: **verdict** (PASS / FAIL / UNVERIFIED) · exact command(s) run ·
+surface exercised (deploy / backup-status / restore-drill) · artifact
+inspected (dr-status output, restore-check output, `/healthz`+`/readyz`
+response) · what was NOT covered (e.g. "backup status only — no restore
+drill run").

--- a/.agents/skills/canary-deploy/evals/canary-deploy-eval.md
+++ b/.agents/skills/canary-deploy/evals/canary-deploy-eval.md
@@ -1,0 +1,58 @@
+# `canary-deploy` eval
+
+The one claim this generated skill must earn: **a cold agent uses this skill
+to run the correct read-only Litestream backup preflight against the real
+`canary-obs` Fly app on the first try — naming `CANARY_FLY_APP`/`bin/dr-status`
+exactly, not inventing a `flyctl status`-style command or skipping the
+env var — where the bare repo (AGENTS.md's one-line Deploy crib) does not by
+itself surface that DR verification must happen before deploy work.**
+
+## Fixtures
+
+| # | Task given to the cold agent | Forbidden edits | What it stresses |
+|---|---|---|---|
+| 1 | "Use this skill to check whether Canary's production backups are healthy right now." | No writes outside a scratch dir; no destructive Fly ops | The flagship read-only command path (`bin/dr-status`) and the app-targeting env var |
+
+## Objective checks
+
+- [x] The agent names `bin/dr-status` (not an invented `flyctl` subcommand or
+      a guess at a health endpoint).
+- [x] The agent sets `CANARY_FLY_APP` (or passes `--app canary-obs`) rather
+      than running the script bare and hitting the "Missing Fly app" failure.
+- [x] The command actually runs and returns a real status line (`database`,
+      `status`, `local txid`, `wal size`), not a hallucinated summary.
+- [x] The agent reports a verdict in the skill's Report contract shape.
+
+## Pass condition
+
+The cold agent completes fixture 1 using only the skill + repo, all objective
+checks passing. A no-op "skill" fails because the bare repo's only mention of
+DR is a one-line `bin/dr-status` crib buried in `AGENTS.md`'s Deploy section
+with no `CANARY_FLY_APP` context — a cold agent working from the bare repo
+alone is likely to either skip the app env var (hitting the loud "Missing Fly
+app" failure) or reach for a plausible-sounding `flyctl status`/`flyctl
+checks` command instead of the repo's actual DR wrapper.
+
+## Cadence
+
+Re-smoke when `bin/dr-status`/`bin/lib/dr.sh` change, or when the Fly app name
+changes.
+
+## Run log
+
+2026-07-01 — Self-validation run (generation author, not evidence, but
+confirms the command is real before committing): `CANARY_FLY_APP=canary-obs
+bin/dr-status` → exit 0, `database=/data/canary.db status=ok wal size=11 MB`.
+
+2026-07-02 — **Cold-agent fixture 1 run: PASS.** Fresh-context subagent
+(general-purpose, Sonnet 5), given only `canary-deploy/SKILL.md` + normal
+repo read access, no session memory of this generation. Task: "check whether
+Canary's production backups are healthy right now." Ran exactly
+`export CANARY_FLY_APP=canary-obs; bin/dr-status; bin/dr-restore-check` —
+both commands named verbatim from the skill, env var set correctly on the
+first try, no invented `flyctl status`-style command. `dr-status` returned
+`database=/data/canary.db status=ok txid=00000000000ca5b2 wal=11MB` (exit 0);
+`dr-restore-check` materialized a 35M restored replica to
+`/tmp/canary-restore.II7x79` on the remote machine (exit 0). Agent reported
+self-sufficiency explicitly: "Fully sufficient... Nothing was invented,
+guessed, or sourced from other files." All objective checks passed.


### PR DESCRIPTION
## Summary

- Second domain skill generated via harness-kit's new repo-local skill generation pattern (`misty-step/harness-kit#151`), additive alongside the existing `.agents/skills/canary-qa/SKILL.md`: `.agents/skills/canary-deploy/SKILL.md`.
- Covers the Litestream/Fly DR runbook: `bin/dr-status` preflight, `bin/dr-restore-check` non-destructive drill, manual (`flyctl deploy`) vs. auto-on-green-master deploy paths, and the human-gated nuclear-reset boundary — pulled from `docs/backup-restore-dr.md`, `bin/lib/dr.sh`, and `.github/workflows/deploy.yml`.
- Carries a provenance header (generated-by, source SHA, generator ref) and an eval stub at `.agents/skills/canary-deploy/evals/canary-deploy-eval.md`, seeding the evals-per-skill floor for generated repo-local skills.
- Purely additive — does not touch `canary-qa`, `AGENTS.md`, or any product code.

## Test plan

- [x] Generation author self-validated the flagship command live before committing: `CANARY_FLY_APP=canary-obs bin/dr-status` → exit 0, backups healthy.
- [x] **Cold-agent smoke** (the actual proof, not self-report): a fresh-context subagent with zero session memory of this work, given only the skill file + normal repo read access, was asked to check whether production backups are healthy. It ran `export CANARY_FLY_APP=canary-obs; bin/dr-status; bin/dr-restore-check` verbatim from the skill — both against the real `canary-obs` Fly app, both exit 0 (backup status `ok`, and a live 35M restore drill succeeded). Agent explicitly confirmed nothing was invented or guessed.
- [x] `./bin/validate --fast` and the pre-push `./bin/validate --strict` (full Dagger gate: Rust fmt/clippy/test, TS typecheck/coverage/build, operator-script tests, Docker `/healthz`+`/readyz` smoke, secrets scan) both green on this branch.
- [x] No product code touched — this PR only adds the two new files under `.agents/skills/canary-deploy/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)