### PR TITLE
test(056): add tests for shared scope module helpers

### DIFF
--- a/crates/canary-store/src/scope.rs
+++ b/crates/canary-store/src/scope.rs
@@ -43,3 +43,55 @@ pub(crate) fn window_params<'a>(
     }
     values
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_clause_with_owner_produces_scoped_fragment() {
+        let clause = owner_clause("error_groups", 2, Some(("tenant-a", "project-b")));
+        assert!(clause.contains("error_groups.tenant_id = ?2"));
+        assert!(clause.contains("error_groups.project_id = ?3"));
+    }
+
+    #[test]
+    fn owner_clause_without_owner_returns_empty_string() {
+        let clause = owner_clause("incidents", 1, None);
+        assert!(clause.is_empty());
+    }
+
+    #[test]
+    fn owner_clause_preserves_alias_and_first_parameter() {
+        let clause = owner_clause("g", 5, Some(("t", "p")));
+        assert!(clause.contains("g.tenant_id = ?5"));
+        assert!(clause.contains("g.project_id = ?6"));
+    }
+
+    #[test]
+    fn owner_params_with_owner_returns_both_values() {
+        let params = owner_params(Some(("tenant-a", "project-b")));
+        assert_eq!(params, vec!["tenant-a", "project-b"]);
+    }
+
+    #[test]
+    fn owner_params_without_owner_returns_empty_vec() {
+        let params = owner_params(None);
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn window_params_with_owner_returns_cutoff_tenant_project() {
+        let params = window_params("2026-07-01T00:00:00Z", Some(("tenant-a", "project-b")));
+        assert_eq!(
+            params,
+            vec!["2026-07-01T00:00:00Z", "tenant-a", "project-b"]
+        );
+    }
+
+    #[test]
+    fn window_params_without_owner_returns_cutoff_only() {
+        let params = window_params("2026-07-01T00:00:00Z", None);
+        assert_eq!(params, vec!["2026-07-01T00:00:00Z"]);
+    }
+}


### PR DESCRIPTION
## Summary
The `scope` module (introduced in #208) hoisted the owner-scope clause builder from `query.rs` and `service_sli.rs` into one `pub(crate)` module. The 056 oracle says: "add one if a shared helper is introduced."

7 tests covering:
- `owner_clause`: with owner (scoped fragment), without owner (empty), alias and `first_parameter` preservation
- `owner_params`: with owner (both values), without owner (empty)
- `window_params`: with owner (cutoff+tenant+project), without owner (cutoff only)

## Verification
- `cargo test -p canary-store --lib scope::tests` — 7 passed, 0 failed.
- `cargo clippy -p canary-store -- -D warnings` — clean.
- `./bin/validate --fast` green.
- `./bin/validate --strict` green (pre-push hook).

Agent: glm
Agent-Surface: OpenCode
Agent-Model: openrouter/z-ai/glm-5.2
Agent-Task: backlog.d/056-report-lock-and-owner-scope-followups.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit coverage for scope-related SQL parameter handling.
  * Verified correct SQL clause generation with and without an owner.
  * Confirmed alias handling, parameter offsets, and expected parameter lists for window and owner queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->