### PR TITLE
feat(responder): add scoped agent writeback

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,17 @@ Canary's MCP surface is the CLI contract served over stdio:
 ```bash
 CANARY_ENDPOINT="https://<your-fly-app>.fly.dev" \
 CANARY_READ_API_KEY=... \
+CANARY_RESPONDER_KEY=... \
 bin/canary mcp-server
 ```
 
 MCP clients can list and call the same generated tools exposed by
 `bin/canary mcp-manifest`: summary, services, errors, incidents, timeline,
-targets, monitors, doctor, dogfood, event capture, remediation claims, and
-integration helpers. The server returns MCP `inputSchema` fields at the wire
-boundary while the checked CLI manifest remains gated in
+targets, monitors, doctor, dogfood, event capture, remediation claims,
+annotations, and integration helpers. Read tools use read or responder
+authority. Claim and annotation writeback tools require `responder-write`
+authority, or admin for break-glass operator use. The server returns MCP
+`inputSchema` fields at the wire boundary while the checked CLI manifest remains gated in
 `priv/mcp/canary-cli-tools.json`.
 
 ## API
@@ -222,6 +225,7 @@ All other endpoints require a scoped API key:
 
 - `ingest-only` for `POST /api/v1/errors` and `POST /api/v1/check-ins`
 - `read-only` for query/report/timeline-style reads
+- `responder-write` for service-bound responder reads plus claim and annotation writeback
 - `admin` for onboarding, key management, target/monitor/webhook management, metrics, and other operator mutations
 
 Manual rotation steps live in [docs/api-key-rotation.md](docs/api-key-rotation.md).
