### PR TITLE
feat(fleet): verify factory coverage readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ packages:
 - operator scripts: entrypoint, DR, and dogfood audit tests
 - production image: Docker build plus `/healthz` and `/readyz` smoke
 
+### Fleet Integration
+
+Agents wiring another runtime into Canary should use the 15-minute recipe in
+[`docs/factory-fleet-integration.md`](docs/factory-fleet-integration.md). It
+covers HTTP target enrollment, Fly private-network reachability, non-HTTP
+check-in monitors, and strict dogfood readback without requiring route trivia
+or secret values in receipts.
+
 The default gate also includes the git-history secrets scan. Run live
 dependency advisory scans explicitly when you want current registry state as
 part of a stricter local release check:

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -13,8 +13,8 @@ visible until a focused PR archives them with evidence.
 | # | Epic | Priority | Relationship |
 |---|------|----------|--------------|
 | 060 | Cold-operator deploy path | P0 | Shipped 2026-07-01. Folded in self-host docs, app-name dehardcoding, bootstrap-key docs, dogfood instance split, and clean-room receipt. |
-| 061 | Fleet plumb-in | P0 | Composition monitoring half: every Factory app reports health/errors/uptime with fresh readback. |
-| 062 | Agent loop write surface | P0 | Adds CLI/MCP annotation writeback and scoped responder-key loop; adopts 048. |
+| 061 | Fleet plumb-in | P0 | Shipped 2026-07-02. Folded in Factory fleet integration docs, powder/BB live enrollment, bastion/powder/BB check-in readback, and check-in-aware dogfood strictness. |
+| 062 | Agent loop write surface | P0 | Next pickup: adds CLI/MCP annotation writeback and scoped responder-key loop; adopts 048. |
 | 063 | Triage contract hardening | P1 | Durable cooldown, dispatch budget caps, claim-gated delivery, and drills. |
 | 064 | Trustworthy release/upgrade | P1 | Absorbs 051; fixes release truth, npm/Docker claims, and upgrade docs. |
 | 065 | Runtime hardening | P1 | Absorbs 056/058/059 plus bcrypt-outside-mutex, tracing, and backup posture. |
@@ -24,7 +24,6 @@ visible until a focused PR archives them with evidence.
 
 | # | Item | Priority | Status | Estimate |
 |---|------|----------|--------|----------|
-| 061 | Fleet plumb-in | P0 | pending | L |
 | 062 | Agent loop write surface | P0 | pending | XL |
 | 063 | Triage contract hardening | P1 | pending | XL |
 | 064 | Trustworthy release/upgrade | P1 | pending | L |
@@ -80,6 +79,7 @@ visible until a focused PR archives them with evidence.
 | 056 | Lower /api/v1/report store-lock contention + dedup SLI owner-scope | P2 | pending | M |
 | 057 | Static MCP manifest parity | P1 | done | S |
 | 060 | Cold-operator deploy path | P0 | done | XL |
+| 061 | Fleet plumb-in | P0 | done | L |
 | 058 | Cadence-aware SLI trajectory sample floor | P2 | pending | M |
 | 059 | Bump anyhow after RUSTSEC-2026-0190 | P2 | pending | S |
 | 020 | Adminifi HTTP surface verification | low | blocked | S |
@@ -154,11 +154,11 @@ visible until a focused PR archives them with evidence.
 endpoint/app configuration, bootstrap-key recovery docs, instance-local dogfood
 state, and a clean-room receipt.
 
-061 is now the next product pickup: the Factory composition needs every app to
-report health/errors/uptime to the Misty Step instance through a 15-minute
-integration path and service-specific readback receipts.
+061 shipped on 2026-07-02: the Factory composition now has a 15-minute
+integration path, live bastion/powder/BB readback, and dogfood strictness that
+counts check-in monitors without accepting registry-only coverage.
 
-062 is the next agent-loop pickup after the deploy/composition basics. It
+062 is now the next agent-loop pickup after the deploy/composition basics. It
 adopts 048's scoped responder safety gate and adds the missing CLI/MCP
 annotation writeback so agents can complete read -> claim -> annotate -> release
 without raw route trivia or admin keys.

--- a/backlog.d/_done/061-fleet-plumb-in.md
+++ b/backlog.d/_done/061-fleet-plumb-in.md
@@ -1,6 +1,6 @@
 # Plumb the Factory fleet into Canary
 
-Priority: P0 · Status: pending · Estimate: L
+Priority: P0 · Status: done · Estimate: L
 
 ## Goal
 Make every Factory app report errors, health, and uptime to the Misty Step
@@ -43,6 +43,12 @@ patches happen in those repos or through external agents.
   refused because the production server was not listening on the Fly 6PN-facing
   address family. Added a server bind fix to listen on `[::]:PORT`; deployment
   proof must include a curl from outside the Fly machine.
