### PR TITLE
chore(backlog): import overnight refill tickets

### DIFF
--- a/backlog.d/070-archive-shipped-backlog-tickets.md
+++ b/backlog.d/070-archive-shipped-backlog-tickets.md
@@ -1,0 +1,39 @@
+# Archive shipped-but-unarchived backlog tickets (054, 055, 059)
+
+Priority: P3 · Status: ready · Estimate: S
+
+## Goal
+`backlog.d/` stops listing tickets as open once their oracle is already satisfied
+in `master`, so the active count reflects real remaining work.
+
+## Oracle
+- [ ] `backlog.d/059-rustsec-anyhow-bump.md` is moved to `backlog.d/_done/`, with a
+      note citing commit `fc87c2a` ("fix(deps): bump anyhow to clear
+      RUSTSEC-2026-0190 (#185)", which itself says "Closes #059") and confirming
+      `Cargo.lock` pins `anyhow 1.0.103`.
+- [ ] `backlog.d/055-principles-rust-cutover-refresh.md` is moved to
+      `backlog.d/_done/`, with a note citing commit `30aaa58` ("docs(principles):
+      refresh examples to Rust+SQLite era (#186)") and confirming
+      `grep -niE "genserver|oban|ecto|\.(ingest|transition|compute_group_hash)/[0-9]" PRINCIPLES.md`
+      returns no matches.
+- [ ] `backlog.d/054-serving-model-self-hosted.md` is moved to `backlog.d/_done/`,
+      with a note confirming `VISION.md` already carries a "Serving Model"
+      section (added in today's groom commit `9639358`) stating the three-way
+      self-hosted / managed-later / no-multi-tenant-by-default distinction, and
+      that it reconciles with "What Canary Is Not" and the "Use Canary when..."
+      comparison table without contradiction.
+- [ ] No other backlog file is touched, renamed, or renumbered.
+
+## Notes
+Found during 2026-07-01 refill-lane runway verification: the resident lane
+closed all three of these earlier tonight (anyhow bump, PRINCIPLES refresh,
+and the groom pass's own VISION.md edit satisfy each ticket's oracle verbatim)
+but never `git mv`'d the ticket file to `_done/`. Pure filing hygiene — no code
+change, no design call. Read each ticket's `## Oracle` section first and
+re-verify against live `master` before moving anything, in case work has moved
+further between when this was filed and when it's picked up.
+
+**Why:** an accurate open-ticket count is what makes runway verification (this
+refill lane's whole job) possible; three phantom-open tickets were undercounting
+the resident lane's real progress and could cause a future groom pass to
+re-propose work that's already done.

--- a/backlog.d/071-responder-context-read-audit-events.md
+++ b/backlog.d/071-responder-context-read-audit-events.md
@@ -1,0 +1,47 @@
+# Record durable read-audit events for responder context fetches
+
+Priority: P1 · Status: ready · Estimate: M
+
+## Goal
+Every time a responder-scoped (non-admin) key reads rich context — `GET
+/api/v1/report` and any incident/error detail-by-id route — Canary durably
+records who read what and when, so a future minimization/redaction pass (048)
+has a real read trail to reason about instead of starting from zero.
+
+## Oracle
+- [ ] A responder-write-scoped or read-only-scoped request to `/api/v1/report`
+      (route: `crates/canary-server/src/lib.rs:143`, gated by
+      `require_read_scope`/`require_responder_write_scope` in
+      `crates/canary-server/src/server_auth.rs:53`) writes one durable audit
+      record capturing: key id, service binding, route, and timestamp.
+- [ ] The audit record reuses the existing `service_events` table's
+      `retention_class = 'audit'` lane (`crates/canary-store/src/schema.rs:680`)
+      rather than introducing a new table, unless a concrete schema conflict is
+      found and documented in the PR.
+- [ ] Admin-key reads are exempt or separately labeled (admin already has full
+      visibility; the goal is a responder-specific trail, not blanket request
+      logging).
+- [ ] Audit records never contain the actual redacted/minimized payload body —
+      only route, scope, key id, service, and timestamp (no payload replay from
+      the audit log itself).
+- [ ] A test proves: one responder read produces exactly one audit event with
+      the correct service binding; a cross-service or admin read does not
+      pollute another service's audit trail.
+- [ ] `./bin/validate` passes.
+
+## Notes
+This is the P0 "add durable read-audit events for rich responder context
+fetches" line from `backlog.d/048-responder-rich-context-safety-gate.md`,
+deliberately narrowed: it does NOT attempt the context-envelope redesign,
+minimization/redaction policy, or new responder scopes that make 048 itself
+XL and ADR-gated. Recording *that a read happened* is mechanical and doesn't
+require deciding *what should be redacted* — that decision stays in 048.
+`service_events.retention_class` already has an `'audit'` value carved out in
+the schema check constraint but (as far as this investigation found) nothing
+writes it yet — worth confirming before assuming it's unused.
+
+**Why:** 048 is the single most important safety gate in the backlog (P0, XL)
+but everything in it is currently one big ADR-shaped decision. Landing the
+mechanical read-audit piece now gives 048's eventual redesign real audit data
+to design against, and unblocks part of its Oracle without requiring the
+scope-model judgment call tonight.

--- a/backlog.d/072-webhook-receiver-conformance-fixtures.md
+++ b/backlog.d/072-webhook-receiver-conformance-fixtures.md
@@ -1,0 +1,47 @@
+# Webhook receiver conformance fixtures (signature, timestamp, dedupe, replay)
+
+Priority: P1 · Status: ready · Estimate: M
+
+## Goal
+A receiver-side conformance test suite proves Canary's existing signed-webhook
+contract (already implemented, not yet fixture-tested end to end) actually
+does what the docs and the responder contract claim: valid signatures pass,
+tampered/expired/replayed deliveries are rejected, and duplicate delivery ids
+are deduped.
+
+## Oracle
+- [ ] Fixtures cover, against the real functions in
+      `crates/canary-http/src/webhooks.rs` (`verify_signature`,
+      `sign_timestamped`/`timestamped_signature_header`, delivery envelope
+      `timestamp.delivery_id.body`):
+      - valid signature + fresh timestamp + unseen delivery id → accepted
+      - tampered body with an otherwise-valid signature → rejected
+      - stale/out-of-window timestamp → rejected
+      - replayed delivery id (same id delivered twice) → second delivery is a
+        no-op, not double-processed
+      - malformed/missing signature header → rejected
+- [ ] Fixtures live as committed test data (not only inline test code) so a
+      future responder implementation (e.g. Bitterblossom's triage workload)
+      can run the same fixtures against its own receiver and prove conformance
+      without depending on Canary's Rust test harness.
+- [ ] Tests fail loudly (not silently skip) if `verify_signature` or the
+      timestamp/dedupe window ever changes shape.
+- [ ] `./bin/validate` passes.
+
+## Notes
+The groom sweep found real signature/timestamp/dedupe code
+(`canary-http/src/webhooks.rs`) but no dedicated conformance test surface —
+`find . -iname "*conformance*"` and `*webhook*test*` come up empty outside
+inline unit tests. This is pure testing-of-existing-behavior: no new auth
+model, no new scopes, no design call. It directly satisfies the P1 line in
+`backlog.d/048-responder-rich-context-safety-gate.md` ("ship receiver
+conformance fixtures for signature timestamp validation, delivery-id dedupe,
+and timeline replay before action") and feeds the conformance-scoring bullet
+in `backlog.d/063-triage-contract-hardening.md` without touching either
+ticket's larger cooldown/budget-cap/claim-gating scope.
+
+**Why:** the triage loop is the product's whole reason for existing and today
+has "one $0.018 synthetic run" as its only end-to-end proof (per the 2026-07-01
+groom report). Fixture-level conformance tests are the cheapest available way
+to raise confidence in the receiver contract before 063's harder enforcement
+work lands.

--- a/backlog.d/080-pin-live-incident-payload-shape.md
+++ b/backlog.d/080-pin-live-incident-payload-shape.md
@@ -1,0 +1,15 @@
+# Pin the live incident-payload shape before anyone "fixes" it
+
+Priority: P0 · Status: ready · Estimate: S
+
+## Goal
+The exact JSON shape canary's incident emitter produces today is pinned by a committed fixture and a conformance test, so any change to it fails CI instead of silently breaking downstream triage.
+
+## Oracle
+- [ ] A committed fixture captures the CURRENT live emitter output (top-level key `incident`, no `schema_version`) generated from `incident_payload` in `crates/canary-store/src/incidents.rs:505`.
+- [ ] A test asserts the emitter output matches the fixture byte-for-byte (or field-for-field); mutating the payload shape fails the test.
+- [ ] `docs/architecture/canary-bitterblossom-triage-contract-2026-07-01.md` is corrected to describe the shape that actually ships (`incident`, no schema_version) with a note that the `subject`+`schema_version` form is a FUTURE coordinated migration, not the current contract.
+
+## Notes
+DO NOT change the emitter to match the contract doc — that direction silently breaks bitterblossom triage (its task.toml JSON pointer filters on `/incident/service`; a renamed key returns HTTP 200 `{"filtered":...}` and no triage run ever fires). Tonight's move is pin-reality-and-fix-the-doc; the coordinated rename to `subject`+`schema_version:1` is daylight work requiring a lockstep bitterblossom change.
+**Why:** 2026-07-01 composition seam audit, Seam 2 — ranked the #1 most-likely-to-break seam; three divergent shapes exist (live emitter, BB's ingress test at `tests/ingress.rs:134`, the contract doc) and only the emitter's is real.

--- a/backlog.d/081-remove-hardcoded-operator-domain-fixture.md
+++ b/backlog.d/081-remove-hardcoded-operator-domain-fixture.md
@@ -1,0 +1,14 @@
+# Remove the hardcoded operator domain from CLI test fixtures
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+No test fixture or default in the codebase references the operator's personal domain, so the repo is portable for external adopters.
+
+## Oracle
+- [ ] `rg "phaedrus\.io" ~/Development/canary` returns zero hits in code and fixtures (docs describing history are fine).
+- [ ] The affected tests in `crates/canary-cli/src/lib.rs` pass using neutral example domains (`example.com` / env-injected values).
+
+## Notes
+Found by the 2026-07-01 adoptability audit: canary ranked #1 most stranger-adoptable (8/10) and this was its ONE named blocker. Mechanical find-and-replace plus test run — no behavior change.
+**Why:** adoptability audit, rank-1 finding; canary already has an external user and a published v1.0.0, so portability debt is live product debt.

--- a/backlog.d/082-triage-github-issue-129.md
+++ b/backlog.d/082-triage-github-issue-129.md
@@ -1,0 +1,40 @@
+# Triage GitHub issue #129 against the 048/062 backlog
+
+Priority: P3 · Status: ready · Estimate: S
+
+## Goal
+GitHub issue #129 ("[P1] Tighten the external responder contract with
+service-scoped context and annotation semantics", open since 2026-04-16, no
+comments) is resolved into exactly one of: closed as superseded, or explicitly
+linked as tracked-by an open `backlog.d/` ticket — so it stops appearing as a
+second, un-cross-referenced backlog surface.
+
+## Oracle
+- [ ] Issue #129's stated goal (tighten the responder contract: service-scoped
+      context, documented annotation-action vocabulary, no Canary-owned
+      remediation runtime) is compared line-by-line against
+      `backlog.d/048-responder-rich-context-safety-gate.md` and
+      `backlog.d/062-agent-loop-write-surface.md`.
+- [ ] If fully covered: issue is closed with a comment naming which ticket(s)
+      supersede it and why (cite the specific Oracle bullets that match).
+- [ ] If partially covered: issue stays open but gets a comment stating exactly
+      what gap remains uncovered by 048/062, and that gap gets its own new
+      backlog line item (or an addition to an existing ticket's Notes) rather
+      than being silently dropped.
+- [ ] No backlog `.md` file is deleted or silently merged — any consolidation
+      is proposed in ticket text, per house grooming rules.
+
+## Notes
+Issue #129 predates both 048 (filed 2026-06-20) and 062 (filed 2026-07-01) and
+reads as an earlier draft of the same problem: annotations that are "flexible"
+but not a documented product contract, and a responder that fetches the global
+`/api/v1/report` and filters client-side rather than getting service-scoped
+context. That's close to word-for-word what 048/062 already scope. This is a
+read-and-decide task, not a design task — the actual scope decision was
+already made when 048/062 were filed; this ticket just closes the loop on the
+older tracking surface.
+
+**Why:** an open P1 GitHub issue that nobody is actively working, sitting
+alongside two backlog tickets covering the same ground, is exactly the kind of
+drift a groom pass exists to catch — cheap to fix, and it stops a future
+contributor from treating #129 as separately-actionable scope.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -24,11 +24,18 @@ visible until a focused PR archives them with evidence.
 
 | # | Item | Priority | Status | Estimate |
 |---|------|----------|--------|----------|
+| 080 | Pin live incident-payload shape | P0 | pending | S |
+| 081 | Remove hardcoded operator domain fixture | P2 | pending | S |
+| 071 | Responder context read-audit events | P1 | pending | M |
 | 062 | Agent loop write surface | P0 | pending | XL |
 | 063 | Triage contract hardening | P1 | pending | XL |
 | 064 | Trustworthy release/upgrade | P1 | pending | L |
 | 065 | Runtime hardening | P1 | pending | L |
 | 066 | Consolidation and archaeology deletion | P2 | pending | XL |
+| 058 | Cadence-aware SLI trajectory sample floor | P2 | pending | M |
+| 082 | Triage GitHub issue #129 | P3 | pending | S |
+| 070 | Archive shipped backlog tickets | P3 | pending | S |
+| 072 | Webhook receiver conformance fixtures | P1 | pending | M |
 | 001 | Annotations API | high | done | M |
 | 002 | Timeline agent polling | high | done | S |
 | 003 | Triage diagnostic webhooks non-fatal | high | done | S |


### PR DESCRIPTION
## Summary
Import 6 tickets from `~/.factory-lanes/refill/canary/`:

- **070**: Archive shipped backlog tickets (054/055/059 already done — verify and close)
- **071**: Responder context read-audit events (P1, M)
- **072**: Webhook receiver conformance fixtures (P1, M — already shipped in #194, needs archival)
- **080**: Pin live incident-payload shape (P0, S)
- **081**: Remove hardcoded operator domain fixture (P2, S)
- **082**: Triage GitHub issue #129 (renumbered from 073 on collision with `_done/073-unified-report-endpoint.md`, slug preserved)

Renumbered 073 → 082 per collision policy. Refill source files deleted after import.

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2