### PR TITLE
feat(071): record durable read-audit events for responder context fetches

### DIFF
--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -34,6 +34,7 @@ mod monitor_overdue;
 mod public_routes;
 mod query_routes;
 mod rate_limit;
+mod read_audit;
 mod report_routes;
 mod retention_prune;
 mod route_state;

--- a/crates/canary-server/src/query_routes.rs
+++ b/crates/canary-server/src/query_routes.rs
@@ -249,12 +249,12 @@ pub(crate) async fn show_error(
         Err(problem) => return problem_response(*problem),
     };
 
-    let store = match state.lock_store() {
+    let mut store = match state.lock_store() {
         Ok(store) => store,
         Err(_) => return problem_response(internal_problem()),
     };
 
-    match store.error_detail_scoped(&id, &key.tenant_id, &key.project_id) {
+    let response = match store.error_detail_scoped(&id, &key.tenant_id, &key.project_id) {
         Ok(Some(result)) => {
             if let Some(bound_service) = key.service.as_deref()
                 && result.service != bound_service
@@ -266,7 +266,10 @@ pub(crate) async fn show_error(
         Ok(None) => problem_response(not_found_problem(format!("Error {id} not found."))),
         Err(QueryError::InvalidWindow) => problem_response(invalid_window_problem()),
         Err(QueryError::Sqlite(_)) => problem_response(internal_problem()),
-    }
+    };
+
+    crate::read_audit::record_read_audit(&mut store, &key, "GET /api/v1/errors/{id}");
+    response
 }
 
 pub(crate) async fn show_incident(
@@ -284,7 +287,7 @@ pub(crate) async fn show_incident(
         Err(_) => return problem_response(internal_problem()),
     };
 
-    match store.incident_detail_scoped(&id, &key.tenant_id, &key.project_id) {
+    let response = match store.incident_detail_scoped(&id, &key.tenant_id, &key.project_id) {
         Ok(Some(result)) => {
             if let Some(bound_service) = key.service.as_deref()
                 && result.incident.service != bound_service
@@ -296,5 +299,8 @@ pub(crate) async fn show_incident(
         Ok(None) => problem_response(not_found_problem(format!("Incident {id} not found."))),
         Err(QueryError::InvalidWindow) => problem_response(invalid_window_problem()),
         Err(QueryError::Sqlite(_)) => problem_response(internal_problem()),
-    }
+    };
+
+    crate::read_audit::record_read_audit(&mut store, &key, "GET /api/v1/incidents/{id}");
+    response
 }

--- a/crates/canary-server/src/read_audit.rs
+++ b/crates/canary-server/src/read_audit.rs
@@ -1,0 +1,186 @@
+//! Durable read-audit events for responder context fetches.
+//!
+//! When a non-admin API key reads rich context (`/api/v1/report`,
+//! `/api/v1/incidents/{id}`, `/api/v1/errors/{id}`), Canary records a
+//! durable audit event in `service_events` with
+//! `retention_class = 'audit'`. The audit record captures *who* read
+//! *what route* and *when* — never the response payload itself.
+//!
+//! This gives the future context-minimization pass (#048) a real read
+//! trail to design against without requiring the scope-model decision tonight.
+
+use canary_core::ids::EventId;
+use canary_store::{Store, TelemetryEventInsert, VerifiedApiKey};
+use serde_json::json;
+
+use crate::server_time::current_rfc3339;
+
+/// Record a read-audit event for a responder-scoped context fetch.
+///
+/// Skips silently for admin keys (admin already has full visibility; the
+/// goal is a responder-specific trail). The audit record never contains the
+/// response payload — only key id, service binding, route, and timestamp.
+pub(crate) fn record_read_audit(store: &mut Store, key: &VerifiedApiKey, route: &str) {
+    if key.scope == "admin" {
+        return;
+    }
+
+    let service = key.service.as_deref().unwrap_or("canary");
+    let now = current_rfc3339();
+    let attributes = json!({
+        "key_id": key.id,
+        "key_scope": key.scope,
+        "key_service": key.service,
+        "route": route,
+    });
+
+    let event = TelemetryEventInsert {
+        id: EventId::generate(),
+        tenant_id: key.tenant_id.clone(),
+        project_id: key.project_id.clone(),
+        service: service.to_owned(),
+        name: "responder.context_read".to_owned(),
+        severity: "info".to_owned(),
+        summary: format!("{service}: context read by key {} via {route}", key.id),
+        attributes_json: attributes.to_string(),
+        retention_class: "audit".to_owned(),
+        privacy_policy: "redacted".to_owned(),
+        sampling_policy: "unsampled".to_owned(),
+        created_at: now,
+    };
+
+    let _ = store.insert_telemetry_event(event);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use canary_store::{BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, TimelineQueryOptions};
+
+    fn make_migrated_store() -> Store {
+        let mut store = Store::open_in_memory().unwrap();
+        store.migrate().unwrap();
+        store
+    }
+
+    fn test_key(scope: &str, service: Option<&str>) -> VerifiedApiKey {
+        VerifiedApiKey {
+            id: "KEY-test".to_owned(),
+            name: "test key".to_owned(),
+            scope: scope.to_owned(),
+            tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
+            project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
+            service: service.map(|s| s.to_owned()),
+        }
+    }
+
+    #[test]
+    fn responder_read_produces_audit_event() {
+        let mut store = make_migrated_store();
+        let key = test_key("responder-write", Some("test-svc"));
+
+        record_read_audit(&mut store, &key, "GET /api/v1/report");
+
+        let response = store
+            .timeline(
+                "1h",
+                TimelineQueryOptions {
+                    tenant_id: Some(BOOTSTRAP_TENANT_ID.to_owned()),
+                    project_id: Some(BOOTSTRAP_PROJECT_ID.to_owned()),
+                    service: Some("test-svc".to_owned()),
+                    limit: Some("10".to_owned()),
+                    cursor: None,
+                    event_type: Some("telemetry.event".to_owned()),
+                },
+            )
+            .unwrap();
+
+        let audit_events: Vec<_> = response
+            .events
+            .iter()
+            .filter(|e| e.event == "telemetry.event")
+            .collect();
+        assert_eq!(audit_events.len(), 1);
+        assert_eq!(audit_events[0].service, "test-svc");
+    }
+
+    #[test]
+    fn admin_read_produces_no_audit_event() {
+        let mut store = make_migrated_store();
+        let key = test_key("admin", None);
+
+        record_read_audit(&mut store, &key, "GET /api/v1/report");
+
+        let response = store
+            .timeline(
+                "1h",
+                TimelineQueryOptions {
+                    tenant_id: Some(BOOTSTRAP_TENANT_ID.to_owned()),
+                    project_id: Some(BOOTSTRAP_PROJECT_ID.to_owned()),
+                    service: None,
+                    limit: Some("10".to_owned()),
+                    cursor: None,
+                    event_type: Some("telemetry.event".to_owned()),
+                },
+            )
+            .unwrap();
+
+        assert!(response.events.is_empty());
+    }
+
+    #[test]
+    fn read_only_key_produces_audit_event() {
+        let mut store = make_migrated_store();
+        let key = test_key("read-only", None);
+
+        record_read_audit(&mut store, &key, "GET /api/v1/incidents/{id}");
+
+        let response = store
+            .timeline(
+                "1h",
+                TimelineQueryOptions {
+                    tenant_id: Some(BOOTSTRAP_TENANT_ID.to_owned()),
+                    project_id: Some(BOOTSTRAP_PROJECT_ID.to_owned()),
+                    service: Some("canary".to_owned()),
+                    limit: Some("10".to_owned()),
+                    cursor: None,
+                    event_type: Some("telemetry.event".to_owned()),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(response.events.len(), 1);
+    }
+
+    #[test]
+    fn audit_event_does_not_contain_payload_body() {
+        let mut store = make_migrated_store();
+        let key = test_key("responder-write", Some("svc-a"));
+
+        record_read_audit(&mut store, &key, "GET /api/v1/errors/{id}");
+
+        let response = store
+            .timeline(
+                "1h",
+                TimelineQueryOptions {
+                    tenant_id: Some(BOOTSTRAP_TENANT_ID.to_owned()),
+                    project_id: Some(BOOTSTRAP_PROJECT_ID.to_owned()),
+                    service: Some("svc-a".to_owned()),
+                    limit: Some("10".to_owned()),
+                    cursor: None,
+                    event_type: Some("telemetry.event".to_owned()),
+                },
+            )
+            .unwrap();
+
+        let event = &response.events[0];
+        let attrs = &event.attributes;
+        assert!(attrs.get("key_id").is_some());
+        assert!(attrs.get("route").is_some());
+        assert!(
+            attrs.get("response_body").is_none(),
+            "audit event must not contain the response payload"
+        );
+    }
+}

--- a/crates/canary-server/src/report_routes.rs
+++ b/crates/canary-server/src/report_routes.rs
@@ -190,7 +190,7 @@ pub(crate) async fn report(
         );
     }
 
-    if accepts_csv(&headers) {
+    let result = if accepts_csv(&headers) {
         response(
             StatusCode::OK.as_u16(),
             "text/csv; charset=utf-8",
@@ -198,7 +198,10 @@ pub(crate) async fn report(
         )
     } else {
         json_status_response(StatusCode::OK.as_u16(), body)
-    }
+    };
+
+    crate::read_audit::record_read_audit(&mut store, &key, "GET /api/v1/report");
+    result
 }
 
 fn error_group_response(group: &ErrorGroupSummary) -> Value {

--- a/crates/canary-workers/src/webhooks.rs
+++ b/crates/canary-workers/src/webhooks.rs
@@ -589,7 +589,7 @@ fn canonical_json(value: &Value) -> String {
         }
         Value::Object(object) => {
             let mut entries = object.iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_by_key(|(left, _)| *left);
             let nested = entries
                 .into_iter()
                 .map(|(key, value)| {


### PR DESCRIPTION
## Summary
Add a read-audit module that records who-read-what-when events when non-admin API keys read rich context routes:
- `GET /api/v1/report`
- `GET /api/v1/incidents/{id}`
- `GET /api/v1/errors/{id}`

The audit event uses the existing `service_events` table with `retention_class = 'audit'` via `Store::insert_telemetry_event`. It captures key id, key scope, key service binding, and route — never the response payload body. Admin keys are exempt (admin already has full visibility).

This is the mechanical read-audit piece from #048, deliberately narrowed: it does NOT attempt context-envelope redesign, minimization/redaction policy, or new responder scopes. Recording *that* a read happened is mechanical; deciding *what* should be redacted stays in #048.

Also fixes a pre-existing clippy lint in `canary-workers/src/webhooks.rs` (`sort_by` → `sort_by_key`) that the workspace-wide clippy check surfaced.

Closes #071.

## Verification
- 4 tests in `read_audit.rs`:
  - responder read produces audit event ✅
  - admin read produces no audit event ✅
  - read-only key produces audit event ✅
  - audit event does not contain response payload ✅
- `cargo test -p canary-server --lib read_audit` — 4 passed, 0 failed.
- `cargo test -p canary-server --lib` — 226 passed, 0 failed.
- `cargo clippy -p canary-server --tests -- -D warnings` — clean.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/071-responder-context-read-audit-events.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit tracking for key read actions in incident, error, and report views.
  * Expanded telemetry coverage for read-only access while keeping admin-only access excluded.
* **Bug Fixes**
  * Improved consistency of exported report and incident responses while preserving existing output formats.
* **Chores**
  * Minor cleanup to response handling and data formatting for webhook-related JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->