### PR TITLE
fix(deps): bump anyhow to clear RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"


### PR DESCRIPTION
## Summary
- Bumps `anyhow` 1.0.102 -> 1.0.103 to clear `RUSTSEC-2026-0190` (unsoundness in `Error::downcast_mut()`).
- The advisory previously surfaced as an allowed warning in the strict gate; this curated patch bump removes it entirely.
- `cargo audit` now reports zero advisories; `./bin/validate --advisories` no longer prints the allowed-warning line.

Closes #059.

## Verification
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).
- `./bin/validate --advisories` no longer reports RUSTSEC-2026-0190.
- Lockfile diff is the single anyhow bump, no unrelated churn.

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/059-rustsec-anyhow-bump.md