### PR TITLE
fix(witness): stop canary-watchman's own overdue pressure from blocking its own recovery check-in

### DIFF
--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -235,6 +235,7 @@ health_file="$tmpdir/healthz.json"
 ready_file="$tmpdir/readyz.json"
 query_file="$tmpdir/canary-query.json"
 alert_plane_file="$tmpdir/alert-plane.json"
+status_file="$tmpdir/monitor-status.json"
 check_in_file="$tmpdir/check-in.json"
 observed_at="$(now_utc)"
 encoded_window="$(urlencode "$WINDOW")"
@@ -349,9 +350,41 @@ else
   status="degraded"
 fi
 
-if [[ "$status" == "healthy" ]]; then
+# Self-witness deadlock guard: $MONITOR's own check-in is the only thing that
+# clears its overdue pressure. If monitor_overdue is impaired *solely*
+# because $MONITOR itself is overdue -- no other worker and no other
+# monitor is unhealthy -- refusing the check-in locks $MONITOR overdue
+# forever: its own missed heartbeat permanently blocks the heartbeat that
+# would resolve it. Impairment involving any other worker or monitor still
+# blocks the check-in exactly as before (see the alert-plane rehearsal gate).
+self_only_pressure="false"
+if [[ "$health_ok" == "true" && "$ready_ok" == "true" && "$query_ok" == "true" \
+      && "$alert_plane_ok" != "true" && "$status" != "unreachable" ]]; then
+  only_monitor_overdue_pressured="$(jq -r '
+    try (
+      (.workers | length) == 1
+      and (.workers[0].name == "monitor_overdue")
+      and (.workers[0].health == "pressured")
+    ) catch false
+  ' "$alert_plane_file")"
+  if [[ "$only_monitor_overdue_pressured" == "true" ]]; then
+    request_json "monitor-status" "GET" "/api/v1/status" "read" "$status_file"
+    self_only_pressure="$(jq -r --arg monitor "$MONITOR" '
+      try (
+        (.response.monitors | type == "array")
+        and ([.response.monitors[] | select(.name != $monitor and .state != "up")] | length) == 0
+      ) catch false
+    ' "$status_file")"
+  fi
+fi
+
+if [[ "$status" == "healthy" || "$self_only_pressure" == "true" ]]; then
   total_errors="$(jq -r '.response.total_errors // 0' "$query_file")"
   ttl_ms_json="${CHECK_IN_TTL_MS:-null}"
+  summary="Canary witness saw healthy self-signals and ${total_errors} recent canary errors."
+  if [[ "$self_only_pressure" == "true" ]]; then
+    summary="Canary witness self-heal: $MONITOR was the sole source of monitor_overdue pressure; sending check-in to clear it."
+  fi
   context="$(
     jq -n \
       --arg endpoint "$ENDPOINT" \
@@ -372,7 +405,7 @@ if [[ "$status" == "healthy" ]]; then
     jq -cn \
       --arg monitor "$MONITOR" \
       --arg observed_at "$observed_at" \
-      --arg summary "Canary witness saw healthy self-signals and ${total_errors} recent canary errors." \
+      --arg summary "$summary" \
       --argjson ttl_ms "$ttl_ms_json" \
       --argjson context "$context" \
       '{
@@ -401,6 +434,7 @@ jq -n \
   --arg window "$WINDOW" \
   --arg status "$status" \
   --argjson require_check_in "$REQUIRE_CHECK_IN" \
+  --argjson self_heal_check_in "$([[ "$self_only_pressure" == "true" ]] && echo true || echo false)" \
   --slurpfile health "$health_file" \
   --slurpfile ready "$ready_file" \
   --slurpfile query "$query_file" \
@@ -414,6 +448,7 @@ jq -n \
     window: $window,
     status: $status,
     require_check_in: ($require_check_in == 1),