+- 2026-07-02: Enrolled powder and bitterblossom-plane targets into the live
+  Misty Step hub, enabled hub-side private-target probes for Fly 6PN, added
+  proof TTL check-ins for both services, verified bastion/powder/BB monitor
+  readback as `up`, and tightened dogfood strict mode so active check-in
+  services cannot pass on registry-only coverage. Evidence:
+  `docs/architecture/factory-fleet-enrollment-2026-07-02.md`.
 
 ## Children
 1. Define the active Factory app inventory and coverage statuses.

--- a/bin/dogfood-audit
+++ b/bin/dogfood-audit
@@ -20,16 +20,17 @@ Audit Canary's deployed-service dogfood registry against a live Canary instance.
 By default the command reads `CANARY_ENDPOINT`, `CANARY_API_KEY`, and the
 instance-local registry at `.canary/dogfood/owned_services.json`. Set
 `CANARY_DOGFOOD_MANIFEST` or pass `--manifest` to use another registry. The
-command compares active HTTP services against live Canary targets and prints:
+command compares active HTTP services against live Canary targets, compares
+active check-in services against live Canary monitors, and prints:
 
 - Canary's current summary for the requested window
-- every active service with target presence, URL match, health state, and errors
+- every active service with target/monitor presence, health state, and errors
 - pending, blocked, follow-on, suspended, and ignored services with next action
 - extra live targets outside the deployed-service registry
 
 `--json` emits the same audit as machine-readable JSON.
-`--strict` exits non-zero when any active service target is missing, duplicated,
-or pointed at the wrong URL.
+`--strict` exits non-zero when any active service coverage is missing,
+duplicated, stale, or pointed at the wrong URL.
 EOF
 }
 
@@ -70,12 +71,16 @@ validate_manifest() {
       (.platform | type == "string" and length > 0) and
       (has("production_url") and (.production_url == null or (.production_url | type == "string"))) and
       (has("health_url") and (.health_url == null or (.health_url | type == "string"))) and
+      (.monitor_mode == null or (.monitor_mode | IN("http", "check_in", "external", "none"))) and
       (.last_checked_at | type == "string" and length > 0) and
       (.failure_mode | type == "string" and length > 0) and
       (.owner | type == "string" and length > 0) and
       (.next_action | type == "string" and length > 0)
     ) and
-    all(.services[] | select(.state == "active"); (.health_url | type == "string" and length > 0))
+    all(.services[] | select(.state == "active");
+      ((.monitor_mode // "http") == "check_in")
+      or (.health_url | type == "string" and length > 0)
+    )
   ' "$MANIFEST" >/dev/null; then
     fail "Invalid deployed-service registry: $MANIFEST"
   fi
@@ -221,10 +226,20 @@ strict_failures=$((strict_failures + $(wc -l < "$registry_policy_failures" | tr 
 
 while IFS= read -r service_json; do
   service="$(jq -r '.service' <<<"$service_json")"
-  expected_url="$(jq -r '.health_url' <<<"$service_json")"
+  expected_url="$(jq -r '.health_url // ""' <<<"$service_json")"
+  monitor_mode="$(jq -r '.monitor_mode // (if (.health_url // "") != "" then "http" else "none" end)' <<<"$service_json")"
   encoded_service="$(urlencode "$service")"
   encoded_window="$(urlencode "$WINDOW")"
   query_json="$(api_get "/api/v1/query?service=${encoded_service}&window=${encoded_window}")"
+
+  target_required=0
+  monitor_required=0
+  if [[ -n "$expected_url" ]]; then
+    target_required=1
+  fi
+  if [[ "$monitor_mode" == "check_in" ]]; then
+    monitor_required=1
+  fi
 
   target_count="$(
     jq -r --arg service "$service" '
@@ -244,43 +259,99 @@ while IFS= read -r service_json; do
     ' <<<"$report_json"
   )"
 
+  monitor_count="$(
+    jq -r --arg service "$service" '
+      [.monitors[]? | select(.service == $service)] | length
+    ' <<<"$report_json"
+  )"
+
+  monitor_state="$(
+    jq -r --arg service "$service" '
+      [.monitors[]? | select(.service == $service) | .state][0] // "missing"
+    ' <<<"$report_json"
+  )"
+
+  monitor_name="$(
+    jq -r --arg service "$service" '
+      [.monitors[]? | select(.service == $service) | .name][0] // ""
+    ' <<<"$report_json"
+  )"
+
+  last_check_in_at="$(
+    jq -r --arg service "$service" '
+      [.monitors[]? | select(.service == $service) | .last_check_in_at][0] // ""
+    ' <<<"$report_json"
+  )"
+
   total_errors="$(jq -r '.total_errors // 0' <<<"$query_json")"
   summary="$(jq -r '.summary // ""' <<<"$query_json")"
 
-  target_state="present"
-  url_state="yes"
+  target_state="n/a"
+  url_state="n/a"
+  monitor_state_label="n/a"
 
