### PR TITLE
docs(064): replace false npm install claim in INTEGRATION.md

### DIFF
--- a/clients/typescript/INTEGRATION.md
+++ b/clients/typescript/INTEGRATION.md
@@ -22,9 +22,20 @@ targets, monitors, webhooks, query readback, and dogfood registry evidence.
 
 ## Step 1: Install
 
+The SDK is not yet published to npm (tracked in #051). Until publication,
+install from source:
+
 ```bash
-npm install @canary-obs/sdk
+# From the Canary repo, build the SDK:
+cd clients/typescript && npm install && npm run build
+
+# In your app, link it via file: (adjust the relative path):
+npm install file:../path/to/canary/clients/typescript
 ```
+
+`bin/canary integrate patch` adds `"@canary-obs/sdk": "^0.1.0"` to your
+`package.json` dependencies; replace that version specifier with the `file:`
+path above before running `npm install`, or the install will 404.
 
 ## Step 2: Add env vars
 


### PR DESCRIPTION
## Summary
`clients/typescript/INTEGRATION.md` instructed `npm install @canary-obs/sdk`, but the package is not published to npm (404; tracked in #051). Replaces the false claim with the actual working install path: build from source and link via `file:`. Also notes that `integrate patch` writes a `^0.1.0` specifier that must be replaced with the `file:` path until npm publish ships.

Advances #064 (child: release/upgrade truth — npm claim honesty).

## Verification
- `npm view @canary-obs/sdk` still 404s (confirmed).
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).
- Grep confirms no other `npm install @canary-obs/sdk` claims in repo docs.

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/064-trustworthy-release-upgrade.md