@@ -497,6 +501,11 @@ curl -X POST $CANARY_ENDPOINT/api/v1/keys \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "cadence-prod", "scope": "read-only"}'
+
+curl -X POST $CANARY_ENDPOINT/api/v1/keys \
+  -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "cadence-responder", "scope": "responder-write", "service": "cadence"}'
 ```
 
 ## Webhook Events

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -75,6 +75,8 @@ pub struct FileConfig {
     pub read_api_key: Option<String>,
     /// Admin-scoped API key.
     pub admin_api_key: Option<String>,
+    /// Responder-write API key.
+    pub responder_api_key: Option<String>,
     /// Fallback API key.
     pub api_key: Option<String>,
 }
@@ -107,6 +109,20 @@ impl Config {
         Self::resolve_with_mode(endpoint_flag, key_flag, config_path, KeyMode::Ingest)
     }
 
+    /// Resolve config for responder claim and annotation writeback.
+    pub fn resolve_for_responder_write(
+        endpoint_flag: Option<String>,
+        key_flag: Option<String>,
+        config_path: Option<PathBuf>,
+    ) -> Result<Self> {
+        Self::resolve_with_mode(
+            endpoint_flag,
+            key_flag,
+            config_path,
+            KeyMode::ResponderWrite,
+        )
+    }
+
     fn resolve_with_mode(
         endpoint_flag: Option<String>,
         key_flag: Option<String>,
@@ -130,8 +146,17 @@ impl Config {
                 ("CANARY_ADMIN_KEY", env::var("CANARY_ADMIN_KEY").ok()),
                 ("CANARY_READ_API_KEY", env::var("CANARY_READ_API_KEY").ok()),
                 ("CANARY_READ_KEY", env::var("CANARY_READ_KEY").ok()),
+                (
+                    "CANARY_RESPONDER_API_KEY",
+                    env::var("CANARY_RESPONDER_API_KEY").ok(),
+                ),
+                (
+                    "CANARY_RESPONDER_KEY",
+                    env::var("CANARY_RESPONDER_KEY").ok(),
+                ),
                 ("config.admin_api_key", file_config.admin_api_key),
                 ("config.read_api_key", file_config.read_api_key),
+                ("config.responder_api_key", file_config.responder_api_key),
                 ("config.api_key", file_config.api_key),
                 ("CANARY_API_KEY", env::var("CANARY_API_KEY").ok()),
             ],
@@ -148,6 +173,26 @@ impl Config {
                 ),
                 ("CANARY_ADMIN_KEY", env::var("CANARY_ADMIN_KEY").ok()),
                 ("config.ingest_api_key", file_config.ingest_api_key),
+                ("config.admin_api_key", file_config.admin_api_key),
+                ("config.api_key", file_config.api_key),
+                ("CANARY_API_KEY", env::var("CANARY_API_KEY").ok()),
+            ],
+            KeyMode::ResponderWrite => vec![
+                ("--api-key", key_flag),
+                (
+                    "CANARY_RESPONDER_API_KEY",
+                    env::var("CANARY_RESPONDER_API_KEY").ok(),
+                ),
+                (
+                    "CANARY_RESPONDER_KEY",
+                    env::var("CANARY_RESPONDER_KEY").ok(),
+                ),
+                (
+                    "CANARY_ADMIN_API_KEY",
+                    env::var("CANARY_ADMIN_API_KEY").ok(),
+                ),
+                ("CANARY_ADMIN_KEY", env::var("CANARY_ADMIN_KEY").ok()),
+                ("config.responder_api_key", file_config.responder_api_key),
                 ("config.admin_api_key", file_config.admin_api_key),
                 ("config.api_key", file_config.api_key),
                 ("CANARY_API_KEY", env::var("CANARY_API_KEY").ok()),
@@ -187,7 +232,7 @@ impl Config {
     fn api_key(&self) -> Result<&str> {
         self.api_key.as_deref().ok_or_else(|| {
             CliError::Message(
-                "missing Canary API key; set --api-key, CANARY_ADMIN_API_KEY, CANARY_ADMIN_KEY, CANARY_INGEST_API_KEY, CANARY_INGEST_KEY, CANARY_READ_API_KEY, CANARY_READ_KEY, CANARY_API_KEY, or config api_key".to_owned(),
+                "missing Canary API key; set --api-key, CANARY_RESPONDER_API_KEY, CANARY_RESPONDER_KEY, CANARY_ADMIN_API_KEY, CANARY_ADMIN_KEY, CANARY_INGEST_API_KEY, CANARY_INGEST_KEY, CANARY_READ_API_KEY, CANARY_READ_KEY, CANARY_API_KEY, or config api_key".to_owned(),
             )
         })
     }
@@ -197,6 +242,7 @@ impl Config {
 enum KeyMode {
     Read,
     Ingest,
+    ResponderWrite,
 }
 
 /// Resolve an endpoint for local-only commands without reading config files.
@@ -513,6 +559,30 @@ pub fn summarize_claims(value: &Value) -> Vec<String> {
             ),
             format!("owner: {}", string_field(value, "owner")),
             format!("state: {}", string_field(value, "state")),
+        ]
+    }
+}
+
+/// Summarize annotation list or create responses.
+pub fn summarize_annotations(value: &Value) -> Vec<String> {
+    if value.get("annotations").is_some() {
+        vec![
+            format!("summary: {}", string_field(value, "summary")),
+            format!("annotations: {}", array_len(value, "annotations")),
+            format!("limit: {}", number_field(value, "limit")),
+            format!("truncated: {}", bool_field(value, "truncated")),
+            format!("cursor: {}", nullable_string_field(value, "cursor")),
+        ]
+    } else {
+        vec![
+            format!("id: {}", string_field(value, "id")),
+            format!(
+                "subject: {} {}",
+                string_field(value, "subject_type"),
+                string_field(value, "subject_id")
+            ),
+            format!("agent: {}", string_field(value, "agent")),
+            format!("action: {}", string_field(value, "action")),
         ]
     }
 }
@@ -4385,7 +4455,7 @@ impl McpToolContext {
                 ))
             }
             "canary_claim_create" => {
-                let client = self.read_client()?;
+                let client = self.responder_write_client()?;
                 let response = client.post_auth_json(
                     "/api/v1/claims",
                     &json!({
@@ -4405,7 +4475,7 @@ impl McpToolContext {
                 ))
             }
             "canary_claim_transition" => {
-                let client = self.read_client()?;
+                let client = self.responder_write_client()?;
                 let claim_id = required_string(arguments, "claim_id")?;
                 let response = client.post_auth_json(
                     &format!("/api/v1/claims/{}/transition", encode(&claim_id)),
@@ -4422,7 +4492,7 @@ impl McpToolContext {
                 ))
             }
             "canary_claim_release" => {
-                let client = self.read_client()?;
+                let client = self.responder_write_client()?;
                 let claim_id = required_string(arguments, "claim_id")?;
                 let response = client.post_auth_json(
                     &format!("/api/v1/claims/{}/release", encode(&claim_id)),
@@ -4430,6 +4500,45 @@ impl McpToolContext {
                 )?;
                 Ok(json_envelope(
                     "canary_claim_release",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_annotations_list" => {
+                let client = self.read_client()?;
+                let mut path = format!(
+                    "/api/v1/annotations?subject_type={}&subject_id={}",
+                    encode(&required_string(arguments, "subject_type")?),
+                    encode(&required_string(arguments, "subject_id")?)
+                );
+                if let Some(limit) = optional_u16(arguments, "limit")? {
+                    path.push_str(&format!("&limit={limit}"));
+                }
+                if let Some(cursor) = optional_string(arguments, "cursor")? {
+                    path.push_str("&cursor=");
+                    path.push_str(&encode(&cursor));
+                }
+                let response = client.get_auth_json(&path)?;
+                Ok(json_envelope(
+                    "canary_annotations_list",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_annotation_create" => {
+                let client = self.responder_write_client()?;
+                let response = client.post_auth_json(
+                    "/api/v1/annotations",
+                    &json!({
+                        "subject_type": required_string(arguments, "subject_type")?,
+                        "subject_id": required_string(arguments, "subject_id")?,
+                        "agent": required_string(arguments, "agent")?,
+                        "action": required_string(arguments, "action")?,
+                        "metadata": optional_object(arguments, "metadata")?,
+                    }),
+                )?;
+                Ok(json_envelope(
+                    "canary_annotation_create",
                     client.endpoint(),
                     response,
                 ))
@@ -4500,6 +4609,14 @@ impl McpToolContext {
 
     fn ingest_client(&self) -> Result<ApiClient> {
         ApiClient::new(Config::resolve_for_ingest(
+            self.endpoint.clone(),
+            self.api_key.clone(),
+            self.config_path.clone(),
+        )?)
+    }
+
+    fn responder_write_client(&self) -> Result<ApiClient> {
+        ApiClient::new(Config::resolve_for_responder_write(
             self.endpoint.clone(),
             self.api_key.clone(),
             self.config_path.clone(),
@@ -4723,6 +4840,16 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
             name: "canary_claim_release",
             description: "Release one remediation claim.",
             input_schema: json!({"type":"object","required":["claim_id","owner"],"properties":{"claim_id":{"type":"string"},"owner":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_annotations_list",
+            description: "List annotations for one Canary subject with read or responder-write authority.",
+            input_schema: json!({"type":"object","required":["subject_type","subject_id"],"properties":{"subject_type":{"type":"string","enum":["incident","error_group","target","monitor"]},"subject_id":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":50},"cursor":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_annotation_create",
+            description: "Write an annotation with responder-write authority after an agent completes follow-up work.",
+            input_schema: json!({"type":"object","required":["subject_type","subject_id","agent","action"],"properties":{"subject_type":{"type":"string","enum":["incident","error_group","target","monitor"]},"subject_id":{"type":"string"},"agent":{"type":"string"},"action":{"type":"string"},"metadata":{"type":"object"}}}),
         },
         ToolSpec {
             name: "canary_integrate_discover",
@@ -5033,14 +5160,16 @@ mod tests {
         let config_path = root.join("config.json");
         fs::write(
             &config_path,
-            r#"{"endpoint":"https://canary.example","read_api_key":"sk_read","ingest_api_key":"sk_ingest","admin_api_key":"sk_admin"}"#,
+            r#"{"endpoint":"https://canary.example","read_api_key":"sk_read","ingest_api_key":"sk_ingest","admin_api_key":"sk_admin","responder_api_key":"sk_responder"}"#,
         )?;
 
         let read_config = Config::resolve(None, None, Some(config_path.clone()))?;
-        let ingest_config = Config::resolve_for_ingest(None, None, Some(config_path))?;
+        let ingest_config = Config::resolve_for_ingest(None, None, Some(config_path.clone()))?;
+        let responder_config = Config::resolve_for_responder_write(None, None, Some(config_path))?;
 
         assert_eq!(read_config.api_key()?, "sk_admin");
         assert_eq!(ingest_config.api_key()?, "sk_ingest");
+        assert_eq!(responder_config.api_key()?, "sk_responder");
         assert_eq!(
             ingest_config.redacted_key(),
             "config.ingest_api_key: redacted"
@@ -5913,6 +6042,8 @@ Vercel CLI completed
         assert!(names.contains("canary_claim_create"));
         assert!(names.contains("canary_claim_transition"));
         assert!(names.contains("canary_claim_release"));
+        assert!(names.contains("canary_annotations_list"));
+        assert!(names.contains("canary_annotation_create"));
         assert!(names.contains("canary_dogfood_value"));
         let tool_by_name = manifest
             .iter()

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -12,10 +12,11 @@ use canary_cli::{
     RenderMode, Result, Window, doctor_report, dogfood_strict_failure_count, dogfood_value_report,
     encode, find_repo_root, integration_discover, integration_enroll, integration_patch,
     integration_plan, integration_status, json_envelope, mcp_tool_manifest, print_json,
-    print_lines, resolve_endpoint_without_config, run_dogfood_inventory, summarize_claims,
-    summarize_doctor, summarize_dogfood, summarize_dogfood_value, summarize_event,
-    summarize_incidents, summarize_integration, summarize_monitors, summarize_query,
-    summarize_report, summarize_services, summarize_targets, summarize_timeline, tool_manifest,
+    print_lines, resolve_endpoint_without_config, run_dogfood_inventory, summarize_annotations,
+    summarize_claims, summarize_doctor, summarize_dogfood, summarize_dogfood_value,
+    summarize_event, summarize_incidents, summarize_integration, summarize_monitors,
+    summarize_query, summarize_report, summarize_services, summarize_targets, summarize_timeline,
+    tool_manifest,
 };
 use clap::{Args, Parser, Subcommand};
 use serde_json::{Value, json};
@@ -60,6 +61,8 @@ enum Commands {
     Events(EventsArgs),
     /// Coordinate agentic remediation claims.
     Claims(ClaimsArgs),
+    /// Read or write coordination annotations.
+    Annotations(AnnotationsArgs),
     /// Discover, plan, patch, and enroll application integrations.
     Integrate(IntegrateArgs),
     /// Run an agent-oriented health and coverage diagnostic.
@@ -238,6 +241,46 @@ struct ClaimReleaseArgs {
     claim_id: String,
     #[arg(long)]
     owner: String,
+}
+
+#[derive(Debug, Args)]
+struct AnnotationsArgs {
+    #[command(subcommand)]
+    command: AnnotationsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum AnnotationsCommand {
+    /// List annotations for one subject.
+    List(AnnotationSubjectArgs),
+    /// Create an annotation for one subject.
+    Create(AnnotationCreateArgs),
+}
+
+#[derive(Debug, Args)]
+struct AnnotationSubjectArgs {
+    #[arg(long)]
+    subject_type: String,
+    #[arg(long)]
+    subject_id: String,
+    #[arg(long)]
+    limit: Option<u16>,
+    #[arg(long)]
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct AnnotationCreateArgs {
+    #[arg(long)]
+    subject_type: String,
+    #[arg(long)]
+    subject_id: String,
+    #[arg(long)]
+    agent: String,
+    #[arg(long)]
+    action: String,
+    #[arg(long = "metadata")]
+    metadata: Vec<String>,
 }
 
 #[derive(Debug, Args)]
@@ -468,116 +511,125 @@ fn run_http_command(
     config_path: Option<PathBuf>,
     mode: RenderMode,
 ) -> Result<()> {
-    let config = match &command {
-        Commands::Events(_) => Config::resolve_for_ingest(endpoint, api_key, config_path)?,
-        _ => Config::resolve(endpoint, api_key, config_path)?,
-    };
-    let client = ApiClient::new(config)?;
-
     match command {
-        Commands::Summary(args) => {
-            let window = Window::parse(&args.window)?;
-            let path = format!("/api/v1/report?window={}", window.as_str());
-            let response = client.get_auth_json(&path)?;
-            render(
-                "summary",
-                client.endpoint(),
-                response,
-                mode,
-                summarize_report,
-            )
+        Commands::Claims(args) => run_claims_command(args, endpoint, api_key, config_path, mode),
+        Commands::Annotations(args) => {
+            run_annotations_command(args, endpoint, api_key, config_path, mode)
         }
-        Commands::Services(args) => {
-            let window = Window::parse(&args.window)?;
-            let path = format!("/api/v1/status?window={}", window.as_str());
-            let response = client.get_auth_json(&path)?;
-            let state = args.state;
-            render_with_lines("services", client.endpoint(), response, mode, |value| {
-                summarize_services(value, state.as_deref())
-            })
-        }
-        Commands::Errors(args) => {
-            let window = Window::parse(&args.window)?;
-            let path = format!(
-                "/api/v1/query?service={}&window={}",
-                encode(&args.service),
-                window.as_str()
-            );
-            let response = client.get_auth_json(&path)?;
-            render("errors", client.endpoint(), response, mode, summarize_query)
-        }
-        Commands::Incidents(_args) => {
-            let response = client.get_auth_json("/api/v1/incidents")?;
-            render(
-                "incidents",
-                client.endpoint(),
-                response,
-                mode,
-                summarize_incidents,
-            )
-        }
-        Commands::Timeline(args) => {
-            let window = Window::parse(&args.window)?;
-            let mut path = format!(
-                "/api/v1/timeline?window={}&limit={}",
-                window.as_str(),
-                args.limit
-            );
-            if let Some(service) = args.service {
-                path.push_str("&service=");
-                path.push_str(&encode(&service));
+        command => {
+            let config = match &command {
+                Commands::Events(_) => Config::resolve_for_ingest(endpoint, api_key, config_path)?,
+                _ => Config::resolve(endpoint, api_key, config_path)?,
+            };
+            let client = ApiClient::new(config)?;
+
+            match command {
+                Commands::Summary(args) => {
+                    let window = Window::parse(&args.window)?;
+                    let path = format!("/api/v1/report?window={}", window.as_str());
+                    let response = client.get_auth_json(&path)?;
+                    render(
+                        "summary",
+                        client.endpoint(),
+                        response,
+                        mode,
+                        summarize_report,
+                    )
+                }
+                Commands::Services(args) => {
+                    let window = Window::parse(&args.window)?;
+                    let path = format!("/api/v1/status?window={}", window.as_str());
+                    let response = client.get_auth_json(&path)?;
+                    let state = args.state;
+                    render_with_lines("services", client.endpoint(), response, mode, |value| {
+                        summarize_services(value, state.as_deref())
+                    })
+                }
+                Commands::Errors(args) => {
+                    let window = Window::parse(&args.window)?;
+                    let path = format!(
+                        "/api/v1/query?service={}&window={}",
+                        encode(&args.service),
+                        window.as_str()
+                    );
+                    let response = client.get_auth_json(&path)?;
+                    render("errors", client.endpoint(), response, mode, summarize_query)
+                }
+                Commands::Incidents(_args) => {
+                    let response = client.get_auth_json("/api/v1/incidents")?;
+                    render(
+                        "incidents",
+                        client.endpoint(),
+                        response,
+                        mode,
+                        summarize_incidents,
+                    )
+                }
+                Commands::Timeline(args) => {
+                    let window = Window::parse(&args.window)?;
+                    let mut path = format!(
+                        "/api/v1/timeline?window={}&limit={}",
+                        window.as_str(),
+                        args.limit
+                    );
+                    if let Some(service) = args.service {
+                        path.push_str("&service=");
+                        path.push_str(&encode(&service));
+                    }
+                    let response = client.get_auth_json(&path)?;
+                    render(
+                        "timeline",
+                        client.endpoint(),
+                        response,
+                        mode,
+                        summarize_timeline,
+                    )
+                }
+                Commands::Targets => {
+                    let response = client.get_auth_json("/api/v1/targets")?;
+                    render(
+                        "targets",
+                        client.endpoint(),
+                        response,
+                        mode,
+                        summarize_targets,
+                    )
+                }
+                Commands::Monitors => {
+                    let response = client.get_auth_json("/api/v1/monitors")?;
+                    render(
+                        "monitors",
+                        client.endpoint(),
+                        response,
+                        mode,
+                        summarize_monitors,
+                    )
+                }
+                Commands::Events(args) => run_events_command(args, &client, mode),
+                Commands::Doctor => {
+                    let cwd = env::current_dir().map_err(|source| CliError::Io {
+                        path: PathBuf::from("."),
+                        source,
+                    })?;
+                    let repo_root = find_repo_root(&cwd)?;
+                    let response = doctor_report(&client, &repo_root);
+                    render(
+                        "doctor",
+                        client.endpoint(),
+                        response,
+                        mode,
+                        summarize_doctor,
+                    )
+                }
+                Commands::Dogfood(_)
+                | Commands::Integrate(_)
+                | Commands::McpManifest
+                | Commands::McpServer
+                | Commands::Claims(_)
+                | Commands::Annotations(_) => {
+                    unreachable!("handled before HTTP setup")
+                }
             }
-            let response = client.get_auth_json(&path)?;
-            render(
-                "timeline",
-                client.endpoint(),
-                response,
-                mode,
-                summarize_timeline,
-            )
-        }
-        Commands::Targets => {
-            let response = client.get_auth_json("/api/v1/targets")?;
-            render(
-                "targets",
-                client.endpoint(),
-                response,
-                mode,
-                summarize_targets,
-            )
-        }
-        Commands::Monitors => {
-            let response = client.get_auth_json("/api/v1/monitors")?;
-            render(
-                "monitors",
-                client.endpoint(),
-                response,
-                mode,
-                summarize_monitors,
-            )
-        }
-        Commands::Events(args) => run_events_command(args, &client, mode),
-        Commands::Claims(args) => run_claims_command(args, &client, mode),
-        Commands::Doctor => {
-            let cwd = env::current_dir().map_err(|source| CliError::Io {
-                path: PathBuf::from("."),
-                source,
-            })?;
-            let repo_root = find_repo_root(&cwd)?;
-            let response = doctor_report(&client, &repo_root);
-            render(
-                "doctor",
-                client.endpoint(),
-                response,
-                mode,
-                summarize_doctor,
-            )
-        }
-        Commands::Dogfood(_)
-        | Commands::Integrate(_)
-        | Commands::McpManifest
-        | Commands::McpServer => {
-            unreachable!("handled before HTTP setup")
         }
     }
 }
@@ -642,7 +694,7 @@ fn handle_mcp_message(context: &McpToolContext, message: &Value) -> Option<Value
                     "title": "Canary",
                     "version": env!("CARGO_PKG_VERSION")
                 },
-                "instructions": "Use Canary tools for agent-first production health inspection and remediation claims. Webhooks are wake-up hints; timeline/report replay is the correctness path."
+                "instructions": "Use Canary tools for agent-first production health inspection, remediation claims, and annotation writeback. Webhooks are wake-up hints; timeline/report replay is the correctness path."
             }),
         )),
         "ping" => Some(jsonrpc_result(id, json!({}))),
@@ -773,9 +825,16 @@ fn parse_attributes(attributes: &[String]) -> Result<serde_json::Map<String, ser
     Ok(object)
 }
 
-fn run_claims_command(args: ClaimsArgs, client: &ApiClient, mode: RenderMode) -> Result<()> {
+fn run_claims_command(
+    args: ClaimsArgs,
+    endpoint: Option<String>,
+    api_key: Option<String>,
+    config_path: Option<PathBuf>,
+    mode: RenderMode,
+) -> Result<()> {
     match args.command {
         ClaimsCommand::List(args) => {
+            let client = ApiClient::new(Config::resolve(endpoint, api_key, config_path)?)?;
             let mut path = format!(
                 "/api/v1/claims?subject_type={}&subject_id={}",
                 encode(&args.subject_type),
@@ -797,6 +856,11 @@ fn run_claims_command(args: ClaimsArgs, client: &ApiClient, mode: RenderMode) ->
             )
         }
         ClaimsCommand::Claim(args) => {
+            let client = ApiClient::new(Config::resolve_for_responder_write(
+                endpoint,
+                api_key,
+                config_path,
+            )?)?;
             let response = client.post_auth_json(
                 "/api/v1/claims",
                 &json!({
@@ -818,6 +882,7 @@ fn run_claims_command(args: ClaimsArgs, client: &ApiClient, mode: RenderMode) ->
             )
         }
         ClaimsCommand::Get(args) => {
+            let client = ApiClient::new(Config::resolve(endpoint, api_key, config_path)?)?;
             let response =
                 client.get_auth_json(&format!("/api/v1/claims/{}", encode(&args.claim_id)))?;
             render(
@@ -829,6 +894,11 @@ fn run_claims_command(args: ClaimsArgs, client: &ApiClient, mode: RenderMode) ->
             )
         }
         ClaimsCommand::Transition(args) => {
+            let client = ApiClient::new(Config::resolve_for_responder_write(
+                endpoint,
+                api_key,
+                config_path,
+            )?)?;
             let response = client.post_auth_json(
                 &format!("/api/v1/claims/{}/transition", encode(&args.claim_id)),
                 &json!({
@@ -846,6 +916,11 @@ fn run_claims_command(args: ClaimsArgs, client: &ApiClient, mode: RenderMode) ->
             )
         }
         ClaimsCommand::Release(args) => {
+            let client = ApiClient::new(Config::resolve_for_responder_write(
+                endpoint,
+                api_key,
+                config_path,
+            )?)?;
             let response = client.post_auth_json(
                 &format!("/api/v1/claims/{}/release", encode(&args.claim_id)),
                 &json!({
@@ -858,6 +933,65 @@ fn run_claims_command(args: ClaimsArgs, client: &ApiClient, mode: RenderMode) ->
                 response,
                 mode,
                 summarize_claims,
+            )
+        }
+    }
+}
+
+fn run_annotations_command(
+    args: AnnotationsArgs,
+    endpoint: Option<String>,
+    api_key: Option<String>,
+    config_path: Option<PathBuf>,
+    mode: RenderMode,
+) -> Result<()> {
+    match args.command {
+        AnnotationsCommand::List(args) => {
+            let client = ApiClient::new(Config::resolve(endpoint, api_key, config_path)?)?;
+            let mut path = format!(
+                "/api/v1/annotations?subject_type={}&subject_id={}",
+                encode(&args.subject_type),
+                encode(&args.subject_id)
+            );
+            if let Some(limit) = args.limit {
+                path.push_str(&format!("&limit={limit}"));
+            }
+            if let Some(cursor) = args.cursor {
+                path.push_str("&cursor=");
+                path.push_str(&encode(&cursor));
+            }
+            let response = client.get_auth_json(&path)?;
+            render(
+                "annotations list",
+                client.endpoint(),
+                response,
+                mode,
+                summarize_annotations,
+            )
+        }
+        AnnotationsCommand::Create(args) => {
+            let client = ApiClient::new(Config::resolve_for_responder_write(
+                endpoint,
+                api_key,
+                config_path,
+            )?)?;
+            let metadata = parse_attributes(&args.metadata)?;
+            let response = client.post_auth_json(
+                "/api/v1/annotations",
+                &json!({
+                    "subject_type": args.subject_type,
+                    "subject_id": args.subject_id,
+                    "agent": args.agent,
+                    "action": args.action,
+                    "metadata": metadata,
+                }),
+            )?;
+            render(
+                "annotations create",
+                client.endpoint(),
+                response,
+                mode,
+                summarize_annotations,
             )
         }
     }

--- a/crates/canary-http/src/auth.rs
+++ b/crates/canary-http/src/auth.rs
@@ -34,6 +34,8 @@ pub enum ApiKeyScope {
     IngestOnly,
     /// Access to read/query routes only.
     ReadOnly,
+    /// Access to read routes plus responder claim/annotation writeback.
+    ResponderWrite,
 }
 
 impl ApiKeyScope {
@@ -43,6 +45,7 @@ impl ApiKeyScope {
             Self::Admin => "admin",
             Self::IngestOnly => "ingest-only",
             Self::ReadOnly => "read-only",
+            Self::ResponderWrite => "responder-write",
         }
     }
 
@@ -52,6 +55,7 @@ impl ApiKeyScope {
             "admin" => Some(Self::Admin),
             "ingest-only" => Some(Self::IngestOnly),
             "read-only" => Some(Self::ReadOnly),
+            "responder-write" => Some(Self::ResponderWrite),
             _ => None,
         }
     }
@@ -61,7 +65,8 @@ impl ApiKeyScope {
         match permission {
             Permission::Admin => matches!(self, Self::Admin),
             Permission::Ingest => matches!(self, Self::Admin | Self::IngestOnly),
-            Permission::Read => matches!(self, Self::Admin | Self::ReadOnly),
+            Permission::Read => matches!(self, Self::Admin | Self::ReadOnly | Self::ResponderWrite),
+            Permission::ResponderWrite => matches!(self, Self::Admin | Self::ResponderWrite),
         }
     }
 }
@@ -75,6 +80,8 @@ pub enum Permission {
     Ingest,
     /// Query and reporting routes.
     Read,
+    /// Responder claim and annotation writeback routes.
+    ResponderWrite,
 }
 
 impl Permission {
@@ -83,7 +90,12 @@ impl Permission {
         match self {
             Self::Admin => &[ApiKeyScope::Admin],
             Self::Ingest => &[ApiKeyScope::Admin, ApiKeyScope::IngestOnly],
-            Self::Read => &[ApiKeyScope::Admin, ApiKeyScope::ReadOnly],
+            Self::Read => &[
+                ApiKeyScope::Admin,
+                ApiKeyScope::ReadOnly,
+                ApiKeyScope::ResponderWrite,
+            ],
+            Self::ResponderWrite => &[ApiKeyScope::Admin, ApiKeyScope::ResponderWrite],
         }
     }
 
@@ -92,6 +104,7 @@ impl Permission {
             Self::Admin => "admin",
             Self::Ingest => "ingest",
             Self::Read => "read",
+            Self::ResponderWrite => "responder-write",
         }
     }
 }
@@ -239,14 +252,22 @@ mod tests {
         assert!(ApiKeyScope::Admin.allows(Permission::Admin));
         assert!(ApiKeyScope::Admin.allows(Permission::Ingest));
         assert!(ApiKeyScope::Admin.allows(Permission::Read));
+        assert!(ApiKeyScope::Admin.allows(Permission::ResponderWrite));
 
         assert!(!ApiKeyScope::IngestOnly.allows(Permission::Admin));
         assert!(ApiKeyScope::IngestOnly.allows(Permission::Ingest));
         assert!(!ApiKeyScope::IngestOnly.allows(Permission::Read));
+        assert!(!ApiKeyScope::IngestOnly.allows(Permission::ResponderWrite));
 
         assert!(!ApiKeyScope::ReadOnly.allows(Permission::Admin));
         assert!(!ApiKeyScope::ReadOnly.allows(Permission::Ingest));
         assert!(ApiKeyScope::ReadOnly.allows(Permission::Read));
+        assert!(!ApiKeyScope::ReadOnly.allows(Permission::ResponderWrite));
+
+        assert!(!ApiKeyScope::ResponderWrite.allows(Permission::Admin));
+        assert!(!ApiKeyScope::ResponderWrite.allows(Permission::Ingest));
+        assert!(ApiKeyScope::ResponderWrite.allows(Permission::Read));
+        assert!(ApiKeyScope::ResponderWrite.allows(Permission::ResponderWrite));
     }
 
     #[test]
@@ -257,6 +278,10 @@ mod tests {
             Some(ApiKeyScope::IngestOnly)
         );
         assert_eq!(ApiKeyScope::parse("read-only"), Some(ApiKeyScope::ReadOnly));
+        assert_eq!(
+            ApiKeyScope::parse("responder-write"),
+            Some(ApiKeyScope::ResponderWrite)
+        );
         assert_eq!(ApiKeyScope::parse("ingest_only"), None);
         assert_eq!(ApiKeyScope::parse(""), None);
     }

--- a/crates/canary-server/src/admin_keys.rs
+++ b/crates/canary-server/src/admin_keys.rs
@@ -211,8 +211,10 @@ fn parse_api_key_create(attrs: Map<String, Value>) -> Result<ApiKeyCreate, Box<P
             "admin".to_owned()
         }
     };
-    if !matches!(scope.as_str(), "admin" | "ingest-only" | "read-only")
-        && !matches!(attrs.get("scope"), Some(value) if !value.is_string())
+    if !matches!(
+        scope.as_str(),
+        "admin" | "ingest-only" | "read-only" | "responder-write"
+    ) && !matches!(attrs.get("scope"), Some(value) if !value.is_string())
     {
         errors.insert("scope".to_owned(), vec!["is invalid".to_owned()]);
     }
@@ -232,6 +234,12 @@ fn parse_api_key_create(attrs: Map<String, Value>) -> Result<ApiKeyCreate, Box<P
         errors.insert(
             "service".to_owned(),
             vec!["cannot be set on admin keys".to_owned()],
+        );
+    }
+    if service.is_none() && scope == "responder-write" {
+        errors.insert(
+            "service".to_owned(),
+            vec!["is required for responder-write keys".to_owned()],
         );
     }
 

--- a/crates/canary-server/src/annotations.rs
+++ b/crates/canary-server/src/annotations.rs
@@ -24,12 +24,11 @@ use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
 use crate::{
-    IngestState,
+    IngestState, enforce_service_authority,
     http_contract::{check_content_length, json_status_response, problem_response},
-    require_query_limited_admin_scope, require_read_scope, require_scope,
+    require_read_scope, require_responder_write_scope,
     server_time::current_rfc3339,
 };
-use canary_http::auth::Permission;
 
 #[derive(Deserialize)]
 pub(crate) struct AnnotationPageParams {
@@ -154,7 +153,7 @@ pub(crate) async fn create_annotation(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response<Body> {
-    let authority = match require_scope(&state, &headers, Permission::Admin) {
+    let authority = match require_responder_write_scope(&state, &headers) {
         Ok(authority) => authority,
         Err(problem) => return problem_response(*problem),
     };
@@ -220,7 +219,7 @@ fn create_annotation_for_subject(
     subject_id: String,
     not_found_detail: &'static str,
 ) -> Response<Body> {
-    let authority = match require_query_limited_admin_scope(&state, &headers) {
+    let authority = match require_responder_write_scope(&state, &headers) {
         Ok(authority) => authority,
         Err(problem) => return problem_response(*problem),
     };
@@ -250,8 +249,8 @@ fn create_annotation_request(
     request: AnnotationCreate,
     not_found_detail: &'static str,
 ) -> Response<Body> {
-    let tenant_id = authority.tenant_id;
-    let project_id = authority.project_id;
+    let tenant_id = authority.tenant_id.clone();
+    let project_id = authority.project_id.clone();
     let (annotation, service) = {
         let mut store = match state.lock_store() {
             Ok(store) => store,
@@ -275,6 +274,16 @@ fn create_annotation_request(
             }
             Err(AnnotationError::Sqlite(_)) => return problem_response(internal_problem()),
         };
+        if let Some(service) = service.as_deref()
+            && let Err(problem) = enforce_service_authority(&authority, service)
+        {
+            return problem_response(*problem);
+        }
+        if service.is_none()
+            && let Some(bound_service) = authority.service.as_deref()
+        {
+            return problem_response(crate::service_authority_problem(bound_service, "*"));
+        }
         let annotation = match store.create_annotation(AnnotationInsert {
             id: canary_core::ids::AnnotationId::generate().into_string(),
             tenant_id: tenant_id.clone(),

--- a/crates/canary-server/src/claims.rs
+++ b/crates/canary-server/src/claims.rs
@@ -22,7 +22,7 @@ use crate::{
     IngestState,
     body_fields::{optional_positive_i64, required_string},
     http_contract::{check_content_length, json_status_response, problem_response},
-    require_query_limited_admin_scope, require_read_scope,
+    require_read_scope, require_responder_write_scope,
     server_time::{current_rfc3339, current_utc, format_rfc3339},
 };
 
@@ -149,7 +149,7 @@ pub(crate) async fn create_claim(
     if let Err(problem) = check_content_length(&headers) {
         return problem_response(payload_too_large_problem(problem.detail));
     }
-    let authority = match require_query_limited_admin_scope(&state, &headers) {
+    let authority = match require_responder_write_scope(&state, &headers) {
         Ok(authority) => authority,
         Err(problem) => return problem_response(*problem),
     };
@@ -226,7 +226,7 @@ pub(crate) async fn transition_claim(
     if let Err(problem) = check_content_length(&headers) {
         return problem_response(payload_too_large_problem(problem.detail));
     }
-    let authority = match require_query_limited_admin_scope(&state, &headers) {
+    let authority = match require_responder_write_scope(&state, &headers) {
         Ok(authority) => authority,
         Err(problem) => return problem_response(*problem),
     };
@@ -250,7 +250,7 @@ pub(crate) async fn release_claim(
     if let Err(problem) = check_content_length(&headers) {
         return problem_response(payload_too_large_problem(problem.detail));
     }
-    let authority = match require_query_limited_admin_scope(&state, &headers) {
+    let authority = match require_responder_write_scope(&state, &headers) {
         Ok(authority) => authority,
         Err(problem) => return problem_response(*problem),
     };

--- a/crates/canary-server/src/keygen.rs
+++ b/crates/canary-server/src/keygen.rs
@@ -15,13 +15,15 @@ use canary_store::{
 use crate::server_time::current_rfc3339;
 
 /// Scopes accepted by the minting path, mirroring the router's permission model.
-const VALID_SCOPES: [&str; 3] = ["admin", "read-only", "ingest-only"];
+const VALID_SCOPES: [&str; 4] = ["admin", "read-only", "ingest-only", "responder-write"];
 
 /// Failure modes when minting an operator API key.
 #[derive(Debug)]
 pub enum MintKeyError {
-    /// The requested scope is not one of `admin`, `read-only`, `ingest-only`.
+    /// The requested scope is not one of Canary's stable key scopes.
     InvalidScope(String),
+    /// The service binding is missing or invalid for the requested scope.
+    InvalidServiceBinding(String),
     /// Opening, migrating, or writing to the store failed.
     Store(canary_store::StoreError),
     /// Bcrypt hashing of the raw key failed.
@@ -33,8 +35,9 @@ impl std::fmt::Display for MintKeyError {
         match self {
             MintKeyError::InvalidScope(scope) => write!(
                 f,
-                "invalid scope {scope:?}; expected one of admin, read-only, ingest-only"
+                "invalid scope {scope:?}; expected one of admin, read-only, ingest-only, responder-write"
             ),
+            MintKeyError::InvalidServiceBinding(message) => write!(f, "{message}"),
             MintKeyError::Store(error) => write!(f, "store error: {error}"),
             MintKeyError::Hash(error) => write!(f, "hash error: {error}"),
         }
@@ -48,9 +51,33 @@ impl std::error::Error for MintKeyError {}
 /// The raw key is shown only here; the store persists the bcrypt hash. Opening
 /// a second connection while the server runs is safe for this one-shot insert:
 /// SQLite WAL serializes the brief write transaction behind the live writer.
-pub fn mint_key(db_path: &Path, scope: &str, name: &str) -> Result<String, MintKeyError> {
+pub fn mint_key(
+    db_path: &Path,
+    scope: &str,
+    name: &str,
+    service: Option<&str>,
+) -> Result<String, MintKeyError> {
     if !VALID_SCOPES.contains(&scope) {
         return Err(MintKeyError::InvalidScope(scope.to_owned()));
+    }
+    let service = match service {
+        Some(value) if !value.trim().is_empty() => Some(value.trim().to_owned()),
+        Some(_) => {
+            return Err(MintKeyError::InvalidServiceBinding(
+                "--service must not be blank".to_owned(),
+            ));
+        }
+        None if scope == "responder-write" => {
+            return Err(MintKeyError::InvalidServiceBinding(
+                "--service is required for responder-write keys".to_owned(),
+            ));
+        }
+        None => None,
+    };
+    if scope == "admin" && service.is_some() {
+        return Err(MintKeyError::InvalidServiceBinding(
+            "--service cannot be set on admin keys".to_owned(),
+        ));
     }
 
     let mut store = Store::open(db_path).map_err(MintKeyError::Store)?;
@@ -70,7 +97,7 @@ pub fn mint_key(db_path: &Path, scope: &str, name: &str) -> Result<String, MintK
             scope: scope.to_owned(),
             tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
-            service: None,
+            service,
         })
         .map_err(MintKeyError::Store)?;
 
@@ -112,7 +139,7 @@ mod tests {
         let db_path = unique_db_path("roundtrip");
         let _guard = DbGuard(db_path.clone());
 
-        let raw_key = mint_key(&db_path, "admin", "recovery")?;
+        let raw_key = mint_key(&db_path, "admin", "recovery", None)?;
 
         let store = Store::open(&db_path)?;
         let verified = store
@@ -127,10 +154,31 @@ mod tests {
         let db_path = unique_db_path("badscope");
         let _guard = DbGuard(db_path.clone());
 
-        let result = mint_key(&db_path, "superuser", "x");
+        let result = mint_key(&db_path, "superuser", "x", None);
         assert!(
             matches!(&result, Err(MintKeyError::InvalidScope(scope)) if scope == "superuser"),
             "expected InvalidScope(\"superuser\"), got {result:?}"
         );
+    }
+
+    #[test]
+    fn responder_write_key_requires_service_binding() -> Result<(), Box<dyn std::error::Error>> {
+        let db_path = unique_db_path("responder");
+        let _guard = DbGuard(db_path.clone());
+
+        let missing = mint_key(&db_path, "responder-write", "bot", None);
+        assert!(
+            matches!(&missing, Err(MintKeyError::InvalidServiceBinding(message)) if message.contains("--service is required")),
+            "expected missing service binding, got {missing:?}"
+        );
+
+        let raw_key = mint_key(&db_path, "responder-write", "bot", Some("billing"))?;
+        let store = Store::open(&db_path)?;
+        let verified = store
+            .verify_api_key(&raw_key)?
+            .ok_or("minted key should verify as active")?;
+        assert_eq!(verified.scope, "responder-write");
+        assert_eq!(verified.service.as_deref(), Some("billing"));
+        Ok(())
     }
 }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -97,7 +97,7 @@ pub use runtime_env::{RuntimeEnvError, ServerProcessConfig};
 pub(crate) use server_auth::{UNKNOWN_AUTH_FAIL_IDENTITY, auth_fail_identity};
 pub(crate) use server_auth::{
     enforce_service_authority, require_ingest_scope, require_query_limited_admin_scope,
-    require_read_scope, require_scope, service_authority_problem,
+    require_read_scope, require_responder_write_scope, require_scope, service_authority_problem,
 };
 use service_onboarding_routes::create_service_onboarding;
 pub use target_probes::{
@@ -291,13 +291,16 @@ mod tests {
     const WRONG_INGEST_PREFIX_KEY: &str = "sk_live_ingest_wrong";
     const READ_KEY: &str = "sk_live_read_secret";
     const OTHER_READ_KEY: &str = "sk_live_other_read_secret";
+    const RESPONDER_KEY: &str = "sk_live_responder_secret";
     const REVOKED_KEY: &str = "sk_live_revoked_secret";
     static ADMIN_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY];
     static INGEST_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY, INGEST_KEY];
-    static READ_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY, READ_KEY];
-    static ADMIN_REJECTED_KEYS: &[&str] = &[INGEST_KEY, READ_KEY];
-    static INGEST_REJECTED_KEYS: &[&str] = &[READ_KEY];
+    static READ_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY, READ_KEY, RESPONDER_KEY];
+    static RESPONDER_WRITE_ACCEPTED_KEYS: &[&str] = &[ADMIN_KEY, RESPONDER_KEY];
+    static ADMIN_REJECTED_KEYS: &[&str] = &[INGEST_KEY, READ_KEY, RESPONDER_KEY];
+    static INGEST_REJECTED_KEYS: &[&str] = &[READ_KEY, RESPONDER_KEY];
     static READ_REJECTED_KEYS: &[&str] = &[INGEST_KEY];
+    static RESPONDER_WRITE_REJECTED_KEYS: &[&str] = &[INGEST_KEY, READ_KEY];
     const TEST_BCRYPT_COST: u32 = 4;
     static TEMP_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -378,7 +381,7 @@ mod tests {
             "POST",
             "/api/v1/incidents/{incident_id}/annotations",
             "/api/v1/incidents/INC-route/annotations",
-            "admin",
+            "responder-write",
         ),
         auth_route(
             "GET",
@@ -390,7 +393,7 @@ mod tests {
             "POST",
             "/api/v1/groups/{group_hash}/annotations",
             "/api/v1/groups/group-route/annotations",
-            "admin",
+            "responder-write",
         ),
         auth_route(
             "GET",
@@ -402,10 +405,15 @@ mod tests {
             "POST",
             "/api/v1/annotations",
             "/api/v1/annotations",
-            "admin",
+            "responder-write",
         ),
         auth_route("GET", "/api/v1/claims", "/api/v1/claims", "read-only"),
-        auth_route("POST", "/api/v1/claims", "/api/v1/claims", "admin"),
+        auth_route(
+            "POST",
+            "/api/v1/claims",
+            "/api/v1/claims",
+            "responder-write",
+        ),
         auth_route(
             "GET",
             "/api/v1/claims/{id}",
@@ -416,13 +424,13 @@ mod tests {
             "POST",
             "/api/v1/claims/{id}/transition",
             "/api/v1/claims/CLM-route/transition",
-            "admin",
+            "responder-write",
         ),
         auth_route(
             "POST",
             "/api/v1/claims/{id}/release",
             "/api/v1/claims/CLM-route/release",
-            "admin",
+            "responder-write",
         ),
         auth_route(
             "GET",
@@ -505,6 +513,7 @@ mod tests {
             "admin" => Ok(ADMIN_ACCEPTED_KEYS),
             "ingest-only" => Ok(INGEST_ACCEPTED_KEYS),
             "read-only" => Ok(READ_ACCEPTED_KEYS),
+            "responder-write" => Ok(RESPONDER_WRITE_ACCEPTED_KEYS),
             scope => Err(format!("unknown scope in route spec: {scope}").into()),
         }
     }
@@ -516,6 +525,7 @@ mod tests {
             "admin" => Ok(ADMIN_REJECTED_KEYS),
             "ingest-only" => Ok(INGEST_REJECTED_KEYS),
             "read-only" => Ok(READ_REJECTED_KEYS),
+            "responder-write" => Ok(RESPONDER_WRITE_REJECTED_KEYS),
             scope => Err(format!("unknown scope in route spec: {scope}").into()),
         }
     }
@@ -4833,6 +4843,35 @@ mod tests {
         assert_eq!(default_key["name"], "unnamed");
         assert_eq!(default_key["scope"], "admin");
 
+        let responder_response = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/keys",
+                ADMIN_KEY,
+                r#"{"name":"bb-responder","scope":"responder-write","service":"bitterblossom"}"#,
+            )?)
+            .await?;
+        assert_eq!(responder_response.status(), StatusCode::CREATED);
+        let responder_key = json_body(responder_response).await?;
+        assert_eq!(responder_key["scope"], "responder-write");
+        assert_eq!(responder_key["service"], "bitterblossom");
+
+        let unbound_responder = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/keys",
+                ADMIN_KEY,
+                r#"{"name":"bad-responder","scope":"responder-write"}"#,
+            )?)
+            .await?;
+        assert_eq!(unbound_responder.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            json_body(unbound_responder).await?["errors"]["service"],
+            json!(["is required for responder-write keys"])
+        );
+
         let forbidden_response = router
             .clone()
             .oneshot(json_request(
@@ -5357,7 +5396,7 @@ mod tests {
                 StatusCode::FORBIDDEN,
                 "insufficient_scope",
                 "detail",
-                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` key.",
+                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` or `responder-write` key.",
             ),
             (
                 read_request(READ_KEY, "/api/v1/timeline?window=99h")?,
@@ -5581,7 +5620,7 @@ mod tests {
                 StatusCode::FORBIDDEN,
                 "insufficient_scope",
                 "detail",
-                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` key.",
+                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` or `responder-write` key.",
             ),
             (
                 read_request(READ_KEY, "/api/v1/webhook-deliveries?limit=0")?,
@@ -5784,7 +5823,7 @@ mod tests {
         assert_eq!(forbidden_body["code"], "insufficient_scope");
         assert_eq!(
             forbidden_body["detail"],
-            "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` key."
+            "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` or `responder-write` key."
         );
 
         Ok(())
