### PR TITLE
chore(066): sweep Phoenix parity comments from canary-store batch

### DIFF
--- a/crates/canary-store/src/annotations.rs
+++ b/crates/canary-store/src/annotations.rs
@@ -16,16 +16,16 @@ pub type AnnotationResult<T> = std::result::Result<T, AnnotationError>;
 /// Annotation validation or storage failure.
 #[derive(Debug, thiserror::Error)]
 pub enum AnnotationError {
-    /// Subject type is not one of the Phoenix types.
+    /// Subject type is not one of the accepted subject types.
     #[error("invalid annotation subject type")]
     InvalidSubjectType,
     /// Subject row does not exist.
     #[error("annotation subject not found")]
     NotFound,
-    /// Limit is not a positive integer up to the Phoenix maximum.
+    /// Limit is not a positive integer up to the accepted maximum.
     #[error("invalid annotation limit")]
     InvalidLimit,
-    /// Cursor is not a valid Phoenix annotation cursor.
+    /// Cursor is not a valid annotation cursor.
     #[error("invalid annotation cursor")]
     InvalidCursor,
     /// SQLite rejected the operation.
@@ -100,7 +100,7 @@ pub enum AnnotationSubjectType {
 }
 
 impl AnnotationSubjectType {
-    /// Parse a Phoenix subject type.
+    /// Parse a subject type.
     pub fn parse(value: &str) -> Option<Self> {
         match value {
             "incident" => Some(Self::Incident),
@@ -122,7 +122,7 @@ impl AnnotationSubjectType {
     }
 }
 
-/// Return Phoenix's accepted annotation subject types in wire order.
+/// Return accepted annotation subject types in wire order.
 pub const fn subject_types() -> &'static [&'static str] {
     &ANNOTATION_SUBJECT_TYPES
 }

--- a/crates/canary-store/src/api_keys.rs
+++ b/crates/canary-store/src/api_keys.rs
@@ -3,7 +3,7 @@ use rusqlite::{Connection, params};
 
 use crate::Result;
 
-/// Number of leading characters stored by Phoenix as `api_keys.key_prefix`.
+/// Number of leading characters stored by as `api_keys.key_prefix`.
 pub const API_KEY_PREFIX_LEN: usize = 12;
 /// Tenant assigned to pre-multitenant rows during the ownership migration.
 pub const BOOTSTRAP_TENANT_ID: &str = "TENANT-bootstrap";
@@ -27,7 +27,7 @@ pub struct ApiKeyInsert {
     pub created_at: String,
     /// ISO8601 revocation timestamp, when the key is inactive.
     pub revoked_at: Option<String>,
-    /// Phoenix wire-value scope, such as `admin` or `ingest-only`.
+    /// Wire-value scope, such as `admin` or `ingest-only`.
     pub scope: String,
     /// Tenant this key can operate within.
     pub tenant_id: String,
@@ -44,7 +44,7 @@ pub struct VerifiedApiKey {
     pub id: String,
     /// Human-readable key name.
     pub name: String,
-    /// Phoenix wire-value scope, such as `admin` or `ingest-only`.
+    /// Wire-value scope, such as `admin` or `ingest-only`.
     pub scope: String,
     /// Tenant this key can operate within.
     pub tenant_id: String,
@@ -61,7 +61,7 @@ pub struct ApiKeyRecord {
     pub id: String,
     /// Human-readable key name.
     pub name: String,
-    /// Phoenix wire-value scope.
+    /// Wire-value scope.
     pub scope: String,
     /// First 12 characters of the raw key.
     pub key_prefix: String,

--- a/crates/canary-store/src/ingest.rs
+++ b/crates/canary-store/src/ingest.rs
@@ -34,11 +34,11 @@ pub struct ErrorIngestPayload {
     pub service: String,
     /// Error class.
     pub error_class: String,
-    /// Message truncated to the Phoenix limit by the caller.
+    /// Message truncated to the limit by the caller.
     pub message: String,
     /// Normalized message template.
     pub message_template: String,
-    /// Optional stack trace truncated to the Phoenix limit by the caller.
+    /// Optional stack trace truncated to the limit by the caller.
     pub stack_trace: Option<String>,
     /// Optional JSON-encoded context.
     pub context_json: Option<String>,

--- a/crates/canary-store/src/query.rs
+++ b/crates/canary-store/src/query.rs
@@ -87,7 +87,7 @@ pub struct RecentTransition {
     pub entity_ref: String,
     /// Surface display name.
     pub name: String,
-    /// Service name resolved through Phoenix's fallback.
+    /// Service name resolved through the service fallback.
     pub service: String,
     /// Current state.
     pub state: String,
@@ -134,7 +134,7 @@ pub enum ErrorGroupQueryError {
     /// Query window is outside Canary's closed set.
     #[error("invalid query window")]
     InvalidWindow,
-    /// Cursor is not a valid Phoenix query cursor.
+    /// Cursor is not a valid query cursor.
     #[error("invalid query cursor")]
     InvalidCursor,
     /// SQLite rejected a read query.
@@ -151,10 +151,10 @@ pub enum TimelineQueryError {
     /// Query window is outside Canary's closed set.
     #[error("invalid query window")]
     InvalidWindow,
-    /// Requested limit is outside Phoenix's accepted range.
+    /// Requested limit is outside accepted range.
     #[error("invalid timeline limit")]
     InvalidLimit,
-    /// Cursor is not a valid Phoenix timeline cursor.
+    /// Cursor is not a valid timeline cursor.
     #[error("invalid timeline cursor")]
     InvalidCursor,
     /// Event type filter includes one or more non-business events.
@@ -177,7 +177,7 @@ pub struct TimelineQueryOptions {
     pub project_id: Option<String>,
     /// Optional service filter. Empty strings are treated as absent.
     pub service: Option<String>,
-    /// Optional limit. Defaults to Phoenix's 50-row page size.
+    /// Optional limit. Defaults to the default 50-row page size.
     pub limit: Option<String>,
     /// Optional cursor. Empty strings are treated as absent.
     pub cursor: Option<String>,

--- a/crates/canary-store/src/webhook_deliveries.rs
+++ b/crates/canary-store/src/webhook_deliveries.rs
@@ -15,13 +15,13 @@ pub type WebhookDeliveryPageResult<T> = std::result::Result<T, WebhookDeliveryPa
 /// Webhook delivery page validation or storage failure.
 #[derive(Debug, thiserror::Error)]
 pub enum WebhookDeliveryPageError {
-    /// Limit is not a positive integer up to the Phoenix maximum.
+    /// Limit is not a positive integer up to the accepted maximum.
     #[error("invalid webhook delivery limit")]
     InvalidLimit,
-    /// Cursor is not a valid Phoenix webhook delivery cursor.
+    /// Cursor is not a valid webhook delivery cursor.
     #[error("invalid webhook delivery cursor")]
     InvalidCursor,
-    /// Status is not one of the Phoenix ledger statuses.
+    /// Status is not one of the ledger statuses.
     #[error("invalid webhook delivery status")]
     InvalidStatus,
     /// SQLite rejected the read.
@@ -29,7 +29,7 @@ pub enum WebhookDeliveryPageError {
     Sqlite(#[from] rusqlite::Error),
 }
 
-/// Delivery status values accepted by the Phoenix schema.
+/// Delivery status values accepted by the schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WebhookDeliveryStatus {
     /// Delivery has been enqueued but not attempted.
@@ -66,7 +66,7 @@ impl WebhookDeliveryStatus {
         }
     }
 
-    /// Parse a user-supplied Phoenix status filter.
+    /// Parse a user-supplied status filter.
     pub fn parse_filter(value: &str) -> Option<Self> {
         match value {
             "pending" => Some(Self::Pending),
@@ -79,7 +79,7 @@ impl WebhookDeliveryStatus {
     }
 }
 
-/// Return Phoenix's accepted webhook delivery statuses in wire order.
+/// Return accepted webhook delivery statuses in wire order.
 pub const fn statuses() -> &'static [&'static str] {
     &[
         "pending",


### PR DESCRIPTION
## Summary
Remove Phoenix parity references from doc comments across 5 files in `canary-store/src/`: `annotations.rs`, `api_keys.rs`, `webhook_deliveries.rs`, `query.rs`, and `ingest.rs`. All references described wire values, limits, or cursors as "Phoenix" — they are now Canary's own contract. No behavior change; only doc comments.

Advances #066 (child: parity archaeology deletion).

## Verification
- `grep -rni 'phoenix' crates/canary-store/src/{annotations,api_keys,webhook_deliveries,query,ingest}.rs` returns nothing.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/066-consolidation-and-archaeology-deletion.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated public-facing API and error documentation to use more generic wording across annotations, API keys, ingest payloads, query validation, and webhook delivery descriptions.
  * Clarified limit, cursor, scope, and status terminology so the docs read consistently and no longer use product-specific phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->