### PR TITLE
refactor(056): dedup owner-scope clause into shared scope module

### DIFF
--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -22,6 +22,7 @@ mod query;
 mod rate_limits;
 mod retention;
 mod schema;
+mod scope;
 mod seeds;
 mod service_sli;
 mod telemetry;

--- a/crates/canary-store/src/query.rs
+++ b/crates/canary-store/src/query.rs
@@ -17,6 +17,8 @@ use rusqlite::{Connection, OptionalExtension, params, params_from_iter, types::T
 use serde_json::Value;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
+use crate::scope::owner_clause;
+
 const MAX_INCIDENT_SIGNALS: usize = 25;
 const MAX_INCIDENT_ANNOTATIONS: usize = 20;
 const MAX_INCIDENT_TIMELINE_EVENTS: usize = 5;
@@ -379,7 +381,7 @@ fn error_summary_at_scoped(
 ) -> QueryResult<Vec<ErrorSummaryItem>> {
     let window = QueryWindow::parse(window).ok_or(QueryError::InvalidWindow)?;
     let cutoff = window.cutoff_at(now);
-    let owner_clause = owner_clause("error_groups", 2);
+    let owner_clause = owner_clause("error_groups", 2, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT service, SUM(total_count), COUNT(group_hash)
@@ -452,7 +454,7 @@ fn report_error_groups_at_scoped(
 ) -> QueryResult<Vec<ErrorGroupSummary>> {
     let window = QueryWindow::parse(window).ok_or(QueryError::InvalidWindow)?;
     let cutoff = window.cutoff_at(now);
-    let owner_clause = owner_clause("g", 2);
+    let owner_clause = owner_clause("g", 2, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT
@@ -545,8 +547,8 @@ fn recent_transitions_at_scoped(
 ) -> QueryResult<Vec<RecentTransition>> {
     let window = QueryWindow::parse(window).ok_or(QueryError::InvalidWindow)?;
     let cutoff = window.cutoff_at(now);
-    let target_owner_clause = owner_clause("t", 2);
-    let monitor_owner_clause = owner_clause("m", 2);
+    let target_owner_clause = owner_clause("t", 2, owner);
+    let monitor_owner_clause = owner_clause("m", 2, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT 'target', t.id, t.name, COALESCE(NULLIF(t.service, ''), t.name), s.state, s.last_transition_at
@@ -645,7 +647,7 @@ fn search_errors_at_scoped(
     }
     let cutoff = window.cutoff_at(now);
     let quoted = format!("\"{}\"", trimmed.replace('"', "\"\""));
-    let owner_clause = owner_clause("e", 3);
+    let owner_clause = owner_clause("e", 3, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT e.id, e.service, e.error_class, e.message, e.group_hash, e.created_at,
@@ -1013,7 +1015,7 @@ fn error_class_aggregates(
     cutoff: &str,
     owner: Option<(&str, &str)>,
 ) -> QueryResult<Vec<ErrorClassAggregate>> {
-    let owner_clause = owner_clause("error_groups", 2);
+    let owner_clause = owner_clause("error_groups", 2, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT error_class, COALESCE(SUM(total_count), 0), COUNT(DISTINCT service)
@@ -1059,7 +1061,7 @@ fn error_class_totals(
     cutoff: &str,
     owner: Option<(&str, &str)>,
 ) -> QueryResult<(u64, u64)> {
-    let owner_clause = owner_clause("error_groups", 2);
+    let owner_clause = owner_clause("error_groups", 2, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT COALESCE(SUM(total_count), 0), COUNT(DISTINCT error_class)
@@ -1173,7 +1175,7 @@ fn incident_rows(
     connection: &Connection,
     owner: Option<(&str, &str)>,
 ) -> QueryResult<Vec<IncidentRow>> {
-    let owner_clause = owner_clause("incidents", 1);
+    let owner_clause = owner_clause("incidents", 1, owner);
     let sql = if owner.is_some() {
         format!(
             "SELECT id, tenant_id, project_id, service, title, opened_at, resolved_at
@@ -2366,13 +2368,6 @@ fn error_query_groups_from_rows(
 ) -> ErrorGroupQueryResult<Vec<ErrorGroupSummary>> {
     let groups = rows.collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(groups)
-}
-
-fn owner_clause(alias: &str, first_parameter: usize) -> String {
-    format!(
-        " AND {alias}.tenant_id = ?{first_parameter} AND {alias}.project_id = ?{}",
-        first_parameter + 1
-    )
 }
 
 fn group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ErrorGroupSummary> {

--- a/crates/canary-store/src/scope.rs
+++ b/crates/canary-store/src/scope.rs
@@ -1,0 +1,45 @@
+//! Shared tenant/project owner-scope helpers for query and SLI read models.
+//!
+//! Both `query.rs` and `service_sli.rs` need to scope SQL by tenant and
+//! project. This module owns the one canonical clause builder and parameter
+//! list so cross-tenant isolation logic cannot drift between the two copies.
+
+/// Build the `AND alias.tenant_id = ?N AND alias.project_id = ?N+1` SQL
+/// fragment. Returns an empty string when `owner` is `None` so callers can
+/// always interpolate `{owner_clause}` into a single SQL template.
+pub(crate) fn owner_clause(
+    alias: &str,
+    first_parameter: usize,
+    owner: Option<(&str, &str)>,
+) -> String {
+    owner
+        .map(|_| {
+            format!(
+                " AND {alias}.tenant_id = ?{first_parameter} AND {alias}.project_id = ?{}",
+                first_parameter + 1
+            )
+        })
+        .unwrap_or_default()
+}
+
+/// Collect tenant and project parameter values for a scoped query. Returns
+/// an empty vector when `owner` is `None`.
+pub(crate) fn owner_params<'a>(owner: Option<(&'a str, &'a str)>) -> Vec<&'a str> {
+    owner
+        .map(|(tenant_id, project_id)| vec![tenant_id, project_id])
+        .unwrap_or_default()
+}
+
+/// Prepend `cutoff` to the owner params, producing the parameter list for a
+/// windowed scoped query: `[cutoff, tenant_id, project_id]` or `[cutoff]`.
+pub(crate) fn window_params<'a>(
+    cutoff: &'a str,
+    owner: Option<(&'a str, &'a str)>,
+) -> Vec<&'a str> {
+    let mut values = vec![cutoff];
+    if let Some((tenant_id, project_id)) = owner {
+        values.push(tenant_id);
+        values.push(project_id);
+    }
+    values
+}

--- a/crates/canary-store/src/service_sli.rs
+++ b/crates/canary-store/src/service_sli.rs
@@ -13,6 +13,8 @@ use canary_core::{
 use rusqlite::{Connection, params_from_iter};
 use time::OffsetDateTime;
 
+use crate::scope::{owner_clause, owner_params, window_params};
+
 use crate::query::{QueryError, QueryResult};
 
 /// Per-service SLI projection returned by the unified report.
@@ -593,32 +595,6 @@ fn incident_sli_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IncidentSliRow>
 
 fn ratio(successful: u64, total: u64) -> Option<f64> {
     (total > 0).then_some(successful as f64 / total as f64)
-}
-
-fn owner_clause(alias: &str, first_parameter: usize, owner: Option<(&str, &str)>) -> String {
-    owner
-        .map(|_| {
-            format!(
-                "AND {alias}.tenant_id = ?{first_parameter} AND {alias}.project_id = ?{}",
-                first_parameter + 1
-            )
-        })
-        .unwrap_or_default()
-}
-
-fn owner_params<'a>(owner: Option<(&'a str, &'a str)>) -> Vec<&'a str> {
-    owner
-        .map(|(tenant_id, project_id)| vec![tenant_id, project_id])
-        .unwrap_or_default()
-}
-
-fn window_params<'a>(cutoff: &'a str, owner: Option<(&'a str, &'a str)>) -> Vec<&'a str> {
-    let mut values = vec![cutoff];
-    if let Some((tenant_id, project_id)) = owner {
-        values.push(tenant_id);
-        values.push(project_id);
-    }
-    values
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Hoist the duplicated tenant/project owner-scope SQL clause builder from `query.rs` and `service_sli.rs` into one `pub(crate) scope` module. The canonical `owner_clause`, `owner_params`, and `window_params` helpers are now called from both read-model paths.

**Before:** Two copies of `owner_clause` with different signatures (`query.rs`: unconditional, `service_sli.rs`: `Option`-aware) invited silent drift on a security-sensitive cross-tenant isolation path.

**After:** One `scope::owner_clause(alias, first_parameter, owner)` used by both. The `Option`-aware signature reconciles the unscoped-default difference noted in the #047 review.

Closes the owner-clause dedup half of #056 (report lock contention measurement remains for a dedicated perf pass).

## Verification
- `grep -n 'fn owner_clause' crates/canary-store/src/` returns one hit (in `scope.rs`).
- `cargo test -p canary-store --lib` — 99 passed, 0 failed.
- `cargo clippy -p canary-store -- -D warnings` — clean.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/056-report-lock-and-owner-scope-followups.md