@@ -6175,7 +6214,7 @@ mod tests {
             assert_eq!(body["code"], "insufficient_scope", "{path}");
             assert_eq!(
                 body["detail"],
-                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` key.",
+                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` or `responder-write` key.",
                 "{path}"
             );
         }
@@ -6997,7 +7036,7 @@ mod tests {
                 read_request(INGEST_KEY, "/api/v1/targets/TGT-any/checks")?,
                 StatusCode::FORBIDDEN,
                 "insufficient_scope",
-                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` key.",
+                "API key scope `ingest-only` cannot access this read endpoint. Use an `admin` or `read-only` or `responder-write` key.",
             ),
         ];
 
@@ -7378,6 +7417,121 @@ mod tests {
                 ]
             );
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn responder_write_key_claims_and_annotates_only_bound_service()
+    -> Result<(), Box<dyn Error>> {
+        const API_RESPONDER_KEY: &str = "sk_live_claims_api_responder_secret";
+        const WEB_RESPONDER_KEY: &str = "sk_live_claims_web_responder_secret";
+        let state = test_ingest_state()?;
+        {
+            let mut store = state.lock_store().map_err(|_| "store lock poisoned")?;
+            seed_responder_api_key_for_service(
+                &mut store,
+                "KEY-api-responder",
+                API_RESPONDER_KEY,
+                "api",
+            )?;
+            seed_responder_api_key_for_service(
+                &mut store,
+                "KEY-web-responder",
+                WEB_RESPONDER_KEY,
+                "web",
+            )?;
+            seed_target(&mut store, "api")?;
+            seed_target(&mut store, "web")?;
+        }
+        let router = ingest_router(state);
+
+        let created = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/claims",
+                API_RESPONDER_KEY,
+                r#"{"subject_type":"target","subject_id":"TGT-api","owner":"codex","purpose":"responder loop","ttl_ms":900000,"idempotency_key":"api-run"}"#,
+            )?)
+            .await?;
+        assert_eq!(created.status(), StatusCode::CREATED);
+        let created_body = json_body(created).await?;
+        assert_eq!(created_body["service"], "api");
+        let claim_id = created_body["id"]
+            .as_str()
+            .ok_or("missing claim id")?
+            .to_owned();
+
+        let visible = router
+            .clone()
+            .oneshot(read_request(
+                API_RESPONDER_KEY,
+                &format!("/api/v1/claims/{claim_id}"),
+            )?)
+            .await?;
+        assert_eq!(visible.status(), StatusCode::OK);
+
+        let hidden = router
+            .clone()
+            .oneshot(read_request(
+                WEB_RESPONDER_KEY,
+                &format!("/api/v1/claims/{claim_id}"),
+            )?)
+            .await?;
+        assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+        let cross_claim = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/claims",
+                API_RESPONDER_KEY,
+                r#"{"subject_type":"target","subject_id":"TGT-web","owner":"codex","purpose":"wrong service","ttl_ms":900000,"idempotency_key":"web-run"}"#,
+            )?)
+            .await?;
+        assert_eq!(cross_claim.status(), StatusCode::NOT_FOUND);
+
+        let transitioned = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                &format!("/api/v1/claims/{claim_id}/transition"),
+                API_RESPONDER_KEY,
+                r#"{"owner":"codex","state":"verified","evidence_links":["https://example.com/proof"]}"#,
+            )?)
+            .await?;
+        assert_eq!(transitioned.status(), StatusCode::OK);
+        assert_eq!(json_body(transitioned).await?["state"], "verified");
+
+        let annotation = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/annotations",
+                API_RESPONDER_KEY,
+                r#"{"subject_type":"target","subject_id":"TGT-api","agent":"codex","action":"fix-verified","metadata":{"claim_id":"CLM-test"}}"#,
+            )?)
+            .await?;
+        assert_eq!(annotation.status(), StatusCode::CREATED);
+        let annotation_body = json_body(annotation).await?;
+        assert_eq!(annotation_body["subject_id"], "TGT-api");
+        assert_eq!(annotation_body["action"], "fix-verified");
+
+        let cross_annotation = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/annotations",
+                API_RESPONDER_KEY,
+                r#"{"subject_type":"target","subject_id":"TGT-web","agent":"codex","action":"fix-verified"}"#,
+            )?)
+            .await?;
+        assert_eq!(cross_annotation.status(), StatusCode::FORBIDDEN);
+        let cross_body = json_body(cross_annotation).await?;
+        assert_eq!(cross_body["code"], "insufficient_scope");
+        assert_eq!(cross_body["bound_service"], "api");
+        assert_eq!(cross_body["requested_service"], "web");
 
         Ok(())
     }
@@ -8964,6 +9118,7 @@ mod tests {
         seed_api_key(&mut store, "KEY-admin", ADMIN_KEY, "admin", None)?;
         seed_api_key(&mut store, "KEY-ingest", INGEST_KEY, "ingest-only", None)?;
         seed_api_key(&mut store, "KEY-read", READ_KEY, "read-only", None)?;
+        seed_responder_api_key_for_service(&mut store, "KEY-responder", RESPONDER_KEY, "test-svc")?;
         seed_api_key(
             &mut store,
             "KEY-revoked",
@@ -9159,6 +9314,27 @@ mod tests {
             created_at: "2026-05-28T20:00:00Z".to_owned(),
             revoked_at: None,
             scope: "read-only".to_owned(),
+            tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
+            project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
+            service: Some(service.to_owned()),
+        })?;
+        Ok(())
+    }
+
+    fn seed_responder_api_key_for_service(
+        store: &mut Store,
+        id: &str,
+        raw_key: &str,
+        service: &str,
+    ) -> Result<(), Box<dyn Error>> {
+        store.insert_api_key(ApiKeyInsert {
+            id: id.to_owned(),
+            name: format!("key {id}"),
+            key_prefix: raw_key.chars().take(API_KEY_PREFIX_LEN).collect(),
+            key_hash: bcrypt::hash(raw_key, TEST_BCRYPT_COST)?,
+            created_at: "2026-05-28T20:00:00Z".to_owned(),
+            revoked_at: None,
+            scope: "responder-write".to_owned(),
             tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
             service: Some(service.to_owned()),

--- a/crates/canary-server/src/main.rs
+++ b/crates/canary-server/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn Error>> {
-    // Operator subcommand: `canary-server mint-key [--scope S] [--name N]`.
+    // Operator subcommand: `canary-server mint-key [--scope S] [--name N] [--service SERVICE]`.
     // Recovery path for issuing a scoped API key directly against the SQLite
     // store when the one-time bootstrap key has been lost. Defaults to admin.
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -36,6 +36,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
 fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
     let mut scope = "admin".to_owned();
     let mut name = "operator-minted".to_owned();
+    let mut service: Option<String> = None;
     let mut iter = args.iter();
     while let Some(flag) = iter.next() {
         match flag.as_str() {
@@ -45,6 +46,9 @@ fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
             "--name" => {
                 name = iter.next().ok_or("--name requires a value")?.clone();
             }
+            "--service" => {
+                service = Some(iter.next().ok_or("--service requires a value")?.clone());
+            }
             other => return Err(format!("unknown mint-key argument: {other}").into()),
         }
     }
@@ -53,7 +57,7 @@ fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_DB_PATH));
 
-    let raw_key = keygen::mint_key(&db_path, &scope, &name)?;
+    let raw_key = keygen::mint_key(&db_path, &scope, &name, service.as_deref())?;
     // The raw key prints to stdout; everything else goes to stderr so the key
     // can be captured cleanly (e.g. `... mint-key | tail -1`).
     eprintln!(

--- a/crates/canary-server/src/server_auth.rs
+++ b/crates/canary-server/src/server_auth.rs
@@ -50,6 +50,20 @@ pub(crate) fn require_query_limited_admin_scope(
     Ok(key)
 }
 
+pub(crate) fn require_responder_write_scope(
+    state: &IngestState,
+    headers: &HeaderMap,
+) -> Result<VerifiedApiKey, Box<ProblemDetails>> {
+    let key = require_scope(state, headers, Permission::ResponderWrite)?;
+    if ApiKeyScope::parse(&key.scope) == Some(ApiKeyScope::ResponderWrite)
+        && key.service.as_deref().is_none()
+    {
+        return Err(Box::new(responder_service_binding_problem()));
+    }
+    enforce_rate_limit(state, RateLimitKind::Query, &key.id)?;
+    Ok(key)
+}
+
 pub(crate) fn require_scope(
     state: &IngestState,
     headers: &HeaderMap,
@@ -129,6 +143,17 @@ pub(crate) fn service_authority_problem(
     )
     .with_extra("bound_service", json!(bound_service))
     .with_extra("requested_service", json!(requested_service))
+}
+
+pub(crate) fn responder_service_binding_problem() -> ProblemDetails {
+    ProblemDetails::new(
+        StatusCode::FORBIDDEN.as_u16(),
+        ProblemCode::InsufficientScope,
+        "API key scope `responder-write` must be bound to one service.",
+        None,
+    )
+    .with_extra("scope", json!("responder-write"))
+    .with_extra("required_service_binding", json!(true))
 }
 
 fn reject_limited_unknown_prefix(

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -13,7 +13,8 @@ The CLI reads:
 - `CANARY_ENDPOINT` for the target Canary instance. Self-hosted operators
   should set this explicitly and should not rely on compiled legacy defaults.
 - `CANARY_ADMIN_API_KEY`, `CANARY_ADMIN_KEY`, `CANARY_READ_API_KEY`,
-  `CANARY_READ_KEY`, or `CANARY_API_KEY`
+  `CANARY_READ_KEY`, `CANARY_RESPONDER_API_KEY`, `CANARY_RESPONDER_KEY`, or
+  `CANARY_API_KEY`
 - `CANARY_CONFIG`, or `~/.config/canary/config.json`
 
 Config JSON:
@@ -22,15 +23,18 @@ Config JSON:
 {
   "endpoint": "https://<your-fly-app>.fly.dev",
   "admin_api_key": "sk_live_...",
-  "read_api_key": "sk_live_..."
+  "read_api_key": "sk_live_...",
+  "responder_api_key": "sk_live_..."
 }
 ```
 
-Admin keys are preferred over read keys when both are present because target
-and monitor inspection use admin-scoped routes. Scoped read/admin credentials
-from env or config are preferred over generic `CANARY_API_KEY` so app ingest
-keys do not shadow operator credentials. Diagnostics redact keys and fail
-closed when an authenticated command is run without a read/admin key.
+Responder keys are preferred for claim and annotation writeback. Admin keys are
+accepted for break-glass operator use, but a service-bound `responder-write`
+key is the intended runtime credential for agents. Scoped read, responder, and
+admin credentials from env or config are preferred over generic
+`CANARY_API_KEY` so app ingest keys do not shadow operator credentials.
+Diagnostics redact keys and fail closed when an authenticated command is run
+without a key that matches the command's authority model.
 
 ## Commands
 
@@ -40,6 +44,10 @@ bin/canary services --state down --json
 bin/canary errors chrondle --window 24h
 bin/canary incidents --open
 bin/canary timeline --service chrondle --window 7d --limit 20
+bin/canary claims list --subject-type target --subject-id TGT-chrondle --json
+bin/canary claims claim --subject-type target --subject-id TGT-chrondle --owner codex --purpose "verify fix" --json
+bin/canary annotations list --subject-type target --subject-id TGT-chrondle --json
+bin/canary annotations create --subject-type target --subject-id TGT-chrondle --agent codex --action fix-verified --metadata pr=https://github.com/example/repo/pull/1 --json
 bin/canary targets
 bin/canary monitors
 bin/canary dogfood audit --strict
@@ -253,7 +261,8 @@ the CLI:
   "args": ["mcp-server"],
   "env": {
     "CANARY_ENDPOINT": "https://<your-fly-app>.fly.dev",
-    "CANARY_READ_API_KEY": "redacted"
+    "CANARY_READ_API_KEY": "redacted",
+    "CANARY_RESPONDER_KEY": "redacted"
   }
 }
 ```
@@ -281,6 +290,7 @@ is gated against `tool_manifest()` so it cannot drift from the runtime list.
 The manifest covers the drill-down surfaces an agent needs after
 `canary_doctor`: summary, services, errors, incidents, timeline, targets,
 monitors, dogfood audit, dogfood value receipts, witness, DR status, event
-capture, remediation claims, and integration discovery/status/plan/patch/enroll.
-The MCP server implements those tools directly through the CLI-backed adapter;
-it does not define separate route semantics.
+capture, remediation claims, annotations, and integration
+discovery/status/plan/patch/enroll. The MCP server implements those tools
+directly through the CLI-backed adapter; it does not define separate route
+semantics.

--- a/docs/api-key-rotation.md
+++ b/docs/api-key-rotation.md
@@ -4,7 +4,8 @@ Canary API keys are scoped. Use the narrowest key that matches the caller:
 
 - `ingest-only`: `POST /api/v1/errors`
 - `read-only`: query, report, timeline, incidents, and read-only health endpoints
-- `admin`: target, webhook, onboarding, metrics, annotations write, and key management
+- `responder-write`: service-bound read access plus remediation claim and annotation writeback
+- `admin`: target, webhook, onboarding, metrics, key management, and break-glass responder writes
 
 Manual rotation is the supported path for now.
 
@@ -54,6 +55,31 @@ curl -X POST $CANARY_ENDPOINT/api/v1/keys \
    - `read-only`: `GET /api/v1/report?window=1h` returns `200`
    - `admin`: key management or target management routes return `200`
 4. Revoke the previous key only after the replacement is confirmed in use.
+
+## Rotate A Responder-Write Key
+
+`responder-write` keys must be bound to one service. They can read that
+service's responder context and write remediation claims or annotations for
+subjects owned by the same service; they cannot ingest data, administer Canary,
+or cross service boundaries.
+
+1. Create the replacement with the same service binding:
+
+```bash
+curl -X POST $CANARY_ENDPOINT/api/v1/keys \
+  -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "billing-api-responder-2026-04", "scope": "responder-write", "service": "billing-api"}'
+```
+
+2. Store the returned raw key as `CANARY_RESPONDER_KEY` or
+   `CANARY_RESPONDER_API_KEY` in the responder runtime.
+3. Verify the replacement can read and write only the bound service:
+   - `bin/canary annotations list --subject-type target --subject-id TGT-billing-api --json` returns `200`
+   - `bin/canary annotations create --subject-type target --subject-id TGT-billing-api --agent rotation-check --action verified --json` returns `201`
+   - the same create call against another service's target returns RFC 9457 `403`
+4. Revoke the previous responder key after the runtime is confirmed on the new
+   key.
 
 ## Zero-Downtime Rule
 

--- a/docs/architecture/agent-loop-write-surface-2026-07-02.md
+++ b/docs/architecture/agent-loop-write-surface-2026-07-02.md
@@ -1,0 +1,135 @@
+# Agent Loop Write Surface QA - 2026-07-02
+
+## Claim
+
+Canary responders can complete service-bound claim and annotation writeback
+through HTTP, the CLI, and the MCP stdio server without admin authority. A
+`responder-write` key must be bound to one service and cannot mutate another
+service's subject.
+
+## Runtime
+
+- Branch: `factory-062-agent-loop`
+- Server: `CANARY_DB_PATH=/tmp/canary-062-live.db PORT=4702 cargo run -q -p canary-server`
+- Endpoint: `http://127.0.0.1:4702`
+- Public readiness:
+  - `GET /healthz` -> `{"status":"ok"}`
+  - `GET /readyz` -> `{"status":"ready", ...}`
+
+Raw API keys were captured into shell variables during the run and are not
+stored in this receipt.
+
+## Commands
+
+```bash
+ADMIN_KEY=$(CANARY_DB_PATH=/tmp/canary-062-live.db \
+  cargo run -q -p canary-server -- mint-key --scope admin --name qa-admin \
+  2>/tmp/canary-062-mint-admin.err | tail -n 1)
+
+RESPONDER_RESPONSE=$(curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/keys" \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"qa-responder","scope":"responder-write","service":"qa-api"}')
+
+curl -sS -o /tmp/canary-062-unbound.json -w "%{http_code}" \
+  -X POST "$CANARY_ENDPOINT/api/v1/keys" \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"bad-responder","scope":"responder-write"}'
+
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/targets" \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/qa-api","name":"QA API","service":"qa-api","interval_ms":60000,"timeout_ms":1000}'
+
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/targets" \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/qa-other","name":"QA Other","service":"qa-other","interval_ms":60000,"timeout_ms":1000}'
+
+CANARY_ENDPOINT="$CANARY_ENDPOINT" CANARY_RESPONDER_KEY="$RESPONDER_KEY" \
+  target/debug/canary claims claim \
+  --subject-type target --subject-id "$TARGET_API_ID" \
+  --owner codex-live --purpose "responder writeback QA" \
+  --idempotency-key qa-responder-writeback-062 --json
+
+CANARY_ENDPOINT="$CANARY_ENDPOINT" CANARY_RESPONDER_KEY="$RESPONDER_KEY" \
+  target/debug/canary claims transition "$CLAIM_ID" \
+  --owner codex-live --state verified \
+  --evidence-link docs/architecture/agent-loop-write-surface-2026-07-02.md \
+  --json
+
+CANARY_ENDPOINT="$CANARY_ENDPOINT" CANARY_RESPONDER_KEY="$RESPONDER_KEY" \
+  target/debug/canary annotations create \
+  --subject-type target --subject-id "$TARGET_API_ID" \
+  --agent codex-live --action fix-verified \
+  --metadata claim_id="$CLAIM_ID" --json
+
+CANARY_ENDPOINT="$CANARY_ENDPOINT" CANARY_RESPONDER_KEY="$RESPONDER_KEY" \
+  target/debug/canary annotations list \
+  --subject-type target --subject-id "$TARGET_API_ID" --json
+
+curl -sS -o /tmp/canary-062-cross.json -w "%{http_code}" \
+  -X POST "$CANARY_ENDPOINT/api/v1/annotations" \
+  -H "Authorization: Bearer $RESPONDER_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"subject_type\":\"target\",\"subject_id\":\"$TARGET_OTHER_ID\",\"agent\":\"codex-live\",\"action\":\"cross-service\"}"
+
+printf "%s\n" \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"canary_annotation_create\",\"arguments\":{\"subject_type\":\"target\",\"subject_id\":\"$TARGET_API_ID\",\"agent\":\"mcp-live\",\"action\":\"mcp-writeback\",\"metadata\":{\"claim_id\":\"$CLAIM_ID\"}}}}" \
+  "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"canary_annotations_list\",\"arguments\":{\"subject_type\":\"target\",\"subject_id\":\"$TARGET_API_ID\",\"limit\":5}}}" \
+  | CANARY_ENDPOINT="$CANARY_ENDPOINT" CANARY_RESPONDER_KEY="$RESPONDER_KEY" \
+    target/debug/canary mcp-server
+```
+
+## Redacted Result
+
+```json
+{
+  "endpoint": "http://127.0.0.1:4702",
+  "health": {"status": "ok"},
+  "ready_status": "ready",
+  "responder_key_created": {
+    "id": "KEY-i4ia9bmwutvf",
+    "scope": "responder-write",
+    "service": "qa-api"
+  },
+  "unbound_responder": {
+    "status": 422,
+    "code": "validation_error",
+    "errors": {"service": ["is required for responder-write keys"]}
+  },
+  "targets": {
+    "api": "TGT-sbxvezded2tv",
+    "other": "TGT-gu798ynnek9l"
+  },
+  "cli": {
+    "claim_id": "CLM-vjohc5jlk4by",
+    "claim_state": "verified",
+    "annotation_id": "ANN-eimkqrxw7okm",
+    "annotations_count": 1
+  },
+  "cross_service_annotation": {
+    "status": 403,
+    "code": "insufficient_scope",
+    "bound_service": "qa-api",
+    "requested_service": "qa-other"
+  },
+  "mcp": {
+    "create_id": "ANN-v64fsh9l31pk",
+    "create_action": "mcp-writeback",
+    "list_count": 2
+  }
+}
+```
+
+## Verdict
+
+PASS for the 062/048 narrow slice: service-bound `responder-write` authority,
+CLI claim and annotation writeback, MCP annotation write/list, and cross-service
+denial are live-proven.
+
+Not covered here: full 048 rich-context minimization, read-audit events for
+rich context reads, browser/public-ingest relay semantics, and webhook receiver
+conformance fixtures. Those remain open 048 children.

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -398,6 +398,75 @@
       "name": "canary_claim_release"
     },
     {
+      "description": "List annotations for one Canary subject with read or responder-write authority.",
+      "input_schema": {
+        "properties": {
+          "cursor": {
+            "type": "string"
+          },
+          "limit": {
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "subject_id": {
+            "type": "string"
+          },
+          "subject_type": {
+            "enum": [
+              "incident",
+              "error_group",
+              "target",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject_type",
+          "subject_id"
+        ],
+        "type": "object"
+      },
+      "name": "canary_annotations_list"
+    },
+    {
+      "description": "Write an annotation with responder-write authority after an agent completes follow-up work.",
+      "input_schema": {
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "agent": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "subject_id": {
+            "type": "string"
+          },
+          "subject_type": {
+            "enum": [
+              "incident",
+              "error_group",
+              "target",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject_type",
+          "subject_id",
+          "agent",
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "canary_annotation_create"
+    },
+    {
       "description": "Discover local project integration state without reading secret values.",
       "input_schema": {
         "properties": {

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -19,7 +19,7 @@
       "crash_recovery": "After a crash or restart, resume from the last persisted cursor, replay missed timeline events, and continue polling until the API returns no further cursor.",
       "cursor_precedence": "When both `after` and `cursor` are provided on timeline-style pagination endpoints, Canary resolves `after` first and ignores `cursor` for that request.",
       "incident_entrypoint": "On an `incident.opened` webhook, call `GET /api/v1/incidents/{id}` once — the response carries summary, the full incident metadata, a deterministic action brief, up to 25 correlated signals with per-type context, up to 20 newest annotations, and up to 5 most recent timeline events. Only fall through to /query, /timeline, or /errors/{id} when `signals_truncated` or `annotations_truncated` is true, or the agent needs raw stack traces.",
-      "scope_semantics": "`x-canary-required-scope` names the least-privilege key scope to provision for the operation. Admin keys may also satisfy read-only and ingest-only route permissions at runtime, but agents should request the narrow scope unless they are managing Canary configuration.",
+      "scope_semantics": "`x-canary-required-scope` names the least-privilege key scope to provision for the operation. Admin keys may also satisfy read-only, ingest-only, and responder-write route permissions at runtime, but agents should request the narrow scope unless they are managing Canary configuration.",
       "cold_start": {
         "entrypoint": "When an agent has no saved cursor, call GET /api/v1/report?window=1h first. The report is the bounded current-state snapshot for targets, monitors, active incidents, and active error groups.",
         "pagination": "If report.truncated is true or report.cursor is non-null, keep calling /api/v1/report with that report cursor until the response is no longer truncated. Report cursors are only for report pagination and are not timeline cursors.",
@@ -1115,7 +1115,7 @@
             "$ref": "#/components/responses/RateLimitedProblem"
           }
         },
-        "x-canary-required-scope": "admin",
+        "x-canary-required-scope": "responder-write",
         "x-agent-guidance": {
           "when_to_call": "Use to record incident-level triage, fix proposal, verification, or dismissal once downstream work has produced evidence.",
           "trust": "The response is the stored annotation row and the annotation.added webhook is a wake-up hint for other consumers.",
@@ -1217,7 +1217,7 @@
             "$ref": "#/components/responses/RateLimitedProblem"
           }
         },
-        "x-canary-required-scope": "admin",
+        "x-canary-required-scope": "responder-write",
         "x-agent-guidance": {
           "when_to_call": "Use to record code-fix or classification work against a stable error_group when the same issue may appear in multiple incidents.",
           "trust": "The response is the stored annotation row; Canary does not interpret metadata beyond preserving and emitting it.",
@@ -1348,7 +1348,7 @@
             "$ref": "#/components/responses/RateLimitedProblem"
           }
         },
-        "x-canary-required-scope": "admin",
+        "x-canary-required-scope": "responder-write",
         "x-agent-guidance": {
           "when_to_call": "Use for generic write-back to incident, error_group, target, or monitor subjects when subject_type and subject_id are already known.",
           "trust": "The response is the stored annotation row with opaque metadata preserved exactly as submitted.",
@@ -2117,7 +2117,7 @@
             "$ref": "#/components/responses/RateLimitedProblem"
           }
         },
-        "x-canary-required-scope": "admin"
+        "x-canary-required-scope": "responder-write"
       }
     },
     "/api/v1/claims/{id}": {
@@ -2223,7 +2223,7 @@
             "$ref": "#/components/responses/RateLimitedProblem"
           }
         },
-        "x-canary-required-scope": "admin"
+        "x-canary-required-scope": "responder-write"
       }
     },
     "/api/v1/claims/{id}/release": {
@@ -2271,7 +2271,7 @@
             "$ref": "#/components/responses/RateLimitedProblem"
           }
         },