-  if [[ "$target_count" == "0" ]]; then
-    target_state="missing"
-    url_state="n/a"
-    strict_failures=$((strict_failures + 1))
-  elif [[ "$target_count" != "1" ]]; then
-    target_state="duplicate"
-    url_state="no"
-    strict_failures=$((strict_failures + 1))
-  elif [[ "$actual_url" != "$expected_url" ]]; then
-    url_state="no"
-    strict_failures=$((strict_failures + 1))
+  if ((target_required == 1)); then
+    target_state="present"
+    url_state="yes"
+
+    if [[ "$target_count" == "0" ]]; then
+      target_state="missing"
+      url_state="n/a"
+      strict_failures=$((strict_failures + 1))
+    elif [[ "$target_count" != "1" ]]; then
+      target_state="duplicate"
+      url_state="no"
+      strict_failures=$((strict_failures + 1))
+    elif [[ "$actual_url" != "$expected_url" ]]; then
+      url_state="no"
+      strict_failures=$((strict_failures + 1))
+    elif [[ "$health_state" == "missing" ]]; then
+      target_state="unobserved"
+      strict_failures=$((strict_failures + 1))
+    fi
+  else
+    actual_url=""
+    health_state="n/a"
+  fi
+
+  if ((monitor_required == 1)); then
+    monitor_state_label="$monitor_state"
+
+    if [[ "$monitor_count" == "0" ]]; then
+      monitor_state_label="missing"
+      strict_failures=$((strict_failures + 1))
+    elif [[ -z "$last_check_in_at" ]]; then
+      monitor_state_label="unobserved"
+      strict_failures=$((strict_failures + 1))
+    fi
   fi
 
   jq -cn \
     --argjson registry "$service_json" \
+    --arg monitor_mode "$monitor_mode" \
     --arg target_state "$target_state" \
     --arg url_state "$url_state" \
     --arg actual_url "$actual_url" \
     --arg health_state "$health_state" \
+    --arg monitor_state "$monitor_state_label" \
+    --arg monitor_name "$monitor_name" \
+    --arg last_check_in_at "$last_check_in_at" \
     --argjson total_errors "$total_errors" \
     --arg summary "$summary" \
     '{
       service: $registry.service,
       state: $registry.state,
       platform: $registry.platform,
+      monitor_mode: $monitor_mode,
       production_url: $registry.production_url,
       expected_health_url: $registry.health_url,
       actual_health_url: $actual_url,
       target: $target_state,
       url: $url_state,
       health: $health_state,
+      monitor: $monitor_state,
+      monitor_name: $monitor_name,
+      last_check_in_at: $last_check_in_at,
       total_errors: $total_errors,
       summary: $summary,
       owner: $registry.owner,
@@ -324,15 +395,16 @@ else
   printf '\n'
 
   printf 'Active services\n'
-  printf '%-18s %-9s %-8s %-10s %-6s %-8s %s\n' "service" "target" "url" "health" "errors" "platform" "expected"
-  printf '%-18s %-9s %-8s %-10s %-6s %-8s %s\n' "-------" "------" "---" "------" "------" "--------" "--------"
+  printf '%-18s %-9s %-8s %-10s %-10s %-6s %-8s %s\n' "service" "target" "url" "health" "monitor" "errors" "platform" "expected"
+  printf '%-18s %-9s %-8s %-10s %-10s %-6s %-8s %s\n' "-------" "------" "---" "------" "-------" "------" "--------" "--------"
 
   while IFS= read -r result_json; do
-    printf '%-18s %-9s %-8s %-10s %-6s %-8s %s\n' \
+    printf '%-18s %-9s %-8s %-10s %-10s %-6s %-8s %s\n' \
       "$(jq -r '.service' <<<"$result_json")" \
       "$(jq -r '.target' <<<"$result_json")" \
       "$(jq -r '.url' <<<"$result_json")" \
       "$(jq -r '.health' <<<"$result_json")" \
+      "$(jq -r '.monitor' <<<"$result_json")" \
       "$(jq -r '.total_errors' <<<"$result_json")" \
       "$(jq -r '.platform' <<<"$result_json")" \
       "$(jq -r '.expected_health_url' <<<"$result_json")"
@@ -375,7 +447,7 @@ fi
 
 if ((STRICT == 1 && strict_failures > 0)); then
   if ((JSON_OUTPUT == 0)); then
-    printf '\nStrict audit failed: %s active service target issue(s).\n' "$strict_failures" >&2
+    printf '\nStrict audit failed: %s active service coverage issue(s).\n' "$strict_failures" >&2
   fi
   exit 1
 fi

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -224,6 +224,10 @@ deliberately split into reviewable phases:
   `--project-root` is supplied. The one-time key and snippets are redacted
   unless `--show-secret` is explicitly passed for a secure handoff.
 
