### PR TITLE
feat(065): adopt tracing for server startup and shutdown logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,8 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "x509-parser",
 ]
 
@@ -1077,6 +1079,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1139,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1710,6 +1730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1856,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1976,7 +2014,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1986,6 +2036,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/crates/canary-server/Cargo.toml
+++ b/crates/canary-server/Cargo.toml
@@ -22,6 +22,8 @@ thiserror = "2.0"
 time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1.48", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tower-http = { version = "0.6", features = ["cors"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 x509-parser = "0.18"
 
 [dev-dependencies]

--- a/crates/canary-server/src/main.rs
+++ b/crates/canary-server/src/main.rs
@@ -3,11 +3,19 @@
 use std::{error::Error, path::PathBuf, process};
 
 use canary_server::{CanaryServer, ServerProcessConfig, keygen};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 const DEFAULT_DB_PATH: &str = "/data/canary.db";
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     if let Err(error) = run().await {
         eprintln!("canary-server: {error}");
         process::exit(1);
@@ -28,7 +36,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let local_addr = listener.local_addr()?;
     let server = CanaryServer::boot(config.server)?;
 
-    eprintln!("canary-server listening on {local_addr}");
+    info!(%local_addr, "canary-server listening");
     server.serve(listener, shutdown_signal()).await?;
     Ok(())
 }
@@ -72,7 +80,7 @@ fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
 async fn shutdown_signal() {
     let ctrl_c = async {
         if let Err(error) = tokio::signal::ctrl_c().await {
-            eprintln!("canary-server: failed to install Ctrl-C handler: {error}");
+            tracing::warn!(%error, "failed to install Ctrl-C handler");
         }
     };
 
@@ -84,7 +92,7 @@ async fn shutdown_signal() {
                     signal.recv().await;
                 }
                 Err(error) => {
-                    eprintln!("canary-server: failed to install SIGTERM handler: {error}");
+                    tracing::warn!(%error, "failed to install SIGTERM handler");
                 }
             }
         };


### PR DESCRIPTION
## Summary
Add `tracing` and `tracing-subscriber` as `canary-server` dependencies. Initialize a `fmt` subscriber with `env-filter` (`RUST_LOG`) at the start of `main()`, before the server boots.

Replace ad hoc `eprintln!` calls on operational paths with structured tracing macros:
- `"canary-server listening on {addr}"` → `tracing::info!`
- Ctrl-C handler failure → `tracing::warn!`
- SIGTERM handler failure → `tracing::warn!`

**Keep as `eprintln!`** (documented operational contracts):
- Fatal error in `main()` (before tracing init or during teardown)
- Bootstrap key messages in `runtime.rs` (`flyctl logs | grep "Bootstrap API key:"` is a documented contract in `docs/self-host-fly.md` and `docs/backup-restore-dr.md`)
- `mint-key` CLI output (stdout/stderr contract for key capture)

Supports `RUST_LOG` for runtime log-level control without recompilation.

Advances #065 (child 4: adopt tracing for server/workers/operator paths).

## Verification
- `cargo test -p canary-server --lib` — 226 passed, 0 failed.
- `cargo clippy -p canary-server -- -D warnings` — clean.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/065-runtime-hardening.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved server logging setup for clearer, filterable runtime output.
  * Startup and shutdown warnings now use structured logs instead of plain stderr messages.
  * The server’s listening address is now reported in the standard log stream.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->