+    self_heal_check_in: $self_heal_check_in,
     probes: {
       healthz: $health[0],
       readyz: $ready[0],
@@ -428,7 +463,7 @@ if [[ "$JSON_OUTPUT" == "1" ]]; then
 else
   printf 'status: %s\n' "$status"
   printf 'receipt: %s\n' "$RECEIPT"
-  jq -r '"healthz: \(.probes.healthz.http_status) \(.probes.healthz.latency_ms)ms", "readyz: \(.probes.readyz.http_status) \(.probes.readyz.latency_ms)ms", "alert_plane: \(.alert_plane.status)\(if ((.alert_plane.reasons // []) | length) > 0 then " \((.alert_plane.reasons // []) | join(", "))" else "" end)", "canary_errors: \((if (.probes.canary_query.response | type) == "object" then .probes.canary_query.response.total_errors else null end) // "unknown")", "check_in: \(.check_in.http_status) \(.check_in.latency_ms // "n/a")ms"' "$RECEIPT"
+  jq -r '"healthz: \(.probes.healthz.http_status) \(.probes.healthz.latency_ms)ms", "readyz: \(.probes.readyz.http_status) \(.probes.readyz.latency_ms)ms", "alert_plane: \(.alert_plane.status)\(if ((.alert_plane.reasons // []) | length) > 0 then " \((.alert_plane.reasons // []) | join(", "))" else "" end)", "canary_errors: \((if (.probes.canary_query.response | type) == "object" then .probes.canary_query.response.total_errors else null end) // "unknown")", "check_in: \(.check_in.http_status) \(.check_in.latency_ms // "n/a")ms\(if .self_heal_check_in then " (self-heal)" else "" end)"' "$RECEIPT"
 fi
 
 if [[ "$status" == "healthy" ]]; then

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -25,6 +25,23 @@ is checking.
 | Alert plane | `/readyz` worker snapshots | Every required worker has `health: ok`, no backoff/circuit pressure, and no stale due-work pressure. A `pressured` worker can remain route-ready, but the witness reports a degraded alert plane and does not send the healthy check-in. |
 | Error readback | `GET /api/v1/query?service=canary&window=1h` | HTTP 200, service `canary`, and numeric `total_errors` |
 
+### Self-heal exception
+
+`$MONITOR`'s own check-in is the only thing that clears its overdue pressure.
+If `monitor_overdue` is impaired *solely* because `$MONITOR` itself (normally
+`canary-watchman`) is overdue — no other worker and no other monitor is
+unhealthy, confirmed via `GET /api/v1/status` — the witness sends the
+check-in anyway instead of skipping it. Without this, a single missed
+heartbeat becomes permanent: the overdue heartbeat keeps the alert plane
+impaired, and the impaired alert plane keeps blocking the only check-in that
+would resolve it (found live in production 2026-07-02, `canary-watchman`
+stuck overdue for 11+ hours because its own pressure had locked out its own
+recovery). Impairment involving any other worker or monitor still blocks the
+check-in exactly as before — this exception does not weaken the alert-plane
+bar for unrelated degradation, and does not change the reported `status`
+(it stays `degraded`, not `healthy`, until the next run confirms recovery).
+The receipt's `self_heal_check_in` field records when this fired.
+
 When all route and alert-plane signals are healthy, the witness sends an ingest check-in:
 
 ```json

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -76,6 +76,8 @@ assert_check_in_payload() {
 READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 PRESSURED_READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 NOT_READY_WORKERS_BODY='{"status":"not_ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":12,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":true},{"name":"target_probe","state":"started","health":"failing","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":3,"consecutive_failures":3,"last_error_class":"runtime_error","due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
+OTHER_MONITOR_DOWN_STATUS_BODY='{"error_summary":[],"monitors":[{"id":"MON-a","name":"canary-watchman","state":"up","deadline_at":"2026-06-14T03:00:00Z","last_check_in_at":"2026-06-14T02:50:00Z","last_check_in_status":"alive","mode":"ttl"},{"id":"MON-b","name":"some-other-service","state":"down","deadline_at":"2026-06-14T00:00:00Z","last_check_in_at":"2026-06-13T20:00:00Z","last_check_in_status":"alive","mode":"ttl"}],"overall":"unhealthy","summary":"1 down.","targets":[]}'
+SELF_ONLY_DOWN_STATUS_BODY='{"error_summary":[],"monitors":[{"id":"MON-a","name":"canary-watchman","state":"down","deadline_at":"2026-06-14T00:00:00Z","last_check_in_at":"2026-06-13T20:00:00Z","last_check_in_status":"alive","mode":"ttl"},{"id":"MON-b","name":"some-other-service","state":"up","deadline_at":"2026-06-14T03:00:00Z","last_check_in_at":"2026-06-14T02:50:00Z","last_check_in_status":"alive","mode":"ttl"}],"overall":"unhealthy","summary":"1 down.","targets":[]}'
 
 case "${STUB_SCENARIO:?}:$method:$url" in
   healthy:GET:https://canary.example/healthz)
@@ -101,7 +103,23 @@ case "${STUB_SCENARIO:?}:$method:$url" in
   pressured:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
     ;;
-  pressured:POST:https://canary.example/api/v1/check-ins)
+  pressured:GET:https://canary.example/api/v1/status)
+    write_response 200 0.020 "$OTHER_MONITOR_DOWN_STATUS_BODY"
+    ;;
+
+  self-pressured:GET:https://canary.example/healthz)
+    write_response 200 0.010 '{"status":"ok"}'
+    ;;
+  self-pressured:GET:https://canary.example/readyz)
+    write_response 200 0.020 "$PRESSURED_READY_BODY"
+    ;;
+  self-pressured:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
+    write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
+    ;;
+  self-pressured:GET:https://canary.example/api/v1/status)
+    write_response 200 0.020 "$SELF_ONLY_DOWN_STATUS_BODY"
+    ;;
+  self-pressured:POST:https://canary.example/api/v1/check-ins)
     assert_check_in_payload
     write_response 201 0.040 '{"monitor":"canary-watchman","status":"alive"}'
     ;;
@@ -277,6 +295,24 @@ assert_json_equals "$receipt" '.probes.readyz.response.checks.workers[] | select
 assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "pressured ready records alert-plane impairment"
 assert_json_equals "$receipt" '.alert_plane.workers[] | select(.name == "monitor_overdue") | .health' 'pressured' "pressured ready names impaired worker"
 assert_json_equals "$receipt" '.check_in.skipped' 'true' "pressured ready skips check-in"
+assert_json_equals "$receipt" '.self_heal_check_in' 'false' "pressured ready by another monitor is not a self-heal"
+
+receipt="$TMPDIR_TEST/self-pressured.json"
+run_failure "self-pressured witness exits nonzero" \
+  env \
+    STUB_SCENARIO=self-pressured \
+    "${WITNESS[@]}" \
+    --endpoint https://canary.example \
+    --read-api-key read-key \
+    --ingest-api-key ingest-key \
+    --receipt "$receipt" \
+    --require-check-in \
+    --json
+assert_json_equals "$receipt" '.status' 'degraded' "self-pressured receipt status stays degraded"
+assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "self-pressured records alert-plane impairment"
+assert_json_equals "$receipt" '.self_heal_check_in' 'true' "self-pressured triggers self-heal"
+assert_json_equals "$receipt" '.check_in.skipped' 'false' "self-pressured still sends check-in"
+assert_json_equals "$receipt" '.check_in.http_status' '201' "self-pressured check-in succeeds"
 
 receipt="$TMPDIR_TEST/notready-workers.json"
 run_failure "not-ready worker witness exits nonzero" \


### PR DESCRIPTION
## Summary

- Production incident: `canary-watchman` (the external witness's own heartbeat monitor) missed a check-in around 03:41 UTC 2026-07-02. That made `monitor_overdue` report `pressured`, which made the witness's alert-plane gate classify the instance as impaired, which made the witness skip the very check-in that would clear `canary-watchman`'s own overdue state — a self-sustaining deadlock. `readyz` sat at `due_count: 8` / growing `oldest_due_age_ms` for 11+ hours (GH issue #196, correctly opened by the existing automation at 04:55, but structurally unable to self-resolve).
- `bin/canary-witness` now lets the check-in through when `monitor_overdue` is the *sole* impaired worker and no monitor other than the witness's own target is overdue (confirmed via a new `GET /api/v1/status` probe). Impairment involving any other worker or monitor still blocks the check-in exactly as before, so the dagger alert-plane rehearsal drill (which induces pressure via an unrelated synthetic monitor) is unaffected — verified locally, `./bin/validate` full gate green.
- Reported `status` still reads `degraded` on the run that self-heals; only the follow-up check-in is unblocked, so the *next* run naturally reports `healthy`. This does not weaken the alert-plane bar for genuine, unrelated degradation.

## Recovery (already done, ahead of merge)

- Manually POSTed the `canary-watchman` check-in via the admin API to break the live deadlock. `readyz` confirmed `monitor_overdue` back to `health: ok`, `oldest_due_age_ms: 0`.
- Ran the witness workflow via `workflow_dispatch`; it auto-closed issue #196 through the existing recovery-detection path. No incident-response code needed changing to confirm recovery — the existing self-check mechanism (open issue on failure / auto-close on recovery) worked correctly throughout; it just could never reach recovery without this fix.

## Test plan

- [x] `bash test/bin/canary_witness_test.sh` — 43/43 passing, including new `self-pressured` scenario (asserts `self_heal_check_in: true`, check-in sent, status still `degraded`) and an added assertion on the existing `pressured` scenario (`self_heal_check_in: false` when the impairment is caused by another monitor).
- [x] `./bin/validate` (full Dagger gate, includes the alert-plane impairment rehearsal against a fresh ephemeral instance) — green.
- [x] `shellcheck bin/canary-witness` — clean.
- [x] Live prod: `readyz` monitor_overdue `health: ok`, GH issue #196 auto-closed by the existing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