+Factory fleet enrollment uses the same CLI surface plus live target and
+check-in readback. The 15-minute operator recipe is
+[`docs/factory-fleet-integration.md`](factory-fleet-integration.md).
+
 Use SDK instrumentation when the application code can ship a patch: it provides
 service names, environments, scrubbed context, and typed request/browser error
 capture. Use platform-level drains only as a supplement for logs/errors the app

--- a/docs/architecture/factory-fleet-enrollment-2026-07-02.md
+++ b/docs/architecture/factory-fleet-enrollment-2026-07-02.md
@@ -1,0 +1,196 @@
+# Factory Fleet Enrollment Evidence - 2026-07-02 UTC
+
+## Claim
+
+The Misty Step Canary hub is now the monitoring half of the current Factory
+composition. Canary, bastion, powder, and the Bitterblossom plane each have
+explicit coverage status, live readback, and a repeatable enrollment path.
+
+Run window: `2026-07-02T01:06Z` through `2026-07-02T01:14Z`.
+
+## Hub Configuration
+
+The hub is `canary-obs` at `https://canary-obs.fly.dev`. Private Fly fleet
+targets require the hub runtime flag below so Fly 6PN addresses are accepted by
+the target validator:
+
+```bash
+flyctl secrets set --app canary-obs ALLOW_PRIVATE_TARGETS=true
+```
+
+This is hub operator configuration, not consumer-repo configuration.
+
+## Coverage Matrix
+
+| Repo / runtime | Status | Health / uptime readback | Error or check-in path | Next app-lane action |
+|---|---|---|---|---|
+| Canary | Integrated | `canary-self` target `TGT-5gowpivgtuvw` read back `up` at `https://canary-obs.fly.dev/healthz`. | `canary-watchman` monitor `MON-5csw7imodfcq` read back `up`; query readback returned `0` canary errors in the last hour. | Keep witness scheduled after each deploy. |
+| Bastion router | Integrated | Non-HTTP uptime monitor `bastion-router` read back `up`. | `MON-vsaibxn27k8p` last check-in `alive` at `2026-07-02T01:13:45.31256448Z`. | Resident bastion lane keeps the heartbeat flowing. |
+| Powder | Integrated | Target `TGT-s637fnhh257c` read back `up` for `http://powder.internal:4000/healthz` at `2026-07-02T01:10:55.804934739Z`. | Proof monitor `MON-8en7bvbq9a5g`, check-in `CHK-8iwuhyz986ai`, state `up`; query readback returned `0` errors in the last hour. | Move the proof heartbeat into the powder app lane. Canary did not edit the resident powder branch. |
+| Bitterblossom plane | Integrated | Target `TGT-zzjlrcj90ynk` read back `up` for `https://bitterblossom-plane.fly.dev/health` at `2026-07-02T01:11:27.25369684Z`. | Proof monitor `MON-btdkn8d6uo9r`, check-in `CHK-6pis4h07vb36`, state `up`; query readback returned `0` errors in the last hour. | Move the proof heartbeat into the BB plane lane. Canary did not mutate the BB repo. |
+
+No other Factory runtime app was named by the 2026-07-01 operator decisions for
+this epic. Non-runtime repos and app-side heartbeat patches are intentionally
+deferred to their resident lanes.
+
+## Live Writes
+
+Powder target enrollment initially failed with:
+
+```text
+target resolved to non-global address fdaa:45:6cb6:a7b:7d2:d9ab:7ac8:2
+```
+
+After setting `ALLOW_PRIVATE_TARGETS=true` on the hub, the same enrollment
+succeeded:
+
+```json
+{
+  "id": "TGT-s637fnhh257c",
+  "service": "powder",
+  "url": "http://powder.internal:4000/healthz",
+  "interval_ms": 60000,
+  "expected_status": "200",
+  "active": true
+}
+```
+
+Bitterblossom-plane target enrollment:
+
+```json
+{
+  "id": "TGT-zzjlrcj90ynk",
+  "service": "bitterblossom-plane",
+  "url": "https://bitterblossom-plane.fly.dev/health",
+  "interval_ms": 60000,
+  "expected_status": "200",
+  "active": true
+}
+```
+
+Proof monitor creation and check-ins:
+
+```json
+[
+  {
+    "monitor_id": "MON-8en7bvbq9a5g",
+    "check_in_id": "CHK-8iwuhyz986ai",
+    "service": "powder",
+    "state": "up",
+    "observed_at": "2026-07-02T01:11:10.651517749Z",
+    "sequence": 1
+  },
+  {
+    "monitor_id": "MON-btdkn8d6uo9r",
+    "check_in_id": "CHK-6pis4h07vb36",
+    "service": "bitterblossom-plane",
+    "state": "up",
+    "observed_at": "2026-07-02T01:11:10.912502549Z",
+    "sequence": 1
+  }
+]
+```
+
+## Live Readback
+
+`GET /api/v1/report?window=24h` showed the new targets and fleet monitors:
+
+```json
+{
+  "targets": [
+    {
+      "service": "bitterblossom-plane",
+      "url": "https://bitterblossom-plane.fly.dev/health",
+      "state": "up",
+      "last_checked_at": "2026-07-02T01:11:27.25369684Z"
+    },
+    {
+      "service": "powder",
+      "url": "http://powder.internal:4000/healthz",
+      "state": "up",
+      "last_checked_at": "2026-07-02T01:10:55.804934739Z"
+    }
+  ],
+  "monitors": [
+    {
+      "service": "bastion",
+      "name": "bastion-router",
+      "state": "up",
+      "last_check_in_status": "alive",
+      "last_check_in_at": "2026-07-02T01:13:45.31256448Z"
+    },
+    {
+      "service": "bitterblossom-plane",
+      "name": "bitterblossom-plane-fleet-heartbeat",
+      "state": "up",
+      "last_check_in_status": "alive",
+      "last_check_in_at": "2026-07-02T01:11:10.912502549Z"
+    },
+    {
+      "service": "powder",
+      "name": "powder-fleet-heartbeat",
+      "state": "up",
+      "last_check_in_status": "alive",
+      "last_check_in_at": "2026-07-02T01:11:10.651517749Z"
+    }
+  ]
+}
+```
+
+Service query readback:
+
+```json
+[
+  {
+    "service": "powder",
+    "total_errors": 0,
+    "summary": "0 errors in powder in the last 1h. 0 unique classes."
+  },
+  {
+    "service": "bitterblossom-plane",
+    "total_errors": 0,
+    "summary": "0 errors in bitterblossom-plane in the last 1h. 0 unique classes."
+  },
+  {
+    "service": "canary",
+    "total_errors": 0,
+    "summary": "0 errors in canary in the last 1h. 0 unique classes."
+  }
+]
+```
+
+## Strict Dogfood Proof
+
+The updated audit was run with a temporary instance-local manifest containing
+`canary-self`, `canary`, `bastion`, `powder`, and `bitterblossom-plane`.
+Result:
+
+```json
+{
+  "strict_failures": 0,
+  "active": [
+    {"service":"canary-self","target":"present","url":"yes","health":"up","monitor":"n/a","total_errors":0},
+    {"service":"canary","target":"n/a","url":"n/a","health":"n/a","monitor":"up","total_errors":1},
+    {"service":"bastion","target":"n/a","url":"n/a","health":"n/a","monitor":"up","total_errors":0},
+    {"service":"powder","target":"present","url":"yes","health":"up","monitor":"up","total_errors":0},
+    {"service":"bitterblossom-plane","target":"present","url":"yes","health":"up","monitor":"up","total_errors":0}
+  ]
+}
+```
+
+The manifest was temporary because Misty Step service names are instance-local
+operator state, not checked-in clean-room examples.
+
+## Residuals
+
+- Powder and BB check-ins are proof monitors with 24-hour TTLs. The app lanes
+  should replace them with scoped app-owned ingest keys and recurring
+  heartbeats.
+- `bin/canary doctor --json` in this 061 worktree reported `degraded` because
+  the alert plane had `monitor_overdue pressured` and the worktree did not have
+  an instance-local `.canary/dogfood/owned_services.json`. The service-specific
+  fleet dogfood audit above passed with live readback.
+- Bitterblossom private Flycast health at
+  `http://bitterblossom-plane.internal:8080/health` refused from the Canary
+  machine during enrollment, so the public health URL was enrolled. The BB lane
+  owns any private-bind change.

