### PR TITLE
fix(081): remove hardcoded operator domain from CLI test fixtures

### DIFF
--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -5565,7 +5565,7 @@ Vercel CLI completed
         let patched = integration_patch(&IntegrationInput {
             target: root.clone(),
             service: Some("vanity".to_owned()),
-            production_url: Some("https://www.phaedrus.io".to_owned()),
+            production_url: Some("https://www.example.com".to_owned()),
             platform_project: None,
             endpoint: DEFAULT_ENDPOINT.to_owned(),
         })?;
@@ -5595,7 +5595,7 @@ Vercel CLI completed
                 && change["status"] == "updated"
         }));
         assert_eq!(receipt["service"], "vanity");
-        assert_eq!(receipt["health_url"], "https://www.phaedrus.io/api/health");
+        assert_eq!(receipt["health_url"], "https://www.example.com/api/health");
         assert_eq!(receipt["verification_status"], "planned");
         assert_eq!(receipt["target_id"], Value::Null);
         assert_eq!(
@@ -5615,7 +5615,7 @@ Vercel CLI completed
                 "service": "vanity",
                 "environment": "production",
                 "canary_endpoint": DEFAULT_ENDPOINT,
-                "health_url": "https://www.phaedrus.io/api/health",
+                "health_url": "https://www.example.com/api/health",
                 "target_id": "TGT-existing",
                 "monitor_ids": ["MON-existing"],
                 "webhook_ids": ["WHK-existing"],
@@ -5629,7 +5629,7 @@ Vercel CLI completed
         integration_patch(&IntegrationInput {
             target: root.clone(),
             service: Some("vanity".to_owned()),
-            production_url: Some("https://www.phaedrus.io".to_owned()),
+            production_url: Some("https://www.example.com".to_owned()),
             platform_project: None,
             endpoint: DEFAULT_ENDPOINT.to_owned(),
         })?;


### PR DESCRIPTION
## Summary
Replace `https://www.phaedrus.io` with `https://www.example.com` in 4 test fixture locations in `crates/canary-cli/src/lib.rs`. The operator's personal domain was baked into integration-patch test data, making the repo less portable for external adopters. Docs references in `backlog.d/_done/` and `docs/dogfood-watchmen-design.md` are historical evidence snapshots and remain unchanged per the ticket.

Closes #081.

## Verification
- `rg "phaedrus\.io" crates/` returns zero hits in code and fixtures.
- `cargo test -p canary-cli --lib integration_patch` — 2 passed, 0 failed.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/081-remove-hardcoded-operator-domain-fixture.md