-        "x-canary-required-scope": "admin",
+        "x-canary-required-scope": "responder-write",
         "requestBody": {
           "required": true,
           "content": {
@@ -5875,7 +5875,8 @@
         "enum": [
           "admin",
           "ingest-only",
-          "read-only"
+          "read-only",
+          "responder-write"
         ],
         "description": "Authorization scope attached to an API key."
       },


### PR DESCRIPTION
## Summary
- add service-bound `responder-write` API keys for responder read plus claim/annotation writeback without admin authority
- expose annotation list/create through `bin/canary annotations` and MCP stdio tools
- document responder key setup/rotation and add the redacted HTTP + CLI + MCP QA receipt

## Live proof
- disposable server: `CANARY_DB_PATH=/tmp/canary-062-live.db PORT=4702 cargo run -q -p canary-server`
- `GET /healthz` returned `{"status":"ok"}`; `GET /readyz` returned `ready`
- admin-created service-bound `responder-write` key for `qa-api`; unbound responder key creation returned RFC 9457 `422 validation_error`
- CLI responder key claimed a target, transitioned the claim to `verified`, created an annotation, and listed it
- HTTP cross-service annotation attempt returned `403 insufficient_scope` with `bound_service=qa-api` and `requested_service=qa-other`
- MCP stdio `canary_annotation_create` and `canary_annotations_list` created/listed annotations against the bound service
- receipt: `docs/architecture/agent-loop-write-surface-2026-07-02.md`

## Verification
- `cargo test -p canary-http auth --locked`
- `cargo test -p canary-server responder_write_key_claims_and_annotates_only_bound_service --locked`
- `cargo test -p canary-cli checked_in_mcp_manifest_matches_generated_manifest --locked`
- `./bin/validate`
- pre-push `./bin/validate --strict`

## Residual scope
This closes the narrow 062/048 responder writeback slice. Full 048 rich-context minimization, read-audit events, browser/public-ingest relay semantics, and webhook receiver conformance fixtures remain open children.

Agent: Codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: backlog/062, backlog/048