--- a/docs/factory-fleet-integration.md
+++ b/docs/factory-fleet-integration.md
@@ -1,0 +1,112 @@
+# Factory Fleet Integration
+
+This is the 15-minute path for a Factory repo to report health, uptime, and
+an error or check-in signal to the Misty Step Canary instance. Use it from the
+consumer repo; keep service-specific code changes in that repo.
+
+## Inputs
+
+- `CANARY_ENDPOINT`: `https://canary-obs.fly.dev` for Misty Step.
+- A read/admin operator key for inspection and enrollment. Do not print it.
+- The service name agents should query, for example `powder`.
+- One production health URL when the app exposes HTTP health.
+- One check-in monitor name when the app has a worker, scheduler, CLI, or
+  process heartbeat.
+
+For private Fly 6PN targets such as `http://<app>.internal:<port>/healthz`, the
+Canary hub must be configured to allow private target probes:
+
+```bash
+flyctl secrets set --app canary-obs ALLOW_PRIVATE_TARGETS=true
+```
+
+That setting belongs on the Canary hub, not in the consumer repo. It keeps the
+default self-host posture conservative while allowing an operator-controlled
+Factory fleet to use Fly private networking.
+
+## Path
+
+1. Inspect current coverage from the consumer repo.
+
+```bash
+/path/to/canary/bin/canary integrate status /path/to/app \
+  --service <service> \
+  --production-url <health-url> \
+  --json
+```
+
+2. Verify the health URL from the Canary hub when the URL is private.
+
+```bash
+flyctl ssh console --app canary-obs \
+  --command 'curl -fsS http://<app>.internal:<port>/healthz'
+```
+
+Public URLs can be verified with a normal `curl -fsS <url>`.
+
+3. Enroll the HTTP target.
+
+```bash
+/path/to/canary/bin/canary integrate enroll \
+  --service <service> \
+  --url <health-url> \
+  --project-root /path/to/app \
+  --json
+```
+
+`--project-root` writes `.canary/integration.json` in the consumer repo. Use it
+only from that repo's own lane so resident work is not overwritten.
+
+4. Enroll a check-in monitor for non-HTTP uptime, then send one proof check-in.
+
+```bash
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/monitors" \
+  -H "Authorization: Bearer $CANARY_ADMIN_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"<service>-worker","service":"<service>","mode":"ttl","expected_every_ms":300000,"grace_ms":120000}'
+
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/check-ins" \
+  -H "Authorization: Bearer $CANARY_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"monitor":"<service>-worker","status":"alive","summary":"fleet integration proof"}'
+```
+
+The app-owned steady-state version should use a scoped ingest key, not an admin
+key. The operator may use an admin key for a one-time proof because admin keys
+also satisfy ingest authority.
+
+5. Read back live proof.
+
+```bash
+curl -fsS -H "Authorization: Bearer $CANARY_READ_API_KEY" \
+  "$CANARY_ENDPOINT/api/v1/report?window=24h" \
+  | jq '.targets,.monitors'
+
+/path/to/canary/bin/dogfood-audit \
+  --manifest /path/to/instance/owned_services.json \
+  --strict --json
+```
+
+The service is integrated only when readback shows either:
+
+- HTTP target coverage: target present, URL matches, and report includes a
+  target state.
+- Check-in coverage: monitor present, report includes a monitor state, and
+  `last_check_in_at` is non-empty.
+
+For Factory composition, use both when the app has both an HTTP health surface
+and a non-HTTP runtime heartbeat.
+
+## Status Receipt
+
+Each Factory repo ends in one of these states:
+
+- `integrated`: live Canary readback proves the target and/or monitor signal.
+- `intentionally deferred`: the repo is not an active runtime app for this
+  fleet slice, or the responsible resident lane owns the app-side patch.
+- `blocked`: the missing production URL, credential, route, or resident-lane
+  boundary is named without printing secret values.
+
+The receipt should include the service name, health URL or monitor name,
+target/monitor IDs when created, the exact readback command, and the next app
+lane action.

