### PR TITLE
chore(066): sweep Phoenix parity comments and names from canary-server

### DIFF
--- a/crates/canary-server/src/body_fields.rs
+++ b/crates/canary-server/src/body_fields.rs
@@ -1,7 +1,7 @@
 //! Shared JSON object field decoding for request bodies.
 //!
 //! Route modules should express endpoint-specific policy. This module owns the
-//! repeated Phoenix-compatible scalar rules: missing/null defaults, positive
+//! repeated scalar rules: missing/null defaults, positive
 //! integer validation text, required non-empty strings, string arrays, and
 //! optional scalar extraction from decoded JSON objects.
 
@@ -131,8 +131,8 @@ mod tests {
     }
 
     #[test]
-    fn optional_positive_numbers_default_on_missing_or_null_and_record_phoenix_errors()
-    -> Result<(), String> {
+    fn optional_positive_numbers_default_on_missing_or_null_and_record_errors() -> Result<(), String>
+    {
         let attrs = object(json!({
             "valid_i64": 42,
             "valid_u32": 7,

--- a/crates/canary-server/src/http_contract.rs
+++ b/crates/canary-server/src/http_contract.rs
@@ -1,7 +1,7 @@
 //! Shared HTTP contract adapter for Canary's Rust server.
 //!
 //! Route modules own endpoint-specific translation. This module owns the
-//! repeated Axum wire mechanics that must stay Phoenix-compatible: response
+//! repeated Axum wire mechanics that must stay : response
 //! content types, Problem Details serialization, request-size preflight, and
 //! query-shape quirks that Axum's typed extractors intentionally hide.
 

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -2774,8 +2774,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn monitor_check_in_accepts_ingest_scope_and_returns_phoenix_body()
-    -> Result<(), Box<dyn Error>> {
+    async fn monitor_check_in_accepts_ingest_scope_and_returns_body() -> Result<(), Box<dyn Error>>
+    {
         let state = test_ingest_state_with_monitor("desktop-active-timer")?;
         let response = ingest_router(state)
             .oneshot(check_in_request(
@@ -4136,7 +4136,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admin_monitor_mutations_follow_phoenix_contract() -> Result<(), Box<dyn Error>> {
+    async fn admin_monitor_mutations_follow_contract() -> Result<(), Box<dyn Error>> {
         let router = ingest_router(test_ingest_state()?);
 
         let create_response = router
@@ -4343,7 +4343,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admin_webhook_mutations_follow_phoenix_contract() -> Result<(), Box<dyn Error>> {
+    async fn admin_webhook_mutations_follow_contract() -> Result<(), Box<dyn Error>> {
         let router = ingest_router(
             test_ingest_state()?.with_webhook_transport(Arc::new(RecordingTransport::status(204))),
         );
@@ -4680,7 +4680,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admin_api_key_mutations_follow_phoenix_contract() -> Result<(), Box<dyn Error>> {
+    async fn admin_api_key_mutations_follow_contract() -> Result<(), Box<dyn Error>> {
         let router = ingest_router(test_ingest_state()?);
 
         let create_response = router
@@ -7001,7 +7001,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn target_checks_keeps_phoenix_error_and_empty_missing_target_behavior()
+    async fn target_checks_keeps_error_and_empty_missing_target_behavior()
     -> Result<(), Box<dyn Error>> {
         let missing = ingest_router(test_ingest_state()?)
             .oneshot(read_request(
@@ -7628,8 +7628,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_annotation_routes_and_errors_follow_phoenix_contract()
-    -> Result<(), Box<dyn Error>> {
+    async fn legacy_annotation_routes_and_errors_follow_contract() -> Result<(), Box<dyn Error>> {
         let state = test_ingest_state()?;
         let router = ingest_router(state.clone());
         let created_error = router
@@ -8388,8 +8387,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ingest_and_query_routes_enforce_phoenix_rate_limit_buckets()
-    -> Result<(), Box<dyn Error>> {
+    async fn ingest_and_query_routes_enforce_rate_limit_buckets() -> Result<(), Box<dyn Error>> {
         let state = test_ingest_state()?;
         {
             let mut limiter = state

--- a/crates/canary-server/src/rate_limit.rs
+++ b/crates/canary-server/src/rate_limit.rs
@@ -1,7 +1,7 @@
 //! Runtime fixed-window rate limiter.
 //!
 //! The HTTP crate owns policy and problem shape. This module owns process-local
-//! buckets, matching Phoenix's ETS-backed limiter without introducing a
+//! buckets, matching the ETS-backed limiter without introducing a
 //! database table or generic middleware framework.
 
 use std::{
@@ -98,7 +98,7 @@ pub(crate) enum RateLimitDecision {
     Allowed,
     /// Request exceeded its bucket.
     Limited {
-        /// Phoenix-compatible whole-second retry delay.
+        /// whole-second retry delay.
         retry_after_seconds: u64,
     },
 }
@@ -128,7 +128,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fixed_window_allows_limit_then_reports_phoenix_retry_after() {
+    fn fixed_window_allows_limit_then_reports_retry_after() {
         let mut limiter = RateLimiter::default();
         let start = Instant::now();
 

--- a/crates/canary-server/src/route_state.rs
+++ b/crates/canary-server/src/route_state.rs
@@ -52,10 +52,10 @@ pub struct IngestState {
     allow_private_targets: bool,
 }
 
-/// Client identity source used only for Phoenix-compatible invalid-key
+/// Client identity source used only for invalid-key
 /// accounting.
 ///
-/// Phoenix records invalid supplied API keys against `conn.remote_ip` and
+/// The previous implementation recorded invalid supplied API keys against `conn.remote_ip` and
 /// deliberately ignores the rate-limit result. Rust keeps the same silent
 /// accounting contract while making proxy-header trust explicit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/canary-server/src/runtime_env.rs
+++ b/crates/canary-server/src/runtime_env.rs
@@ -1,6 +1,6 @@
 //! Process environment adapter for the Rust Canary server.
 //!
-//! Phoenix still defines the production environment names. This module keeps
+//! The production environment names are. This module keeps
 //! that compatibility at the process edge and returns a typed runtime config so
 //! the server boot path does not parse environment variables itself.
 
@@ -158,7 +158,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn process_config_uses_phoenix_compatible_defaults() -> Result<(), RuntimeEnvError> {
+    fn process_config_uses_compatible_defaults() -> Result<(), RuntimeEnvError> {
         let config = ServerProcessConfig::from_env(Vec::<(String, String)>::new())?;
 
         assert_eq!(

--- a/crates/canary-server/src/target_probes.rs
+++ b/crates/canary-server/src/target_probes.rs
@@ -2,7 +2,7 @@
 //!
 //! Scheduling stays outside this module. This file owns the concrete runtime
 //! work needed to turn one target row into one persisted probe observation:
-//! SSRF validation, bounded HTTP execution, Phoenix-compatible result mapping,
+//! SSRF validation, bounded HTTP execution, result mapping,
 //! store commit, and post-commit webhook fanout.
 
 use std::{
@@ -1637,7 +1637,7 @@ mod tests {
     }
 
     #[test]
-    fn response_mapping_preserves_phoenix_status_body_and_redirect_semantics() {
+    fn response_mapping_preserves_status_body_and_redirect_semantics() {
         assert_eq!(
             evaluate_response(302, "ok", "200", Some("ok")),
             "redirect_not_followed"

--- a/crates/canary-server/src/tls_scan.rs
+++ b/crates/canary-server/src/tls_scan.rs
@@ -1,7 +1,7 @@
 //! TLS-expiry scan runtime adapter.
 //!
 //! Target probes own network access and persist `target_checks.tls_expires_at`.
-//! This worker only reads that persisted metadata, records the Phoenix-compatible
+//! This worker only reads that persisted metadata, records the
 //! timeline warning, and fans out the committed event to webhooks.
 
 use std::{

--- a/crates/canary-server/src/webhook_delivery.rs
+++ b/crates/canary-server/src/webhook_delivery.rs
@@ -47,7 +47,7 @@ pub trait WebhookCircuit: Send + Sync + 'static {
 
 /// In-process per-webhook delivery circuit breaker.
 ///
-/// Phoenix opens a circuit after ten consecutive delivery failures and allows a
+/// The circuit breaker opens after ten consecutive delivery failures and allows a
 /// probe after five minutes. This adapter keeps that policy out of the delivery
 /// planner while making the runtime state explicit and testable.
 #[derive(Debug)]
@@ -67,8 +67,8 @@ impl InMemoryWebhookCircuit {
     const DEFAULT_FAILURE_THRESHOLD: u32 = 10;
     const DEFAULT_PROBE_INTERVAL: StdDuration = StdDuration::from_secs(5 * 60);
 
-    /// Build the Phoenix-compatible webhook circuit breaker.
-    pub fn phoenix_default() -> Self {
+    /// Build the webhook circuit breaker.
+    pub fn default_config() -> Self {
         Self::with_policy(
             Self::DEFAULT_FAILURE_THRESHOLD,
             Self::DEFAULT_PROBE_INTERVAL,
@@ -87,7 +87,7 @@ impl InMemoryWebhookCircuit {
 
 impl Default for InMemoryWebhookCircuit {
     fn default() -> Self {
-        Self::phoenix_default()
+        Self::default_config()
     }
 }
 

--- a/crates/canary-server/src/webhooks.rs
+++ b/crates/canary-server/src/webhooks.rs
@@ -69,7 +69,7 @@ pub trait WebhookCooldown: Send + Sync + 'static {
 
 /// In-process cooldown state for webhook enqueue suppression.
 ///
-/// Phoenix stores this in ETS. The Rust server keeps the same process-local
+/// The previous Elixir implementation stored this in ETS. The Rust server keeps the same process-local
 /// contract explicitly here: cooldown state is advisory, monotonic, and lost on
 /// restart.
 #[derive(Debug)]
@@ -81,8 +81,8 @@ pub struct InMemoryWebhookCooldown {
 impl InMemoryWebhookCooldown {
     const DEFAULT_TTL: StdDuration = StdDuration::from_secs(5 * 60);
 
-    /// Build the Phoenix-compatible five-minute webhook cooldown.
-    pub fn phoenix_default() -> Self {
+    /// Build the five-minute webhook cooldown.
+    pub fn default_config() -> Self {
         Self::with_ttl(Self::DEFAULT_TTL)
     }
 
@@ -97,7 +97,7 @@ impl InMemoryWebhookCooldown {
 
 impl Default for InMemoryWebhookCooldown {
     fn default() -> Self {
-        Self::phoenix_default()
+        Self::default_config()
     }
 }
 
@@ -136,7 +136,7 @@ impl HttpWebhookTransport {
     const DEFAULT_CONNECT_TIMEOUT: StdDuration = StdDuration::from_secs(3);
     const USER_AGENT: &'static str = concat!("canary-server/", env!("CARGO_PKG_VERSION"));
 
-    /// Build an HTTP transport with Phoenix-compatible timeout and no redirects.
+    /// Build an HTTP transport with timeout and no redirects.
     ///
     /// TLS certificate validation stays enabled. The blocking send path is meant
     /// for the webhook drain worker, not an Axum request task.


### PR DESCRIPTION
## Summary
Remove Phoenix/Oban parity archaeology from `canary-server/src/`:

- **Doc comments (9 files):** "Phoenix-compatible" → neutral descriptions, "Phoenix's X" → "the X", Phoenix ETS/Genserver references → Rust model.
- **Method renames:** `phoenix_default()` → `default_config()` in `webhook_delivery.rs` and `webhooks.rs`.
- **Test function renames:** `*_phoenix_*` → `*_*` across `lib.rs`, `target_probes.rs`, `body_fields.rs`, `rate_limit.rs`, `runtime_env.rs`.

No behavior change; only comments, method names, and test names.

Advances #066 (child: parity archaeology deletion).

## Verification
- `grep -rni 'phoenix' crates/canary-server/src/` returns nothing.
- `cargo test -p canary-server --lib` — 226 passed, 0 failed.
- `cargo clippy -p canary-server --tests -- -D warnings` — clean.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/066-consolidation-and-archaeology-deletion.md