### PR TITLE
docs(066): document oban_jobs compatibility rationale and refresh debt map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ Prefer these over re-deriving from the code base.
 |---|---|---|
 | **#010 Ramp pattern** (blocked, XL, north-star) | `backlog.d/010-ramp-pattern.md` | Blocked on bitterblossom triage sprite (`bitterblossom/backlog.d/011-canary-triage-sprite.md`). Agent-consumer shape of error→triage→fix. |
 | **#020 Adminifi HTTP surface verification** (blocked, S) | `backlog.d/020-adminifi-http-surface-verification.md` | Upstream Adminifi HTTP surface stability. |
+| **#048 Responder rich-context safety gate** (pending, XL, P0) | `backlog.d/048-responder-rich-context-safety-gate.md` | Context-envelope redesign, minimization/redaction policy, new responder scopes. Read-audit events landed (#071); scope-model decision is ADR-gated. |
+| **#062 Agent loop write surface** (pending, XL, P0) | `backlog.d/062-agent-loop-write-surface.md` | CLI/MCP annotation writeback so agents can complete the loop the vision promises. |
+| **#063 Triage contract hardening** (pending, XL, P1) | `backlog.d/063-triage-contract-hardening.md` | Durable webhook cooldown, dispatch budgets, claim-gated delivery. |
+| **#064 Trustworthy release/upgrade** (pending, L, P1) | `backlog.d/064-trustworthy-release-upgrade.md` | npm publish, Docker image publish, v1.0.0 release-note truth gap. Children 4+5 (upgrade/compatibility docs) shipped. |
+| **#065 Runtime hardening** (pending, L, P1) | `backlog.d/065-runtime-hardening.md` | bcrypt-outside-mutex, tracing adoption (server startup shipped), backup posture. Children 4 (tracing), 5 (anyhow), 6 (SLI floor) shipped. |
+| **#066 Consolidation and archaeology deletion** (pending, XL, P2) | `backlog.d/066-consolidation-and-archaeology-deletion.md` | Worker lifecycle quad unification, oban_jobs rename (gated on prod DB restamp), canary-ingest fold, legacy fixture retirement. Parity comment sweep complete; Burst bucket, stale yarn.lock, .backlog.d/ deleted. |
 | Recurring footgun surface | `CLAUDE.md` footgun list + Rust store/runtime/schema modules | See `CLAUDE.md` — load-bearing. Every remediation here must cite the footgun list and extend it when new failure modes appear. |
 
 All other tracked items are shipped and archived under `backlog.d/_done/`. Priority map + Lanes 1–5 in `backlog.d/README.md`.

--- a/crates/canary-store/src/oban_jobs.rs
+++ b/crates/canary-store/src/oban_jobs.rs
@@ -1,4 +1,28 @@
-//! Minimal Oban-compatible persistence for Rust-owned webhook delivery jobs.
+//! Webhook delivery job persistence.
+//!
+//! The `oban_jobs` SQLite table and the `Canary.Workers.WebhookDelivery` worker
+//! string are inherited from the deleted Elixir/Oban implementation. They are
+//! kept as-is because:
+//!
+//! 1. **Production databases already have rows in `oban_jobs`.** Renaming the
+//!    table requires a data migration that touches the single-writer store
+//!    during a deploy window. The risk/reward is not yet justified — the table
+//!    works correctly and the name does not affect runtime behavior.
+//!
+//! 2. **The `Canary.Workers.WebhookDelivery` worker string is persisted in
+//!    existing `oban_jobs.worker` rows.** Changing it requires an `UPDATE`
+//!    migration that could leave stale rows unclaimable if it runs
+//!    partially.
+//!
+//! 3. **The legacy fixture compat tests** (`tests/legacy_fixture_compat.rs`)
+//!    verify that the Rust migration path correctly handles databases created
+//!    by the Elixir app. Renaming the table would break that compatibility path
+//!    until the fixtures are regenerated.
+//!
+//! When the production database is next restamped (all Elixir-era rows are
+//! drained), this table should be renamed to `webhook_delivery_jobs` and the
+//! worker string updated to a Rust-idiomatic name. That is a coordinated
+//! migration tracked by 066 child 2.
 
 use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::Value;


### PR DESCRIPTION
## Summary
Two plain-docs deliverables for #066:

1. **`oban_jobs.rs` module doc**: Replace "Minimal Oban-compatible persistence" with a 3-point compatibility rationale explaining why the table name and worker string are kept (production rows, partial-migration risk, legacy fixture compat). Documents the future restamp-and-rename path (066 child 2).

2. **`AGENTS.md` known-debt map**: Refresh from 2 stale entries (010/020 only) to the current 7-entry factory-groom epic map (010, 020, 048, 062, 063, 064, 065, 066) with shipped-child annotations so a cold reader knows what's done vs pending (066 child 9).

Advances #066 (child 2: document compatibility rationale; child 9: refresh AGENTS.md known-debt map).

## Verification
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/066-consolidation-and-archaeology-deletion.md