--- a/docs/networked-service-dogfooding.md
+++ b/docs/networked-service-dogfooding.md
@@ -16,11 +16,12 @@ bin/dogfood-audit --strict
 ```
 
 The command reads `CANARY_ENDPOINT` and `CANARY_API_KEY`, validates the registry
-schema, compares active HTTP services against live Canary targets, and prints:
+schema, compares active HTTP services against live Canary targets, compares
+active check-in services against live Canary monitors, and prints:
 
 - the unified Canary report summary for the requested window
-- every active service with target presence, URL match, health state, platform,
-  and current error totals
+- every active service with target presence, URL match, health state, monitor
+  state, platform, and current error totals
 - pending, blocked, follow-on, suspended, and ignored services with failure mode
   and next action
 - extra live targets outside the registry
@@ -100,8 +101,8 @@ Each service entry has:
   `service`, or `null` when there is no deployment project
 - `production_url`: public production surface when one exists
 - `repo_path`: local checkout path when known, otherwise `null`
-- `health_url`: HTTP target URL for active services, or `null` for non-HTTP or
-  not-yet-healthable services
+- `health_url`: HTTP target URL for services that expose HTTP health, or `null`
+  for monitor-only services
 - `monitor_mode`: `http`, `check_in`, `external`, or `none`
 - `ingest_status`: `verified`, `partial`, `missing`, `not_applicable`, or
   `blocked`
@@ -110,9 +111,17 @@ Each service entry has:
 - `owner`: accountable org or owner namespace
 - `next_action`: concrete next step
 
-`active` services must have a non-empty `health_url`; strict audit fails if the
-live Canary target is missing, duplicated, or pointed at another URL. Other
-states stay visible in the report but do not fail strict mode.
+`active` services must have either a non-empty `health_url` or
+`monitor_mode: "check_in"`.
+
+- `monitor_mode: "http"` with a `health_url` requires exactly one live Canary
+  target for that service, a matching URL, and target state readback in
+  `/api/v1/report`.
+- `monitor_mode: "check_in"` requires live monitor readback and a non-empty
+  `last_check_in_at`. If `health_url` is also set, strict mode verifies both
+  the HTTP target and the check-in monitor.
+
+Other states stay visible in the report but do not fail strict mode.
 
 ## Registry Lifecycle
 

--- a/test/bin/dogfood_audit_test.sh
+++ b/test/bin/dogfood_audit_test.sh
@@ -39,6 +39,8 @@ JSON
   {"service":"alpha","url":"https://alpha.example/health","state":"up"},
   {"service":"bravo","url":"https://bravo.example/health","state":"up"},
   {"service":"canary-self","url":"https://canary.example/healthz","state":"up"}
+],"monitors":[
+  {"service":"foxtrot","name":"foxtrot-worker","state":"up","last_check_in_status":"alive","last_check_in_at":"2026-06-11T23:59:00Z"}
 ]}
 JSON
     ;;
@@ -50,6 +52,16 @@ JSON
   https://canary.example/api/v1/query?service=bravo\&window=24h)
     cat <<'JSON'
 {"service":"bravo","summary":"0 errors in bravo in the last 24h. 0 unique classes.","total_errors":0}
+JSON
+    ;;
+  https://canary.example/api/v1/query?service=foxtrot\&window=24h)
+    cat <<'JSON'
+{"service":"foxtrot","summary":"0 errors in foxtrot in the last 24h. 0 unique classes.","total_errors":0}
+JSON
+    ;;
+  https://canary.example/api/v1/query?service=golf\&window=24h)
+    cat <<'JSON'
+{"service":"golf","summary":"0 errors in golf in the last 24h. 0 unique classes.","total_errors":0}
 JSON
     ;;
   https://canary.example/api/v1/query?service=missing\&window=24h)
@@ -100,6 +112,18 @@ write_manifest() {
       "failure_mode": "No current blocker.",
       "owner": "example-org",
       "next_action": "Keep enrolled."
+    },
+    {
+      "service": "foxtrot",
+      "state": "active",
+      "platform": "fly",
+      "production_url": null,
+      "health_url": null,
+      "monitor_mode": "check_in",
+      "last_checked_at": "2026-06-11T00:00:00Z",
+      "failure_mode": "No current blocker.",
+      "owner": "example-org",
+      "next_action": "Keep check-in monitor fresh."
     },
     {
       "service": "charlie",
@@ -188,6 +212,29 @@ write_missing_manifest() {
       "failure_mode": "Fixture ignores self target.",
       "owner": "example-org",
       "next_action": "No fixture action."
+    }
+  ]
+}
+JSON
+}
+
+write_missing_monitor_manifest() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "schema_version": 1,
+  "services": [
+    {
+      "service": "golf",
+      "state": "active",
+      "platform": "fly",
+      "production_url": null,
+      "health_url": null,
+      "monitor_mode": "check_in",
+      "last_checked_at": "2026-06-11T00:00:00Z",
+      "failure_mode": "Monitor is not enrolled.",
+      "owner": "example-org",
+      "next_action": "Create the check-in monitor."
     }
   ]
 }
@@ -310,10 +357,12 @@ assert_json_equals() {
 
 MANIFEST="$TMPDIR_TEST/manifest.json"
 MISSING_MANIFEST="$TMPDIR_TEST/missing-manifest.json"
+MISSING_MONITOR_MANIFEST="$TMPDIR_TEST/missing-monitor-manifest.json"
 INVALID_MANIFEST="$TMPDIR_TEST/invalid-manifest.json"
 STALE_MANIFEST="$TMPDIR_TEST/stale-manifest.json"
 write_manifest "$MANIFEST"
 write_missing_manifest "$MISSING_MANIFEST"
+write_missing_monitor_manifest "$MISSING_MONITOR_MANIFEST"
 write_invalid_manifest "$INVALID_MANIFEST"
 write_stale_manifest "$STALE_MANIFEST"
 
@@ -338,6 +387,7 @@ assert_contains "$OUTPUT" "Canary dogfood audit (24h)" "prints report header"
 assert_contains "$OUTPUT" "Active services" "prints active section"
 assert_contains "$OUTPUT" "alpha" "includes first active service"
 assert_contains "$OUTPUT" "bravo" "includes second active service"
+assert_contains "$OUTPUT" "foxtrot" "includes active check-in service"
 assert_contains "$OUTPUT" "pending services" "prints pending section"
 assert_contains "$OUTPUT" "charlie" "includes pending service"
 assert_contains "$OUTPUT" "blocked services" "prints blocked section"
@@ -352,7 +402,8 @@ echo "Test 3: dogfood-audit emits machine-readable json"
 setup_stubbed_curl
 OUTPUT=$(CANARY_ENDPOINT=https://canary.example CANARY_API_KEY=sk_test run_and_capture "$DOGFOOD_AUDIT" --manifest "$MANIFEST" --now 2026-06-12T00:00:00Z --json)
 assert_json_equals "$OUTPUT" ".window" "24h" "json includes window"
-assert_json_equals "$OUTPUT" ".active_services | length" "2" "json includes active service results"
+assert_json_equals "$OUTPUT" ".active_services | length" "3" "json includes active service results"
+assert_json_equals "$OUTPUT" ".active_services[] | select(.service == \"foxtrot\") | .monitor" "up" "json includes check-in monitor state"
 assert_json_equals "$OUTPUT" ".registry[] | select(.service == \"delta\") | .state" "blocked" "json includes non-active registry states"
 assert_json_equals "$OUTPUT" ".extra_targets | length" "0" "json excludes ignored registry target from extras"
 
@@ -365,7 +416,16 @@ assert_exit_code "$STATUS" "1" "strict mode exits non-zero"
 assert_contains "$BODY" "Strict audit failed" "strict mode explains the failure"
 assert_contains "$BODY" "missing" "strict output names the missing service state"
 
-echo "Test 5: dogfood-audit rejects invalid registry shape"
+echo "Test 5: dogfood-audit strict mode fails when an active check-in monitor is missing"
+setup_stubbed_curl
+OUTPUT=$(CANARY_ENDPOINT=https://canary.example CANARY_API_KEY=sk_test run_failure "$DOGFOOD_AUDIT" --manifest "$MISSING_MONITOR_MANIFEST" --now 2026-06-12T00:00:00Z --strict)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "1" "missing monitor exits non-zero"
+assert_contains "$BODY" "Strict audit failed" "missing monitor explains the failure"
+assert_contains "$BODY" "golf" "strict output names the missing monitor service"
+
+echo "Test 6: dogfood-audit rejects invalid registry shape"
 setup_stubbed_curl
 OUTPUT=$(CANARY_ENDPOINT=https://canary.example CANARY_API_KEY=sk_test run_failure "$DOGFOOD_AUDIT" --manifest "$INVALID_MANIFEST")
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
@@ -373,7 +433,7 @@ BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
 assert_exit_code "$STATUS" "1" "invalid registry exits non-zero"
 assert_contains "$BODY" "Invalid deployed-service registry" "invalid registry explains the schema failure"
 
-echo "Test 6: dogfood-audit strict json reports stale evidence and singular completed-ticket next actions"
+echo "Test 7: dogfood-audit strict json reports stale evidence and singular completed-ticket next actions"
 setup_stubbed_curl
 OUTPUT=$(CANARY_ENDPOINT=https://canary.example CANARY_API_KEY=sk_test run_failure "$DOGFOOD_AUDIT" --manifest "$STALE_MANIFEST" --now 2026-06-14T00:00:00Z --max-evidence-age-hours 24 --strict --json)
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
@@ -383,7 +443,7 @@ assert_json_equals "$BODY" ".registry_policy_failures | length" "2" "json includ
 assert_json_equals "$BODY" ".registry_policy_failures[0].kind" "stale_registry_evidence" "json names stale evidence failure"
 assert_json_equals "$BODY" ".registry_policy_failures[1].kind" "completed_ticket_next_action" "json names completed-ticket failure"
 
-echo "Test 7: dogfood-audit fails cleanly when curl is unavailable"
+echo "Test 8: dogfood-audit fails cleanly when curl is unavailable"
 setup_path_without_curl
 OUTPUT=$(PATH="$MISSING_CURL_PATH" CANARY_ENDPOINT=https://canary.example CANARY_API_KEY=sk_test run_failure "$BASH_BIN" "$DOGFOOD_AUDIT")
 STATUS=$(printf '%s' "$OUTPUT" | head -n 1)


### PR DESCRIPTION
## Summary
- add a 15-minute Factory fleet integration recipe for HTTP targets, Fly private-network probes, and check-in monitors
- tighten dogfood strict mode so active check-in services require live monitor/check-in readback instead of registry-only coverage
- archive epic 061 with live Misty Step evidence for canary, bastion, powder, and bitterblossom-plane

## Live Evidence
- powder target: TGT-s637fnhh257c, http://powder.internal:4000/healthz, report state up
- powder check-in: MON-8en7bvbq9a5g / CHK-8iwuhyz986ai, state up
- bitterblossom-plane target: TGT-zzjlrcj90ynk, https://bitterblossom-plane.fly.dev/health, report state up
- bitterblossom-plane check-in: MON-btdkn8d6uo9r / CHK-6pis4h07vb36, state up
- bastion-router monitor: MON-vsaibxn27k8p, state up with alive check-ins flowing
- strict dogfood proof with temporary Misty Step fleet manifest: strict_failures=0

## Verification
- git diff --check
- bash test/bin/dogfood_audit_test.sh
- ./bin/validate
- pre-commit ./bin/validate --fast
- pre-push ./bin/validate --strict

Agent: Codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: backlog/061