### PR TITLE
docs(064): add upgrade/rollback guide and compatibility policy

### DIFF
--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -1,0 +1,78 @@
+# Compatibility Policy
+
+Canary's external contracts are stable by version. Breaking changes
+require explicit migration steps and are documented here.
+
+## OpenAPI (`GET /api/v1/openapi.json`)
+
+- The `info.version` field tracks the API version.
+- Route paths, request/response shapes, and status codes are stable
+  within a major version.
+- The `info.x-agent-guide` extension embeds the canonical replay guide;
+  changes to it are documented in the spec diff.
+- Source: `priv/openapi/` (committed JSON fragments).
+
+## CLI (`bin/canary`)
+
+- The JSON envelope `schema_version` field is stable at `1`.
+- Commands that change shape get a new envelope version or a documented
+  additive field.
+- Text output is terse and may change format; JSON output is the stable
+  contract.
+- The MCP manifest (`bin/canary mcp-manifest`) is gated against the
+  runtime tool list so it cannot drift from the CLI.
+
+## MCP (`bin/canary mcp-server`)
+
+- The MCP protocol version is pinned in `crates/canary-cli/src/main.rs`.
+- Tool names and `inputSchema` are derived from the CLI manifest;
+  changes are additive (new tools) or versioned (renamed tools require
+  a protocol bump).
+- Tool call results return the CLI JSON envelope as
+  `structuredContent`; runtime failures return `isError: true`.
+
+## TypeScript SDK (`clients/typescript/`)
+
+- The SDK is not yet published to npm (tracked in #051).
+- Until npm publish ships, install from source via `file:` linking
+  (see `clients/typescript/INTEGRATION.md`).
+- The package exports `@canary-obs/sdk` (main) and
+  `@canary-obs/sdk/nextjs` (Next.js integration); these entry points
+  are stable.
+- Breaking changes to public exports are versioned (semver bump).
+
+## SQLite Schema Migrations
+
+- Migrations are forward-only. `Store::migrate` stamps `user_version`
+  after applying missing migrations.
+- The migration set fails closed on partial existing schemas before
+  stamping (see `CLAUDE.md` footgun: "Schema ownership").
+- There is no automated schema rollback. See
+  [`docs/upgrade-and-rollback.md`](upgrade-and-rollback.md) for the
+  restore-based rollback procedure.
+
+## Webhook Payloads
+
+- The webhook contract version is pinned at `x-webhook-version: 1`.
+- Payload shapes are stable product contracts consumed by downstream
+  responders (e.g. Bitterblossom).
+- The incident event payload shape is pinned by conformance tests in
+  `crates/canary-store/src/incidents.rs` (see #080).
+- Bumping the webhook version is a breaking change requiring lockstep
+  consumer migration. The `subject` + `schema_version:1` form is a
+  future coordinated migration, not the current contract.
+
+## API Key Scopes
+
+- Scopes (`ingest-only`, `read-only`, `responder-write`, `admin`) are
+  stable wire values. See `docs/api-key-rotation.md`.
+- Adding a new scope is additive; removing or renaming a scope is a
+  breaking change.
+
+## Error Responses (RFC 9457)
+
+- All error responses use RFC 9457 Problem Details with stable
+  `type` URIs, `title` strings, and `code` values.
+- Adding new problem codes is additive; removing or renaming codes is
+  a breaking change.
+- Source: `crates/canary-http/src/problem_details.rs`.

--- a/docs/upgrade-and-rollback.md
+++ b/docs/upgrade-and-rollback.md
@@ -1,0 +1,103 @@
+# Upgrade and Rollback
+
+Canary is a single-process, single-database service. Upgrades are
+image-and-deploy; rollback is image-and-restore. There are no
+zero-downtime rolling deploys, blue/green pools, or schema rollback
+scripts — the design is intentionally simpler than a clustered system.
+
+## Upgrade Path
+
+1. **Verify backups before touching anything:**
+
+   ```bash
+   bin/dr-status --app "$CANARY_FLY_APP"
+   bin/dr-restore-check --app "$CANARY_FLY_APP"
+   ```
+
+   If either fails, do not upgrade. Fix backup configuration first.
+
+2. **Pull the latest master and build:**
+
+   ```bash
+   git pull origin master
+   flyctl deploy --app "$CANARY_FLY_APP" --remote-only
+   ```
+
+3. **Verify after deploy:**
+
+   ```bash
+   curl -fsS "$CANARY_ENDPOINT/healthz"
+   curl -fsS "$CANARY_ENDPOINT/readyz"
+   curl -fsS -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+     "$CANARY_ENDPOINT/api/v1/report?window=1h" | jq '.status'
+   ```
+
+   Also check for `service=canary` errors in the post-deploy window:
+
+   ```bash
+   bin/canary errors canary --window 1h
+   ```
+
+## Schema Migrations
+
+Schema migrations are **forward-only**. `Store::migrate` runs on boot
+and stamps `user_version` after applying missing migrations. It fails
+closed on partial existing schemas (see `CLAUDE.md` footgun: "Schema
+ownership").
+
+There is no automated schema rollback. If a migration introduces a
+problem:
+
+1. Stop the machine (`flyctl machines stop`).
+2. Restore the database from the pre-upgrade Litestream replica (see
+   `docs/backup-restore-dr.md` → Destructive Recovery).
+3. Deploy the previous image.
+
+## Rollback
+
+### Image Rollback (no data change)
+
+If the new code is broken but the schema is unchanged:
+
+```bash
+flyctl deploy --app "$CANARY_FLY_APP" --remote-only --image <previous-image-digest>
+```
+
+Or use Fly's built-in rollback:
+
+```bash
+flyctl image rollback --app "$CANARY_FLY_APP"
+```
+
+### Data Rollback (schema changed)
+
+If the new version applied a schema migration and you need to revert:
+
+1. Stop the machine.
+2. Follow the Destructive Recovery procedure in
+   `docs/backup-restore-dr.md`.
+3. Deploy the previous image. `Store::migrate` on the old image will
+   see the restored `user_version` and skip forward migrations.
+
+**Important:** The restored database must come from a Litestream replica
+taken *before* the upgrade. If the only available replica is from after
+the migration ran, the old image may fail to read the newer schema.
+
+## Pre-Upgrade Checklist
+
+- [ ] `bin/dr-status` passes
+- [ ] `bin/dr-restore-check` passes (non-destructive drill)
+- [ ] No open `service=canary` incidents
+- [ ] `./bin/validate --strict` green on the target commit
+- [ ] Operator has the previous image digest recorded for rollback
+
+## What Not to Do
+
+- Do not delete the database file while the app is running. SQLite WAL
+  keeps file handles open; see `CLAUDE.md` footgun: "SQLite WAL and
+  `rm -f`".
+- Do not run two versions against the same database simultaneously.
+  The single-writer invariant assumes one process owns the store.
+- Do not skip the backup verification step. "Restore-based DR" means
+  the backup is the rollback — if it is stale or missing, there is no
+  safety net.


### PR DESCRIPTION
## Summary
Add two plain-docs deliverables for #064 (trustworthy release/upgrade):

**`docs/upgrade-and-rollback.md`** (child 4):
- Upgrade path: verify backups, deploy, verify health
- Schema migrations: forward-only, fail-closed on partial schemas
- Rollback: image rollback (no schema change) vs data rollback (restore from pre-upgrade Litestream replica)
- Pre-upgrade checklist and what-not-to-do

**`docs/compatibility-policy.md`** (child 5):
- OpenAPI: versioned in `info.version`, stable within major version
- CLI: JSON envelope `schema_version` stable at 1
- MCP: protocol version pinned, tool manifest gated
- TypeScript SDK: not on npm yet, `file:` linking, stable entry points
- SQLite migrations: forward-only, no automated rollback
- Webhook payloads: `x-webhook-version:1`, pinned by conformance tests (#080)
- API key scopes: stable wire values
- Error responses: RFC 9457, stable `type`/`title`/`code`

Advances #064 (children 4 and 5).

## Verification
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).
- Both docs cross-reference existing repo contracts (`CLAUDE.md` footguns, `docs/backup-restore-dr.md`, `docs/api-key-rotation.md`).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/064-trustworthy-release-upgrade.md