### PR TITLE
chore(066): sweep final Phoenix parity refs from canary-store

### DIFF
--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -1283,7 +1283,7 @@ mod tests {
     }
 
     #[test]
-    fn migrate_creates_the_current_phoenix_tables() -> Result<()> {
+    fn migrate_creates_the_current_tables() -> Result<()> {
         let mut store = migrated_store()?;
 
         assert_eq!(
@@ -3486,7 +3486,7 @@ mod tests {
     }
 
     #[test]
-    fn api_keys_table_preserves_phoenix_hash_storage_shape() -> Result<()> {
+    fn api_keys_table_preserves_hash_storage_shape() -> Result<()> {
         let store = migrated_store()?;
         let columns = columns(&store.connection, "api_keys")?;
 
@@ -3669,7 +3669,7 @@ mod tests {
     }
 
     #[test]
-    fn errors_by_service_returns_phoenix_group_shape_and_summary()
+    fn errors_by_service_returns_group_shape_and_summary()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut store = migrated_store()?;
         store.commit_error_ingest(error_ingest(
@@ -4245,7 +4245,7 @@ mod tests {
     }
 
     #[test]
-    fn report_read_models_match_phoenix_filters_ordering_and_search()
+    fn report_read_models_match_filters_ordering_and_search()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut store = migrated_store()?;
         store.insert_target(TargetInsert {

--- a/crates/canary-store/src/oban_jobs.rs
+++ b/crates/canary-store/src/oban_jobs.rs
@@ -50,7 +50,7 @@ impl WebhookDeliveryJobState {
 /// Fields required to insert one webhook delivery job.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WebhookDeliveryJobInsert {
-    /// Phoenix-compatible job args.
+    /// Job args.
     pub args: Value,
     /// Initial scheduled timestamp.
     pub scheduled_at: String,
@@ -67,7 +67,7 @@ pub struct WebhookDeliveryJobRow {
     pub id: i64,
     /// Current state.
     pub state: WebhookDeliveryJobState,
-    /// Phoenix-compatible args.
+    /// Args.
     pub args: Value,
     /// Current one-based attempt after claiming.
     pub attempt: u32,


### PR DESCRIPTION
## Summary
Remove the last 6 Phoenix parity references from `canary-store`:

- `lib.rs`: 4 test function renames (`*_phoenix_*` → `*_*`)
- `oban_jobs.rs`: 2 doc comments ("Phoenix-compatible" → neutral)

With this PR, `grep -rni 'phoenix' crates/` returns zero hits outside of `.codex/agents/` (harness residue, operator-gated) and historical doc snapshots.

Advances #066 (child: parity archaeology deletion — nearly complete).

## Verification
- `grep -rni 'phoenix' crates/ --include='*.rs'` returns nothing.
- `cargo test -p canary-store --lib` — 99 passed, 0 failed.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/066-consolidation-and-archaeology-deletion.md