### PR TITLE
feat(ui): add Canary human dashboard

### DIFF
--- a/backlog.d/067-human-dashboard-incident-history.md
+++ b/backlog.d/067-human-dashboard-incident-history.md
@@ -1,0 +1,36 @@
+# Human dashboard historical incident index
+
+Priority: P2 · Status: pending · Estimate: M
+
+## Goal
+Give the human dashboard a first-class incident history surface instead of
+deriving recent history from timeline events. The current v1 dashboard lists
+open incidents from `GET /api/v1/incidents` and recent incident events from
+`GET /api/v1/timeline`; that keeps the client thin, but it is not a complete
+historical incident index.
+
+## Oracle
+- [ ] Given an operator opens the Incidents view, then open and resolved
+      incidents come from one bounded incident-list read model with pagination.
+- [ ] Given an incident is resolved, then it remains selectable without relying
+      on a recent timeline event still being inside the requested window.
+- [ ] Given a service-bound read key is used, then historical incidents are
+      filtered by that service without leaking other services.
+- [ ] Given the dashboard renders history, then it still fetches detail through
+      `GET /api/v1/incidents/{id}` and does not reimplement incident state.
+
+## Verification System
+- Claim: humans can inspect all incident history through a thin dashboard
+  client.
+- Falsifier: an incident disappears from the dashboard once its timeline event
+  ages out, or the browser reconstructs incident rows from raw event payloads.
+- Driver: route tests for the new read model, OpenAPI scope tests, service-scope
+  isolation tests, and light/dark dashboard screenshots with resolved history.
+- Grader: response shape is deterministic, paginated, scoped, and backed by
+  existing store incident state.
+- Evidence packet: dashboard screenshot set plus route-test names in the PR.
+
+## Notes
+Filed from the v1 human dashboard lane. Do not add this by making timeline a
+private data lake in the client; add the smallest read model that answers the
+operator question directly.

--- a/backlog.d/068-human-dashboard-read-contract.md
+++ b/backlog.d/068-human-dashboard-read-contract.md
@@ -1,0 +1,37 @@
+# Human dashboard read contract and private-network mode
+
+Priority: P2 · Status: pending · Estimate: M
+
+## Goal
+Make the dashboard read contract explicit enough that a read-only key can answer
+the operator's support views without opportunistically probing admin endpoints,
+and decide whether self-hosted private-network deployments should enable
+keyless reads through an env-gated mode.
+
+## Oracle
+- [ ] Given a read-only key opens the Checks view, then exact target cadence and
+      monitor configuration needed for the view are available through a
+      read-scoped endpoint.
+- [ ] Given the public `canary-obs` app serves the dashboard, then no
+      unauthenticated route returns private data.
+- [ ] Given a self-hosted operator explicitly enables keyless private-network
+      dashboard reads, then the mode is guarded by configuration and documented
+      as unsafe for public Fly apps.
+- [ ] Given OpenAPI is inspected, then the dashboard's read dependencies and
+      scopes are visible to agents.
+
+## Verification System
+- Claim: the dashboard has a deliberate least-privilege read story instead of
+  relying on admin keys for polish.
+- Falsifier: a read-only key cannot show configured watch cadence, or an env
+  flag accidentally opens data on a public app.
+- Driver: auth/scope route tests, OpenAPI scope checks, local dashboard QA with
+  read-only and admin keys, and a public-app auth smoke.
+- Grader: read-only dashboard works without admin-only fallbacks for its core
+  support views; any keyless mode is impossible unless explicitly configured.
+- Evidence packet: PR screenshots plus auth matrix transcript.
+
+## Notes
+The v1 dashboard chooses session-key paste because `canary-obs` is public. This
+ticket is the place to make a separate private-network affordance explicit if
+operators still want powder-style keyless reads on isolated deployments.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -32,6 +32,8 @@ visible until a focused PR archives them with evidence.
 | 064 | Trustworthy release/upgrade | P1 | pending | L |
 | 065 | Runtime hardening | P1 | pending | L |
 | 066 | Consolidation and archaeology deletion | P2 | pending | XL |
+| 067 | Human dashboard historical incident index | P2 | pending | M |
+| 068 | Human dashboard read contract and private-network mode | P2 | pending | M |
 | 058 | Cadence-aware SLI trajectory sample floor | P2 | done | M |
 | 082 | Triage GitHub issue #129 | P3 | done | S |
 | 070 | Archive shipped backlog tickets | P3 | done | S |

--- a/crates/canary-server/src/dashboard_routes.rs
+++ b/crates/canary-server/src/dashboard_routes.rs
@@ -1,0 +1,65 @@
+//! Static human dashboard shell.
+//!
+//! The dashboard is intentionally a same-origin static client over Canary's
+//! existing API. It does not mint keys, proxy reads, or expose any new data
+//! surface; operators paste a scoped API key into the browser session.
+
+use axum::{
+    Router,
+    body::Body,
+    http::{
+        Response, StatusCode,
+        header::{CACHE_CONTROL, CONTENT_TYPE, HeaderValue},
+    },
+    routing::get,
+};
+
+const DASHBOARD_HTML: &str = include_str!("../static/dashboard/index.html");
+const DASHBOARD_CSS: &str = include_str!("../static/dashboard/dashboard.css");
+const DASHBOARD_JS: &str = include_str!("../static/dashboard/app.js");
+const AESTHETIC_CSS: &str = include_str!("../static/dashboard/aesthetic.css");
+
+/// Router for Canary's human dashboard shell.
+pub fn dashboard_router() -> Router {
+    Router::new()
+        .route("/ui", get(index))
+        .route("/ui/", get(index))
+        .route("/ui/dashboard.css", get(dashboard_css))
+        .route("/ui/aesthetic.css", get(aesthetic_css))
+        .route("/ui/app.js", get(app_js))
+}
+
+async fn index() -> Response<Body> {
+    static_response("text/html; charset=utf-8", DASHBOARD_HTML)
+}
+
+async fn dashboard_css() -> Response<Body> {
+    static_response("text/css; charset=utf-8", DASHBOARD_CSS)
+}
+
+async fn aesthetic_css() -> Response<Body> {
+    static_response("text/css; charset=utf-8", AESTHETIC_CSS)
+}
+
+async fn app_js() -> Response<Body> {
+    static_response("text/javascript; charset=utf-8", DASHBOARD_JS)
+}
+
+fn static_response(content_type: &'static str, body: &'static str) -> Response<Body> {
+    match Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, HeaderValue::from_static(content_type))
+        .header(CACHE_CONTROL, HeaderValue::from_static("no-store"))
+        .body(Body::from(body))
+    {
+        Ok(response) => response,
+        Err(_) => {
+            let mut response = Response::new(Body::from("dashboard response error"));
+            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            response
+                .headers_mut()
+                .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+            response
+        }
+    }
+}

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -23,6 +23,7 @@ mod admin_webhooks;
 mod annotations;
 mod body_fields;
 mod claims;
+mod dashboard_routes;
 mod egress;
 mod health_fanout;
 mod health_routes;
@@ -63,6 +64,7 @@ use annotations::{
     list_group_annotations, list_incident_annotations,
 };
 use claims::{create_claim, list_claims, release_claim, show_claim, transition_claim};
+pub use dashboard_routes::dashboard_router;
 pub use health_fanout::{
     EnqueueFailure, EnqueueFailureKey, EnqueueFailureRecorder, EnqueueFailureSink,
     EventFanoutReport, HealthEventFanout, HealthEventSource,
@@ -220,7 +222,8 @@ mod tests {
     use axum::{
         body::{Body, to_bytes},
         http::{
-            HeaderMap, HeaderValue, Method, Request, Response, StatusCode, header::CONTENT_TYPE,
+            HeaderMap, HeaderValue, Method, Request, Response, StatusCode,
+            header::{CACHE_CONTROL, CONTENT_TYPE},
         },
     };
     use canary_core::{
@@ -690,6 +693,16 @@ mod tests {
             .await?;
         assert_eq!(health.status(), StatusCode::OK);
 
+        let dashboard = server
+            .router()
+            .oneshot(Request::get("/ui").body(Body::empty())?)
+            .await?;
+        assert_eq!(dashboard.status(), StatusCode::OK);
+        assert_eq!(
+            dashboard.headers().get(CONTENT_TYPE),
+            Some(&HeaderValue::from_static("text/html; charset=utf-8"))
+        );
+
         let query = server
             .router()
             .oneshot(read_request(READ_KEY, "/api/v1/query?service=test-svc")?)
@@ -761,6 +774,51 @@ mod tests {
         assert_eq!(keys[0].name, "bootstrap");
         assert_eq!(keys[0].scope, "admin");
         fs::remove_file(path)?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dashboard_shell_serves_assets_without_private_data() -> Result<(), Box<dyn Error>> {
+        let router = dashboard_router();
+
+        let shell = router
+            .clone()
+            .oneshot(Request::get("/ui").body(Body::empty())?)
+            .await?;
+        assert_eq!(shell.status(), StatusCode::OK);
+        assert_eq!(
+            shell.headers().get(CONTENT_TYPE),
+            Some(&HeaderValue::from_static("text/html; charset=utf-8"))
+        );
+        assert_eq!(
+            shell.headers().get(CACHE_CONTROL),
+            Some(&HeaderValue::from_static("no-store"))
+        );
+        let shell_body = text_body(shell).await?;
+        assert!(shell_body.contains("data-canary-dashboard"));
+        assert!(!shell_body.contains("sk_live_"));
+        assert!(!shell_body.contains("/api/v1/status"));
+
+        let script = router
+            .clone()
+            .oneshot(Request::get("/ui/app.js").body(Body::empty())?)
+            .await?;
+        assert_eq!(script.status(), StatusCode::OK);
+        assert_eq!(
+            script.headers().get(CONTENT_TYPE),
+            Some(&HeaderValue::from_static("text/javascript; charset=utf-8"))
+        );
+        let script_body = text_body(script).await?;
+        assert!(script_body.contains("Authorization"));
+        assert!(script_body.contains("sessionStorage"));
+
+        let aesthetic = router
+            .oneshot(Request::get("/ui/aesthetic.css").body(Body::empty())?)
+            .await?;
+        assert_eq!(aesthetic.status(), StatusCode::OK);
+        let aesthetic_body = text_body(aesthetic).await?;
+        assert!(aesthetic_body.contains("aesthetic v2.8.1"));
 
         Ok(())
     }

--- a/crates/canary-server/src/runtime.rs
+++ b/crates/canary-server/src/runtime.rs
@@ -32,7 +32,7 @@ use crate::{
     TargetProbeOptions, TargetProbeRuntime, TlsExpiryScanLifecycle, TlsExpiryScanLifecycleConfig,
     TlsExpiryScanLifecycleWorker, WebhookDeliveryDrain, WebhookDeliveryDrainWorker,
     WebhookDeliveryRuntime, WebhookEnqueueEffectSink, WebhookTransport, WorkerHealthRegistry,
-    ingest_router, public_router,
+    dashboard_router, ingest_router, public_router,
     server_time::{current_rfc3339, current_unix_millis},
 };
 
@@ -240,7 +240,9 @@ impl CanaryServer {
             store: store.clone(),
             workers: worker_health.clone(),
         }));
-        let router = public_router(readiness).merge(ingest_router(ingest_state));
+        let router = public_router(readiness)
+            .merge(dashboard_router())
+            .merge(ingest_router(ingest_state));
 
         Ok(Self {
             router,

--- a/crates/canary-server/static/dashboard/aesthetic.css
+++ b/crates/canary-server/static/dashboard/aesthetic.css
@@ -1,0 +1,2113 @@
+/* ═══════════════════════════════════════════════════════════════════
+   aesthetic v2.8.1
+   The Misty Step design system. https://github.com/misty-step/aesthetic
+
+   The law:
+   · One size. Exactly one font size on every surface; the headline is
+     heavier and blacker, never larger.
+   · Three inks by three weights (400 / 550 / 800): nine registers.
+   · The accent is yours. Define your scheme and use it with judgment;
+     identity comes from ink, hairlines, type, and motion — never from
+     a color-counting rule. Color earns its place; it is not ambient.
+   · Status rides the glyph: danger, success, and warning color the
+     icon (✕ ✓ !), never the sentence, never a filled pill.
+   · Every view fits the viewport. 100dvh screens, no page scrolling;
+     when content exceeds one screen, a quiet nav swaps views.
+   · Motion is feedback, never decoration: small, brief, eased, and
+     gone when the user prefers reduced motion. State resolutions are
+     gentler (--ae-gentle) and resolve once — success persists, it is
+     never rewound. Nothing changes size while it animates.
+   · Buttons are not links: contained ink shapes. Links navigate,
+     buttons act.
+   · Light and dark, defaulting to the system, with a user toggle.
+
+   Steering: every token is a CSS custom property; downstream projects
+   steer the scheme — --ae-accent / --ae-accent-dark, and the status
+   triplet when their domain needs different hues. Everything else is
+   the shared identity.
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── tokens ───────────────────────────────────────────────────────── */
+
+:root {
+  --ae-surface: #fcfcfc;
+  --ae-wash: #f3f3f3;
+  --ae-ink: #151515;
+  --ae-ink-muted: #737373;
+  --ae-ink-faint: #a3a3a3;
+  --ae-line: #e9e9e9;
+  --ae-accent: #2643d0;
+
+  /* status inks: hue rides the glyph, words stay ink */
+  --ae-ok: #15714b;
+  --ae-warn: #8a5f32;
+  --ae-err: #a84138;
+
+  /* dark counterparts, resolved by the mode blocks below */
+  --ae-surface-dark: #121212;
+  --ae-wash-dark: #1b1b1b;
+  --ae-ink-dark: #ededed;
+  --ae-ink-muted-dark: #8f8f8f;
+  --ae-ink-faint-dark: #5c5c5c;
+  --ae-line-dark: #262626;
+  --ae-accent-dark: #8c9eff;
+  --ae-ok-dark: #6fd2a8;
+  --ae-warn-dark: #c49d72;
+  --ae-err-dark: #e58379;
+
+  --ae-font: 'Geist', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --ae-font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --ae-w-regular: 400;
+  --ae-w-medium: 550;
+  --ae-w-black: 800;
+
+  --ae-measure: 38rem; /* rem: bars in the 13px chrome register must not shrink the measure */
+  --ae-measure-wide: 68rem;
+  --ae-radius: 0;
+
+  /* the spacing scale: consumers use these instead of ad-hoc em values.
+     The token-guard (015) will enforce them. Off-scale internal values
+     are left as literals — the scale is the vocabulary going forward. */
+  --ae-space-0: 0.1em; /* micro — tag padding, chrome adjustments */
+  --ae-space-1: 0.25em; /* tight — icon gaps, control insets */
+  --ae-space-2: 0.5em; /* small — button padding, small gaps */
+  --ae-space-3: 0.75em; /* medium — control padding, row gaps */
+  --ae-space-4: 1em; /* base — group padding, standard gap */
+  --ae-space-5: 1.5em; /* comfortable — section internals */
+  --ae-space-6: 2em; /* spacious — section gaps, stage padding */
+  --ae-space-7: 2.5em; /* large — document section spacing */
+  --ae-space-8: 3em; /* section — top-level margins */
+
+  /* z-index scale: named layers so consumers don't guess at magic numbers */
+  --ae-z-tip: 10; /* tooltips, hover whispers */
+  --ae-z-toast: 100; /* toasts, persistent notifications */
+
+  /* motion: feedback, never decoration */
+  --ae-ease: cubic-bezier(0.23, 1, 0.32, 1);
+  --ae-quick: 160ms;
+  --ae-soft: 240ms;
+  --ae-gentle: 480ms; /* state resolutions: slower than feedback, never abrupt */
+
+  color-scheme: light dark;
+}
+
+/* auto dark: follows the OS unless the page pins a mode */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light):not([data-ae-mode='light']) {
+    --ae-surface: var(--ae-surface-dark);
+    --ae-wash: var(--ae-wash-dark);
+    --ae-ink: var(--ae-ink-dark);
+    --ae-ink-muted: var(--ae-ink-muted-dark);
+    --ae-ink-faint: var(--ae-ink-faint-dark);
+    --ae-line: var(--ae-line-dark);
+    --ae-accent: var(--ae-accent-dark);
+    --ae-ok: var(--ae-ok-dark);
+    --ae-warn: var(--ae-warn-dark);
+    --ae-err: var(--ae-err-dark);
+  }
+}
+
+/* pinned modes narrow color-scheme so UA widgets (scrollbars, form
+   controls) match the pinned mode instead of following the OS */
+.light,
+[data-ae-mode='light'] {
+  color-scheme: light;
+}
+
+/* pinned dark: class or attribute set by the site's mode toggle */
+.dark,
+[data-ae-mode='dark'] {
+  color-scheme: dark;
+  --ae-surface: var(--ae-surface-dark);
+  --ae-wash: var(--ae-wash-dark);
+  --ae-ink: var(--ae-ink-dark);
+  --ae-ink-muted: var(--ae-ink-muted-dark);
+  --ae-ink-faint: var(--ae-ink-faint-dark);
+  --ae-line: var(--ae-line-dark);
+  --ae-accent: var(--ae-accent-dark);
+  --ae-ok: var(--ae-ok-dark);
+  --ae-warn: var(--ae-warn-dark);
+  --ae-err: var(--ae-err-dark);
+}
+
+/* ── base ─────────────────────────────────────────────────────────── */
+
+html {
+  scroll-behavior: auto;
+}
+
+body {
+  margin: 0;
+  background: var(--ae-surface);
+  color: var(--ae-ink);
+  font-family: var(--ae-font);
+  font-size: 16px;
+  font-weight: var(--ae-w-regular);
+  line-height: 1.8;
+  cursor: default; /* no I-beam on static text; pointer/text are earned */
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* one size: nothing earns scale, only ink and weight */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+li,
+dt,
+dd,
+blockquote,
+figcaption,
+label,
+input,
+textarea,
+button,
+table {
+  font-size: 1em;
+  font-family: inherit;
+  line-height: inherit;
+  margin: 0;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--ae-font-mono);
+  font-size: 0.92em;
+}
+
+::selection {
+  background: var(--ae-wash);
+  color: var(--ae-ink);
+}
+
+:focus-visible {
+  outline: 2px solid var(--ae-ink);
+  outline-offset: 3px;
+}
+
+/* links: ink at rest, warm to accent on hover (the locked treatment).
+   Approved alternates, documented for easy change, live in the README:
+   marker sweep and draw-on-hover. */
+a {
+  color: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-color: var(--ae-ink-faint);
+  padding-block: 0.35em;
+  margin-block: -0.35em;
+  transition:
+    color var(--ae-quick) var(--ae-ease),
+    text-decoration-color var(--ae-quick) var(--ae-ease);
+}
+
+a:hover {
+  color: var(--ae-accent);
+  text-decoration-color: currentColor;
+}
+
+/* list rows: the whole row is the link, so the cursor never crosses a
+   dead band between rows */
+.ae-row-link {
+  display: block;
+  text-decoration: none;
+  padding: 0.42em 0;
+  margin-block: 0;
+  color: inherit;
+}
+
+.ae-row-link:hover {
+  color: inherit;
+}
+
+.ae-row-link .ae-item {
+  transition: color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-row-link:hover .ae-item {
+  color: var(--ae-accent);
+}
+
+/* ── screens: every view fits the viewport ────────────────────────── */
+
+/* the screen: one viewport, no page scroll */
+.ae-screen {
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* a bar: quiet chrome at the top or bottom of a screen */
+.ae-bar {
+  flex: none;
+  width: min(var(--ae-measure), 100% - 5rem);
+  margin-inline: auto;
+  padding: 1.4em 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4em 1.5em;
+}
+
+/* the stage: the screen's content, vertically centered; a view that
+   cannot fit scrolls inside the stage, never the page */
+.ae-stage {
+  flex: 1;
+  min-height: 0;
+  width: min(var(--ae-measure), 100% - 5rem);
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.ae-stage > * {
+  margin-block: auto;
+  padding-block: var(--ae-space-5);
+}
+
+/* long documents: top-aligned instead of centered */
+.ae-stage-scroll > * {
+  margin-block: 0;
+  padding-block: var(--ae-space-6);
+}
+
+/* a wide screen: catalog, specimen, and dashboard shapes that cannot
+   live in 38rem. One decision per screen — set it on .ae-screen. */
+.ae-wide .ae-bar,
+.ae-wide .ae-stage {
+  width: min(var(--ae-measure-wide), 100% - 5rem);
+}
+
+/* a view: one screenful of content; remount to replay the entrance */
+.ae-view {
+  animation: ae-enter var(--ae-soft) var(--ae-ease) both;
+}
+
+/* hash-routed views: one mounts at a time; the display toggle remounts
+   the view and replays its entrance (behavior: recipes/views.js) */
+[data-route] {
+  display: none;
+}
+
+[data-route].is-on {
+  display: block;
+}
+
+@keyframes ae-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+/* the nav: quiet words with a sliding ink underline. The site positions
+   .ae-nav-ind under the active item (left/width) on view change.
+   .ae-tabs is the same instrument pointed at panels instead of views:
+   role="tablist" buttons, aria-selected marks the open one. */
+.ae-nav,
+.ae-tabs {
+  position: relative;
+  display: flex;
+  gap: var(--ae-space-6);
+}
+
+.ae-nav a,
+.ae-nav button,
+.ae-tabs a,
+.ae-tabs button {
+  background: transparent;
+  border: 0;
+  padding: 0 0 0.6em;
+  margin-block: 0;
+  cursor: pointer;
+  color: var(--ae-ink-muted);
+  font-weight: var(--ae-w-medium);
+  text-decoration: none;
+  transition: color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-nav a:hover,
+.ae-nav button:hover,
+.ae-tabs a:hover,
+.ae-tabs button:hover {
+  color: var(--ae-ink);
+}
+
+.ae-nav [aria-current],
+.ae-nav .is-active,
+.ae-tabs [aria-current],
+.ae-tabs [aria-selected='true'],
+.ae-tabs .is-active {
+  color: var(--ae-ink);
+}
+
+.ae-nav-ind {
+  position: absolute;
+  bottom: 0;
+  height: 2px;
+  background: var(--ae-ink);
+  transition:
+    left var(--ae-soft) var(--ae-ease),
+    width var(--ae-soft) var(--ae-ease);
+}
+
+/* chrome: the one sanctioned second size. Content gets 16px; chrome
+   (footers, utility links, metadata) gets 13px and muted ink. */
+.ae-chrome {
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+}
+
+.ae-chrome a {
+  color: var(--ae-ink-muted);
+  text-decoration: none;
+}
+
+.ae-chrome a:hover {
+  color: var(--ae-ink);
+}
+
+/* the footer: hairline-topped, two ends, chrome register */
+.ae-foot {
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+  border-top: 1px solid var(--ae-line);
+  padding-top: var(--ae-space-4);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ae-space-4) var(--ae-space-6);
+  flex-wrap: wrap;
+}
+
+.ae-foot a {
+  color: var(--ae-ink-muted);
+  text-decoration: none;
+}
+
+.ae-foot a:hover {
+  color: var(--ae-ink);
+}
+
+.ae-foot-links {
+  display: inline-flex;
+  gap: var(--ae-space-5);
+  align-items: center;
+}
+
+/* icons: Lucide (ISC), inlined as SVG symbols. 1.5px stroke, round
+   caps, sized to ride alongside text. */
+.ae-icon {
+  width: 1.2em;
+  height: 1.2em;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  vertical-align: -0.2em;
+}
+
+/* the mode toggle: an icon button; sun and moon rotate-crossfade.
+   Markup: button.ae-mode > svg.ae-icon.ae-sun + svg.ae-icon.ae-moon */
+.ae-mode {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2em;
+  height: 2.2em;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: var(--ae-ink-muted);
+  transition: color var(--ae-quick) var(--ae-ease);
+}
+
+/* the icons are absolutely stacked, so the button has no in-flow text;
+   this zero-width space gives it a real baseline so bars can
+   baseline-align it with neighboring links */
+.ae-mode::before {
+  content: '\200b';
+}
+
+.ae-mode:hover {
+  color: var(--ae-ink);
+}
+
+.ae-mode .ae-icon {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 1.25em;
+  height: 1.25em;
+  transition:
+    opacity var(--ae-soft) var(--ae-ease),
+    transform var(--ae-soft) var(--ae-ease);
+}
+
+.ae-mode .ae-sun {
+  opacity: 1;
+  transform: rotate(0) scale(1);
+}
+
+.ae-mode .ae-moon {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0.6);
+}
+
+.dark .ae-mode .ae-sun,
+[data-ae-mode='dark'] .ae-mode .ae-sun {
+  opacity: 0;
+  transform: rotate(90deg) scale(0.6);
+}
+
+.dark .ae-mode .ae-moon,
+[data-ae-mode='dark'] .ae-mode .ae-moon {
+  opacity: 1;
+  transform: rotate(0) scale(1);
+}
+
+/* a panel: soft depth for dense content (forms). Radius stays 0. */
+.ae-panel {
+  background: var(--ae-surface);
+  padding: var(--ae-space-6);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 8px 28px rgba(0, 0, 0, 0.06);
+}
+
+.dark .ae-panel,
+[data-ae-mode='dark'] .ae-panel {
+  background: var(--ae-wash);
+  box-shadow: none;
+}
+
+/* auto dark (no pinned mode): panel and mode icon follow the OS */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light):not([data-ae-mode='light']) .ae-panel {
+    background: var(--ae-wash);
+    box-shadow: none;
+  }
+
+  :root:not(.light):not([data-ae-mode='light']) .ae-mode .ae-sun {
+    opacity: 0;
+    transform: rotate(90deg) scale(0.6);
+  }
+
+  :root:not(.light):not([data-ae-mode='light']) .ae-mode .ae-moon {
+    opacity: 1;
+    transform: rotate(0) scale(1);
+  }
+
+  :root:not(.light):not([data-ae-mode='light']) dialog.ae-dialog {
+    background: var(--ae-wash);
+    box-shadow: none;
+  }
+
+  :root:not(.light):not([data-ae-mode='light']) dialog.ae-dialog::backdrop {
+    background: rgba(18, 18, 18, 0.4);
+  }
+
+  :root:not(.light):not([data-ae-mode='light']) .ae-pop,
+  :root:not(.light):not([data-ae-mode='light']) .ae-toast {
+    background: var(--ae-wash);
+    box-shadow: none;
+  }
+
+  :root:not(.light):not([data-ae-mode='light']) [data-ae-tip]::after {
+    background: var(--ae-wash);
+  }
+}
+
+/* the dialog: the panel costume in the top layer. A decision is asked
+   in a soft-depth panel over a whisper of paper dim; Escape and the
+   quiet button decline it. Pair with <dialog> + showModal(). */
+dialog.ae-dialog {
+  border: 0;
+  border-radius: var(--ae-radius);
+  background: var(--ae-surface);
+  color: var(--ae-ink);
+  width: min(26em, calc(100vw - 3em));
+  box-sizing: border-box;
+  padding: var(--ae-space-6);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.05),
+    0 12px 36px rgba(0, 0, 0, 0.09);
+}
+
+dialog.ae-dialog[open] {
+  animation: ae-enter var(--ae-soft) var(--ae-ease) both;
+}
+
+dialog.ae-dialog::backdrop {
+  background: rgba(252, 252, 252, 0.4);
+}
+
+.dark dialog.ae-dialog,
+[data-ae-mode='dark'] dialog.ae-dialog {
+  background: var(--ae-wash);
+  box-shadow: none;
+}
+
+.dark dialog.ae-dialog::backdrop,
+[data-ae-mode='dark'] dialog.ae-dialog::backdrop {
+  background: rgba(18, 18, 18, 0.4);
+}
+
+/* the dialog's title and action row */
+.ae-dialog-title {
+  font-weight: var(--ae-w-black);
+  margin-bottom: var(--ae-space-2);
+}
+
+.ae-dialog-acts {
+  display: flex;
+  gap: var(--ae-space-4);
+  justify-content: flex-end;
+  margin-top: 1.8em;
+}
+
+/* the popover: a slip of surface anchored to its invoker — hairline
+   frame, soft depth, no dim. Pair with the native popover attribute
+   (or popovertarget); the recipe places it by the anchor. */
+.ae-pop {
+  position: fixed;
+  inset: auto;
+  margin: 0;
+  border: 1px solid var(--ae-line);
+  background: var(--ae-surface);
+  color: var(--ae-ink);
+  width: max-content;
+  max-width: 22em;
+  padding: 1em 1.2em;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 8px 28px rgba(0, 0, 0, 0.06);
+}
+
+.ae-pop:popover-open {
+  animation: ae-enter var(--ae-quick) var(--ae-ease) both;
+}
+
+.ae-pop::backdrop {
+  background: transparent;
+}
+
+/* a popover holding only a menu drops the padding; the menu's own
+   inset carries it */
+.ae-pop > .ae-menu:only-child {
+  margin: -1em -1.2em;
+  border: 0;
+}
+
+.dark .ae-pop,
+[data-ae-mode='dark'] .ae-pop {
+  background: var(--ae-wash);
+  box-shadow: none;
+}
+
+/* the tip: a whisper that answers hover — chrome-register words in a
+   hairline slip. Patience built in: it waits a beat on hover, answers
+   focus at once. Set the words in data-ae-tip; keep them short. */
+[data-ae-tip] {
+  position: relative;
+}
+
+[data-ae-tip]::after {
+  content: attr(data-ae-tip);
+  position: absolute;
+  bottom: calc(100% + 0.6em);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ae-surface);
+  color: var(--ae-ink-muted);
+  border: 1px solid var(--ae-line);
+  font-family: var(--ae-font);
+  font-size: 13px;
+  font-weight: var(--ae-w-regular);
+  letter-spacing: normal;
+  line-height: 1.5;
+  padding: 0.25em 0.7em;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  z-index: var(--ae-z-tip);
+  transition: opacity var(--ae-quick) var(--ae-ease);
+}
+[data-ae-tip]:hover::after {
+  opacity: 1;
+  transition-delay: 450ms;
+}
+
+[data-ae-tip]:focus-visible::after {
+  opacity: 1;
+}
+
+.dark [data-ae-tip]::after,
+[data-ae-mode='dark'] [data-ae-tip]::after {
+  background: var(--ae-wash);
+}
+
+/* the toast: news arrives at the edge and waits to be read. The tray
+   stacks bottom-right; each toast is a slip with the status on its
+   glyph. It persists until dismissed or replaced — never an anxious
+   timer by default. Behavior glue: recipes (aeToast). */
+.ae-toasts {
+  position: fixed;
+  right: 1.4em;
+  bottom: 1.4em;
+  z-index: var(--ae-z-toast);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.6em;
+}
+
+.ae-toast {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6em;
+  background: var(--ae-surface);
+  border: 1px solid var(--ae-line);
+  color: var(--ae-ink);
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 0.7em 1.1em;
+  max-width: 26em;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 8px 28px rgba(0, 0, 0, 0.06);
+  animation: ae-enter var(--ae-soft) var(--ae-ease) both;
+}
+
+.ae-toast.is-leaving {
+  opacity: 0;
+  transition: opacity var(--ae-quick) var(--ae-ease);
+}
+
+.ae-toast-x {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin-left: 0.4em;
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  line-height: inherit;
+  color: var(--ae-ink-faint);
+  cursor: pointer;
+  transition: color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-toast-x:hover {
+  color: var(--ae-ink);
+}
+
+.dark .ae-toast,
+[data-ae-mode='dark'] .ae-toast {
+  background: var(--ae-wash);
+  box-shadow: none;
+}
+
+/* ── registers ────────────────────────────────────────────────────── */
+
+/* the name: heavy and spaced, never large */
+.ae-name {
+  font-weight: var(--ae-w-black);
+  letter-spacing: 0.38em;
+}
+
+a.ae-name {
+  text-decoration: none;
+}
+
+/* the lede: the page's whole argument, plainly */
+.ae-lede {
+  max-width: 34em;
+  text-wrap: pretty;
+}
+
+/* a group: whitespace is the only divider */
+.ae-group {
+  margin-bottom: 2.6em;
+}
+
+.ae-group:last-child {
+  margin-bottom: 0;
+}
+
+.ae-group p {
+  margin-bottom: 0.15em;
+}
+
+/* a group heading: muted, spaced, medium */
+.ae-h {
+  font-weight: var(--ae-w-medium);
+  color: var(--ae-ink-muted);
+  letter-spacing: 0.18em;
+  margin-bottom: 0.7em;
+}
+
+/* an item that matters: medium ink */
+.ae-item {
+  font-weight: var(--ae-w-medium);
+}
+
+/* supporting matter: muted ink */
+.ae-dim {
+  color: var(--ae-ink-muted);
+}
+
+/* the accent: yours to define and spend with judgment */
+.ae-accent {
+  color: var(--ae-accent);
+  font-weight: var(--ae-w-medium);
+  text-decoration: underline;
+  text-decoration-color: currentColor;
+  text-underline-offset: 0.2em;
+}
+
+/* status inks: put these on the glyph (svg.ae-icon), never the
+   sentence — the word stays ink, the icon carries the hue */
+.ae-ok {
+  color: var(--ae-ok);
+}
+
+.ae-warn {
+  color: var(--ae-warn);
+}
+
+.ae-err {
+  color: var(--ae-err);
+}
+
+/* the tag: a word in the plate-caption voice — mono, spaced, hairline
+   at most. This is the badge, refused: no fill, no pill; status comes
+   as a glyph beside the word, never as a colored box. */
+.ae-tag {
+  display: inline-block;
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.14em;
+  color: var(--ae-ink-muted);
+  border: 1px solid var(--ae-line);
+  padding: 0.1em 0.6em;
+  vertical-align: 0.1em;
+}
+
+.ae-tag-bare {
+  border: 0;
+  padding: 0;
+}
+
+/* the keycap: a quiet square of wash around the key's name */
+kbd {
+  background: var(--ae-wash);
+  border: 1px solid var(--ae-line);
+  padding: 0.08em 0.5em;
+}
+
+/* ── forms: a line, not a box ─────────────────────────────────────── */
+
+.ae-label {
+  display: block;
+  font-weight: var(--ae-w-medium);
+  margin-bottom: var(--ae-space-0);
+}
+
+.ae-input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  background: transparent;
+  color: var(--ae-ink);
+  cursor: text;
+  border: 0;
+  border-bottom: 1px solid var(--ae-line);
+  border-radius: var(--ae-radius);
+  padding: 0.4em 0 calc(0.4em - 1px);
+  transition: border-color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-input::placeholder {
+  color: var(--ae-ink-faint);
+}
+
+/* the focus ring: a 2px underline (not 1px) so the state reads at a
+   glance, never a glow. padding-bottom compensates the extra px so
+   the field doesn't shift height on focus. */
+.ae-input:focus-visible {
+  outline: none;
+  border-bottom-width: 2px;
+  border-bottom-color: var(--ae-ink);
+}
+
+textarea.ae-input {
+  resize: none;
+  min-height: 5.5em;
+}
+
+/* field validation: the line confesses, the glyph carries the hue,
+   the sentence stays ink. Set aria-invalid on the field; put the
+   message in a field note with a status icon. */
+.ae-input[aria-invalid='true'] {
+  border-bottom-color: var(--ae-err);
+}
+
+.ae-field-note {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45em;
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+  margin-top: 0.4em;
+}
+
+/* buttons are not links: contained shape, ink, never resizing.
+   Primary is solid ink by default; .ae-button-quiet is the hairline
+   secondary. Spend the accent on a button when the project's scheme calls
+   for it — where the accent goes is the consumer's judgment, not a rule. */
+.ae-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ae-space-2);
+  background: var(--ae-ink);
+  border: 1px solid var(--ae-ink);
+  border-radius: var(--ae-radius);
+  color: var(--ae-surface);
+  font-weight: var(--ae-w-medium);
+  padding: 0.55em 1.5em;
+  min-height: 44px;
+  cursor: pointer;
+  transition:
+    opacity var(--ae-quick) var(--ae-ease),
+    background-color var(--ae-quick) var(--ae-ease),
+    transform var(--ae-quick) var(--ae-ease);
+}
+
+.ae-button:hover {
+  opacity: 0.9;
+}
+
+.ae-button:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.ae-button:disabled {
+  cursor: default;
+  opacity: 0.7;
+  transform: none;
+}
+
+.ae-button-quiet {
+  background: transparent;
+  color: var(--ae-ink);
+}
+
+.ae-button-quiet:hover {
+  background: var(--ae-wash);
+  opacity: 1;
+}
+
+/* the compact scale: a button living in the 13px chrome register —
+   toolbars, table rows, rails. Same shapes, smaller breath. */
+.ae-button-compact {
+  font-size: 13px;
+  padding: 0.35em 1em;
+  min-height: 32px;
+}
+
+/* the send moment: the label gives way to the resolved state, gently,
+   once. Success persists — disable the button instead of resetting it.
+   Markup: <button class="ae-button ae-send">
+             <span class="ae-send-label">Send message</span>
+             <span class="ae-send-done" aria-hidden="true">Sent
+               <svg class="ae-icon">…check…</svg></span>
+           </button>
+   Add .is-sent to resolve. The status icon sits AFTER the word.
+   The button never changes size: the resting label defines the box and
+   the resolved layer is absolutely stacked over it. */
+.ae-send {
+  position: relative;
+  overflow: hidden;
+}
+
+.ae-send .ae-send-label,
+.ae-send .ae-send-done {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ae-space-2);
+  transition:
+    opacity var(--ae-gentle) var(--ae-ease),
+    transform var(--ae-gentle) var(--ae-ease);
+}
+
+.ae-send .ae-send-done {
+  position: absolute;
+  inset: 0;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(45%);
+}
+
+.ae-send.is-sent .ae-send-label {
+  opacity: 0;
+  transform: translateY(-55%);
+}
+
+.ae-send.is-sent .ae-send-done {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ae-send.is-sent,
+.ae-send.is-sent:disabled {
+  opacity: 1;
+}
+
+/* ── choice marks: squares, since radius is 0 everywhere ──────────── */
+
+/* a choice row: the mark and its words share a line and one cursor */
+.ae-choice {
+  display: flex;
+  align-items: center;
+  gap: 0.65em;
+  cursor: pointer;
+}
+
+.ae-choice + .ae-choice {
+  margin-top: 0.3em;
+}
+
+/* the checkbox: a pen-stroke square that fills with ink; the check is
+   drawn in surface. The radio is the same square holding an ink core —
+   a circle would be the only curve in the system, so there isn't one. */
+input.ae-check,
+input.ae-radio {
+  appearance: none;
+  width: 1em;
+  height: 1em;
+  flex: none;
+  margin: 0;
+  display: inline-grid;
+  place-content: center;
+  background: transparent;
+  border: 1px solid var(--ae-ink-muted);
+  border-radius: var(--ae-radius);
+  cursor: pointer;
+  vertical-align: -0.12em;
+  transition:
+    border-color var(--ae-quick) var(--ae-ease),
+    background-color var(--ae-quick) var(--ae-ease);
+}
+
+input.ae-check:hover,
+input.ae-radio:hover,
+.ae-choice:hover input.ae-check,
+.ae-choice:hover input.ae-radio {
+  border-color: var(--ae-ink);
+}
+
+input.ae-check::before {
+  content: '';
+  width: 0.55em;
+  height: 0.3em;
+  margin-top: -0.12em;
+  border-left: 2px solid var(--ae-surface);
+  border-bottom: 2px solid var(--ae-surface);
+  transform: rotate(-45deg);
+  opacity: 0;
+  transition: opacity var(--ae-quick) var(--ae-ease);
+}
+
+input.ae-check:checked {
+  background: var(--ae-ink);
+  border-color: var(--ae-ink);
+}
+
+input.ae-check:checked::before {
+  opacity: 1;
+}
+
+input.ae-radio::before {
+  content: '';
+  width: 0.42em;
+  height: 0.42em;
+  background: var(--ae-ink);
+  opacity: 0;
+  transition: opacity var(--ae-quick) var(--ae-ease);
+}
+
+input.ae-radio:checked {
+  border-color: var(--ae-ink);
+}
+
+input.ae-radio:checked::before {
+  opacity: 1;
+}
+
+input.ae-check:disabled,
+input.ae-radio:disabled,
+input.ae-switch:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+/* the switch: a hairline channel and an ink slide — state reads from
+   position and fill, never from a green pill. The slide is the
+   feedback; it resolves once per flip. */
+input.ae-switch {
+  appearance: none;
+  position: relative;
+  width: 2.1em;
+  height: 1.15em;
+  flex: none;
+  margin: 0;
+  background: transparent;
+  border: 1px solid var(--ae-ink-muted);
+  border-radius: var(--ae-radius);
+  cursor: pointer;
+  vertical-align: -0.18em;
+  transition: border-color var(--ae-quick) var(--ae-ease);
+}
+
+input.ae-switch::before {
+  content: '';
+  position: absolute;
+  top: 0.14em;
+  bottom: 0.14em;
+  left: 0.14em;
+  width: 0.68em;
+  background: var(--ae-ink-muted);
+  transition:
+    left var(--ae-quick) var(--ae-ease),
+    background-color var(--ae-quick) var(--ae-ease);
+}
+
+input.ae-switch:hover {
+  border-color: var(--ae-ink);
+}
+
+input.ae-switch:checked {
+  border-color: var(--ae-ink);
+}
+
+input.ae-switch:checked::before {
+  left: calc(100% - 0.82em);
+  background: var(--ae-ink);
+}
+
+/* ── data: the table is an instrument, framed as a plate ──────────── */
+
+/* the table: terminal density — 13px mono, lowercase headers on a
+   wash band, hairline row rules. A column header shares its column's
+   alignment: put .num on the th AND its tds. */
+.ae-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--ae-font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.ae-table th {
+  text-align: left;
+  font-weight: var(--ae-w-regular);
+  letter-spacing: 0.08em;
+  color: var(--ae-ink);
+  background: var(--ae-wash);
+  padding: 0.45em 1.4em 0.45em 0.7em;
+}
+
+.ae-table td {
+  border-top: 1px solid var(--ae-line);
+  padding: 0.42em 1.4em 0.42em 0.7em;
+}
+
+.ae-table tbody tr:first-child td {
+  border-top: 0;
+}
+
+.ae-table .num {
+  text-align: right;
+}
+
+.ae-table .ae-item {
+  font-weight: var(--ae-w-medium);
+}
+
+/* the plate: a numbered figure frame around a table or specimen —
+   mono caption above, hairline frame, footnote rule below */
+.ae-plate {
+  border: 1px solid var(--ae-line);
+  padding: 1.4em 1.6em 1.2em;
+}
+
+.ae-plate-cap {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--ae-ink-muted);
+  margin-bottom: var(--ae-space-4);
+}
+
+.ae-plate-note {
+  font-size: 13px;
+  color: var(--ae-ink-faint);
+  border-top: 1px solid var(--ae-line);
+  padding-top: 0.8em;
+  margin-top: 1.1em;
+}
+
+/* ── instruments: ink on a ruled line ─────────────────────────────── */
+
+/* the meter: a wash channel and an ink fill — a ruled line, never a
+   glowing pill. The fill takes a status ink only when the level IS
+   the signal (thresholds); ticks are hairline marks. Width changes
+   are state resolutions: gentle, once. */
+.ae-meter {
+  position: relative;
+  height: 4px;
+  background: var(--ae-wash);
+  border: 1px solid var(--ae-line);
+}
+
+.ae-meter-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--ae-ink);
+  transition: width var(--ae-gentle) var(--ae-ease);
+}
+
+.ae-meter-fill.ae-ok {
+  background: var(--ae-ok);
+}
+
+.ae-meter-fill.ae-warn {
+  background: var(--ae-warn);
+}
+
+.ae-meter-fill.ae-err {
+  background: var(--ae-err);
+}
+
+.ae-meter-mark {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 1px;
+  background: var(--ae-ink-muted);
+}
+
+/* figures: tabular numerals that tick without jitter. Compose with the
+   weights — a hero figure is 800 and isolated, never larger. */
+.ae-num {
+  font-family: var(--ae-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* the strong register: the one loud thing, by weight alone */
+.ae-strong {
+  font-weight: var(--ae-w-black);
+}
+
+/* a delta: the arrow carries the hue, the figure stays ink */
+.ae-delta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35em;
+}
+
+/* the spark: a pen-stroke trend — no axes, no area fill. Inline SVG:
+   <svg class="ae-spark" viewBox="0 0 100 24" preserveAspectRatio="none">
+     <polyline points="0,18 20,14 40,16 60,9 80,11 100,4" /></svg> */
+.ae-spark {
+  width: 7em;
+  height: 1.1em;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  vertical-align: -0.15em;
+}
+
+/* the interval: the meter with a spread. A ruled track carrying a
+   [lo,hi] range band and a mean tick, so a score reads as a level AND
+   its confidence — and where two bands share a column, the lead is
+   inside the spread (the certification read). Marks are positioned by
+   inline left/width %, exactly like the meter. Every mark is a
+   rectangle, so radius 0 holds (round marks are the scatter's pen). */
+.ae-ci {
+  position: relative;
+  height: 1.6em;
+}
+
+.ae-ci::before {
+  /* the shared baseline rule the interval sits on */
+  content: '';
+  position: absolute;
+  inset: 50% 0 auto;
+  height: 1px;
+  background: var(--ae-line);
+}
+
+/* the [lo,hi] range band: a bounded mass with a hairline edge — never a
+   filled status pill. It draws in once from the mean (the meter's
+   width-as-resolution), gentle and only on first render. */
+.ae-ci-band {
+  position: absolute;
+  top: 50%;
+  height: 10px;
+  transform: translateY(-50%);
+  transform-origin: center;
+  background: color-mix(in oklab, var(--ae-ink) 9%, var(--ae-surface));
+  border: 1px solid var(--ae-ink-faint);
+  animation: ae-ci-draw var(--ae-soft) var(--ae-ease) both;
+}
+
+@keyframes ae-ci-draw {
+  from {
+    transform: translateY(-50%) scaleX(0.04);
+  }
+}
+
+/* the mean: a single ink tick, like .ae-meter-mark. is-lead spends the
+   accent on it — one accent role per view, the consumer's to assign. */
+.ae-ci-mean {
+  position: absolute;
+  top: 50%;
+  width: 2px;
+  height: 1.15em;
+  transform: translate(-50%, -50%);
+  background: var(--ae-ink);
+}
+
+.ae-ci.is-lead .ae-ci-mean {
+  background: var(--ae-accent);
+}
+
+/* the no-fill variant: a thin lo→hi rule with square end caps, for a
+   field that should read as points rather than mass */
+.ae-ci-whisker {
+  position: absolute;
+  top: 50%;
+  height: 1px;
+  transform: translateY(-50%);
+  background: var(--ae-ink-muted);
+}
+
+.ae-ci-cap {
+  position: absolute;
+  top: 50%;
+  width: 1px;
+  height: 0.8em;
+  transform: translate(-50%, -50%);
+  background: var(--ae-ink-muted);
+}
+
+/* hover (or keyboard focus) reveals the exact figures at the track's
+   right edge — surface-backed so it rides over the baseline rule with
+   no layout shift. The mark carries the field; the numbers stay exact
+   on inspection. */
+.ae-ci-detail {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--ae-space-2);
+  padding: 0.1em 0.2em 0.1em 0.7em;
+  background: var(--ae-surface);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ae-ink);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--ae-quick) var(--ae-ease);
+}
+
+.ae-ci-detail .ae-ci-bound {
+  color: var(--ae-ink-faint);
+}
+
+.ae-ci:hover .ae-ci-detail,
+.ae-ci:focus-within .ae-ci-detail {
+  opacity: 1;
+}
+
+/* touch has no hover: show the exact figures by default there, so the
+   precise read is never pointer-only. Screen readers get them from the
+   element's aria-label (role="img"). */
+@media (hover: none) {
+  .ae-ci-detail {
+    opacity: 1;
+  }
+}
+
+/* the plane: an XY field — cost against quality — with a Pareto
+   frontier. Like .ae-spark, the kit dresses a consumer-authored <svg>
+   (the consumer owns the data and the projection); round dots are the
+   pen (SVG <circle>, never a CSS radius), the frame/axes/ticks stay
+   radius 0. Default composition = frontier: a dashed guide threads the
+   non-dominated points, the pick is the lone accent dot, the rest drop
+   to faint. */
+.ae-plot {
+  display: block;
+  width: 100%;
+  height: auto;
+  font-family: var(--ae-font-mono);
+}
+.ae-plot-axis {
+  fill: none;
+  stroke: var(--ae-line);
+  stroke-width: 1;
+}
+.ae-plot-tick {
+  stroke: var(--ae-line);
+  stroke-width: 1;
+}
+.ae-plot-ticklabel {
+  fill: var(--ae-ink-faint);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.ae-plot-axislabel {
+  fill: var(--ae-ink-muted);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+}
+.ae-plot-frontier {
+  fill: none;
+  stroke: var(--ae-ink);
+  stroke-width: 1.5;
+  stroke-dasharray: 5 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.ae-plot-crosshair {
+  stroke: var(--ae-ink-faint);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+}
+.ae-plot-dot {
+  fill: var(--ae-ink);
+  transition: fill var(--ae-soft) var(--ae-ease);
+}
+.ae-plot-dot.is-dominated {
+  fill: var(--ae-ink-faint);
+}
+.ae-plot-dot.is-chosen {
+  fill: var(--ae-accent);
+}
+.ae-plot-ring {
+  fill: none;
+  stroke: var(--ae-ink-muted);
+  stroke-width: 1.5;
+}
+.ae-plot-label {
+  fill: var(--ae-ink-muted);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+.ae-plot-label.is-dominated {
+  fill: var(--ae-ink-faint);
+}
+.ae-plot-label.is-chosen {
+  fill: var(--ae-accent);
+}
+
+/* a gate-failed datum is a colored mark where its dot would sit —
+   status rides the glyph; compose with .ae-ok / .ae-warn / .ae-err */
+.ae-plot-glyph {
+  fill: none;
+  stroke: var(--ae-ink);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+.ae-plot-glyph.ae-ok {
+  stroke: var(--ae-ok);
+}
+.ae-plot-glyph.ae-warn {
+  stroke: var(--ae-warn);
+}
+.ae-plot-glyph.ae-err {
+  stroke: var(--ae-err);
+}
+
+/* the flow: a pipeline as a diagram — hairline-framed nodes (hard
+   corners, radius 0) joined by orthogonal ink wires. Like the plot, the
+   kit dresses a consumer-authored <svg> so node and wire geometry share
+   one coordinate space; non-scaling strokes keep hairlines 1px at any
+   fit. State rides the frame and a glyph (✓ done, ✗ failed), the running
+   stage takes the accent, locked stages go dashed-faint. The default is
+   the spine: a row of stages, the gate/lineage backbone. */
+.ae-flow {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.ae-node {
+  fill: var(--ae-surface);
+  stroke: var(--ae-line);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+.ae-node.is-done {
+  stroke: var(--ae-ink-muted);
+}
+.ae-node.is-active {
+  stroke: var(--ae-accent);
+  stroke-width: 1.5;
+}
+.ae-node.is-locked {
+  fill: var(--ae-wash);
+  stroke: var(--ae-ink-faint);
+  stroke-dasharray: 3 3;
+}
+.ae-node.is-failed {
+  stroke: var(--ae-err);
+}
+
+/* the node label — the 13px instrument register, ink. State lives in the
+   frame and the glyph; only the running stage spends the accent. */
+.ae-node-label {
+  fill: var(--ae-ink);
+  font-family: var(--ae-font);
+  font-size: 13px;
+  font-weight: var(--ae-w-medium);
+}
+.ae-node-label.is-active {
+  fill: var(--ae-accent);
+  font-weight: var(--ae-w-black);
+}
+.ae-node-label.is-locked {
+  fill: var(--ae-ink-faint);
+  font-weight: var(--ae-w-regular);
+}
+
+/* a mono ordinal above the label, and mono in/out port labels at the
+   node's edges (a node's typed interface) */
+.ae-node-kicker {
+  fill: var(--ae-ink-faint);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+}
+.ae-node-port {
+  fill: var(--ae-ink-muted);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.ae-node-port.is-locked {
+  fill: var(--ae-ink-faint);
+}
+.ae-node-stub {
+  stroke: var(--ae-line);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+/* the wire: an orthogonal ink connector (H/V segments only), colored by
+   the stage it feeds. A round junction marks a split or merge — the one
+   round mark, like the spark's caps; the frames stay square. */
+.ae-wire {
+  fill: none;
+  stroke: var(--ae-line);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+.ae-wire.is-reached {
+  stroke: var(--ae-ink-muted);
+}
+.ae-wire.is-active {
+  stroke: var(--ae-accent);
+}
+.ae-wire.is-locked {
+  stroke: var(--ae-ink-faint);
+  stroke-dasharray: 3 3;
+}
+.ae-wire-junction {
+  fill: var(--ae-ink-muted);
+}
+.ae-wire-junction.is-active {
+  fill: var(--ae-accent);
+}
+
+/* ── choice controls: rows that open ──────────────────────────────── */
+
+/* a setting is a quiet hairline row — label left, current value right
+   in muted ink; activating it opens a chooser beneath. Progressive
+   disclosure: the form rests as a column of lines. */
+.ae-settings {
+  border-bottom: 1px solid var(--ae-line);
+}
+
+.ae-setting {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--ae-space-5);
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--ae-line);
+  border-radius: var(--ae-radius);
+  padding: 0.8em 0;
+  margin: 0;
+  font: inherit;
+  line-height: inherit;
+  color: var(--ae-ink);
+  font-weight: var(--ae-w-medium);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ae-setting-val {
+  color: var(--ae-ink-muted);
+  font-weight: var(--ae-w-regular);
+  transition: color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-setting:hover .ae-setting-val {
+  color: var(--ae-ink);
+}
+
+/* the chooser: folds open under its row — the smooth expand is
+   feedback to the activation, once per action */
+.ae-setting-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--ae-soft) var(--ae-ease);
+}
+
+.ae-setting-panel.is-open {
+  grid-template-rows: 1fr;
+}
+
+.ae-setting-panel > * {
+  overflow: hidden;
+  min-height: 0;
+
+  /* the child's border and padding outlive a 0fr row; stop painting
+     them once the fold completes */
+  visibility: hidden;
+  transition: visibility 0s var(--ae-soft);
+}
+
+.ae-setting-panel.is-open > * {
+  visibility: visible;
+  transition: visibility 0s;
+}
+
+/* the menu: a quiet option list (also the long-select answer) */
+.ae-menu {
+  margin: 0 0 0.9em;
+  padding: 0.3em 0;
+  border: 1px solid var(--ae-line);
+  background: var(--ae-surface);
+  max-height: 14em;
+  overflow-y: auto;
+}
+
+.ae-menu button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: var(--ae-radius);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--ae-ink-muted);
+  padding: 0.4em 1.1em;
+  cursor: pointer;
+  transition:
+    color var(--ae-quick) var(--ae-ease),
+    background-color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-menu button:hover {
+  background: var(--ae-wash);
+  color: var(--ae-ink);
+}
+
+.ae-menu button.is-sel {
+  color: var(--ae-ink);
+  font-weight: var(--ae-w-medium);
+}
+
+/* the fold: disclosure as a hairline row — native details in the
+   settings costume. The marker is a mono plus that turns into a
+   close; the quarter-turn is the feedback, once per action. */
+details.ae-fold {
+  border-top: 1px solid var(--ae-line);
+}
+
+details.ae-fold:last-of-type {
+  border-bottom: 1px solid var(--ae-line);
+}
+
+.ae-fold summary {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--ae-space-5);
+  padding: 0.8em 0;
+  font-weight: var(--ae-w-medium);
+  cursor: pointer;
+}
+
+.ae-fold summary::marker {
+  content: '';
+}
+
+.ae-fold summary::after {
+  content: '+';
+  font-family: var(--ae-font-mono);
+  font-weight: var(--ae-w-regular);
+  color: var(--ae-ink-muted);
+  transition: rotate var(--ae-soft) var(--ae-ease);
+}
+
+.ae-fold[open] summary::after {
+  rotate: 45deg;
+}
+
+.ae-fold > :not(summary) {
+  padding-bottom: var(--ae-space-4);
+}
+
+/* ── structure: paths, waiting, and absence ───────────────────────── */
+
+/* the breadcrumb: a chrome-register path — here is ink, the way back
+   is muted, the separators are faint */
+.ae-crumbs {
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+}
+
+.ae-crumbs ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6em;
+}
+
+.ae-crumbs li {
+  display: flex;
+  gap: 0.6em;
+}
+
+.ae-crumbs li + li::before {
+  content: '/';
+  color: var(--ae-ink-faint);
+}
+
+.ae-crumbs a {
+  color: var(--ae-ink-muted);
+  text-decoration: none;
+}
+
+.ae-crumbs a:hover {
+  color: var(--ae-ink);
+}
+
+.ae-crumbs [aria-current] {
+  color: var(--ae-ink);
+  font-weight: var(--ae-w-medium);
+}
+
+/* waiting: still wash, never a shimmer. The skeleton holds the layout
+   in quiet blocks; motion is feedback and waiting is not an action —
+   the view's entrance acknowledges arrival. Give the words to a
+   chrome-register status line (role="status"), not to an animation. */
+.ae-skeleton {
+  display: block;
+  background: var(--ae-wash);
+  color: transparent;
+  pointer-events: none;
+  user-select: none;
+}
+
+.ae-skeleton * {
+  visibility: hidden;
+}
+
+/* absence: an honest sentence where the content will be — muted words,
+   one quiet action, no illustration party */
+.ae-empty {
+  padding: 2.4em 0;
+  border-block: 1px solid var(--ae-line);
+}
+
+.ae-empty > p {
+  margin-bottom: 0.15em;
+}
+
+.ae-empty .ae-button {
+  margin-top: 1.2em;
+}
+
+/* opt-in via data-ae-anticipate on the form; the recipe drives
+   --ae-intent (0–0.6) on the nearest field's label and input.
+   Color only — nothing moves; focus snaps to the committed state;
+   off for touch, keyboards, and reduced motion. */
+[data-ae-anticipate] .ae-label {
+  color: color-mix(
+    in srgb,
+    var(--ae-ink) calc(var(--ae-intent, 0) * 100%),
+    var(--ae-ink-muted)
+  );
+  transition: color 120ms ease-out;
+}
+
+[data-ae-anticipate] .ae-input {
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--ae-ink) calc(var(--ae-intent, 0) * 100%),
+    var(--ae-line)
+  );
+  transition: border-color 120ms ease-out;
+}
+
+[data-ae-anticipate] .ae-label:has(+ .ae-input:focus-visible) {
+  color: var(--ae-ink);
+}
+
+[data-ae-anticipate] .ae-input:focus-visible {
+  border-bottom-color: var(--ae-ink);
+}
+
+/* ── the mode change: one soft breath ─────────────────────────────── */
+
+/* the recipe wraps the flip in document.startViewTransition and sets
+   .ae-vt-mode on the root for the duration (700ms, the house ease) */
+.ae-vt-mode::view-transition-old(root),
+.ae-vt-mode::view-transition-new(root) {
+  animation-duration: 700ms;
+  animation-timing-function: var(--ae-ease);
+}
+
+/* fallback where view transitions are unsupported: every surface
+   eases its colors together for one gentle beat */
+.ae-mode-easing,
+.ae-mode-easing *,
+.ae-mode-easing *::before,
+.ae-mode-easing *::after {
+  transition:
+    background-color var(--ae-gentle) var(--ae-ease),
+    color var(--ae-gentle) var(--ae-ease),
+    border-color var(--ae-gentle) var(--ae-ease),
+    fill var(--ae-gentle) var(--ae-ease),
+    stroke var(--ae-gentle) var(--ae-ease) !important;
+}
+
+/* ── the app shell: a chrome rail beside the working desk ─────────── */
+
+/* the second archetype. One viewport, hairline-divided: a 13px rail
+   for places, a desk for work. The screen law holds — the desk
+   scrolls inside itself, the page never moves. */
+.ae-shell {
+  height: 100dvh;
+  display: grid;
+  grid-template-columns: 14rem minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.ae-rail {
+  border-right: 1px solid var(--ae-line);
+  padding: 1.6em 1.4em;
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.ae-rail .ae-h {
+  margin-top: 1.8em;
+}
+
+.ae-rail .ae-h:first-child {
+  margin-top: 0;
+}
+
+.ae-rail a,
+.ae-rail button:not(.ae-mode) {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
+  text-decoration: none;
+  color: var(--ae-ink-muted);
+  padding: 0.3em 0;
+  margin-block: 0;
+  cursor: pointer;
+  transition: color var(--ae-quick) var(--ae-ease);
+}
+
+.ae-rail a:hover,
+.ae-rail button:hover {
+  color: var(--ae-ink);
+}
+
+.ae-rail [aria-current],
+.ae-rail .is-active {
+  color: var(--ae-ink);
+  font-weight: var(--ae-w-medium);
+}
+
+/* the rail's foot pins to the bottom: version, account, the mode */
+.ae-rail-foot {
+  margin-top: auto;
+  padding-top: 1.6em;
+}
+
+.ae-desk {
+  min-width: 0;
+  overflow-y: auto;
+  padding: 2.2em 2.8em;
+}
+
+/* ── the document: long-form prose, unclassed inside ──────────────── */
+
+/* the third archetype: rendered markdown drops in bare. Headings are
+   weight, never size; rules are hairlines; quotes are inset. Put the
+   article in a scrolling stage (.ae-stage-scroll) or a desk. */
+.ae-doc h1,
+.ae-doc h2 {
+  font-weight: var(--ae-w-black);
+  margin: 2.2em 0 0.6em;
+}
+
+.ae-doc h3,
+.ae-doc h4 {
+  font-weight: var(--ae-w-medium);
+  margin: 1.8em 0 0.4em;
+}
+
+.ae-doc h5,
+.ae-doc h6 {
+  font-weight: var(--ae-w-medium);
+  color: var(--ae-ink-muted);
+  margin: 1.8em 0 0.4em;
+}
+
+.ae-doc h1:first-child,
+.ae-doc h2:first-child,
+.ae-doc h3:first-child {
+  margin-top: 0;
+}
+
+.ae-doc p,
+.ae-doc ul,
+.ae-doc ol {
+  margin-bottom: 0.9em;
+}
+
+.ae-doc ul,
+.ae-doc ol {
+  padding-left: 1.4em;
+}
+
+.ae-doc li {
+  margin-bottom: 0.2em;
+}
+
+.ae-doc hr {
+  border: 0;
+  border-top: 1px solid var(--ae-line);
+  margin: 2.4em 0;
+}
+
+.ae-doc blockquote {
+  border-left: 1px solid var(--ae-line);
+  padding-left: 1.4em;
+  color: var(--ae-ink-muted);
+  margin: 1.2em 0;
+}
+
+.ae-doc pre {
+  background: var(--ae-wash);
+  font-size: 13px;
+  line-height: 1.75;
+  padding: 1.2em 1.4em;
+  margin: 1.2em 0;
+  overflow-x: auto;
+}
+
+.ae-doc :not(pre) > code {
+  background: var(--ae-wash);
+  padding: 0.1em 0.35em;
+}
+
+.ae-doc img {
+  max-width: 100%;
+}
+
+/* ── report sub-registers: opt-in, for a generated document that is read
+   and shared. Weight + space + hairlines + the 11px mono caption
+   register only — never a new type size, never a serif. The plain
+   .ae-doc above stays the default. ──────────────────────────────────── */
+
+/* numbered figures: a <figure> in a doc auto-numbers and its <figcaption>
+   drops to the mono caption register, prefixed FIG n. Pairs with
+   .ae-plate for the figure body. */
+.ae-doc {
+  counter-reset: ae-fig;
+}
+
+.ae-doc figure {
+  counter-increment: ae-fig;
+  margin: 1.8em 0;
+}
+
+.ae-doc figcaption {
+  margin-bottom: 0.7em;
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--ae-ink-muted);
+}
+
+.ae-doc figcaption::before {
+  content: 'FIG ' counter(ae-fig) ' · ';
+  color: var(--ae-ink);
+  font-weight: var(--ae-w-medium);
+}
+
+/* the lede / standfirst: the opening paragraph lifts to medium weight
+   with a hairline rule beneath — a way in, the conclusion up front. */
+.ae-doc .ae-lede {
+  margin-bottom: 1.6em;
+  padding-bottom: 1.4em;
+  border-bottom: 1px solid var(--ae-line);
+  font-weight: var(--ae-w-medium);
+}
+
+/* the findings box: a hairline frame (never a filled card) summarizing
+   the conclusion. The called-out result is weight; the recommendation
+   takes the one accent rule the report spends. */
+.ae-findings {
+  margin: 1.8em 0;
+  padding: 1.4em 1.6em 1.3em;
+  border: 1px solid var(--ae-line);
+}
+
+.ae-findings-title {
+  margin-bottom: var(--ae-space-4);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--ae-ink-muted);
+}
+
+.ae-rec {
+  margin-top: 1.1em;
+  padding-left: 1.1em;
+  border-left: 2px solid var(--ae-accent);
+}
+
+/* the pull-quote: a sentence lifted forward by weight + space + a
+   hairline rule. Never a larger size, never an italic serif — the
+   closest call to the one-size law, held on the right side of it. */
+.ae-pull {
+  margin: 1.8em 0;
+  padding-left: 1.4em;
+  border-left: 1px solid var(--ae-line);
+  font-weight: var(--ae-w-medium);
+  line-height: 1.7;
+}
+
+.ae-pull-by {
+  display: block;
+  margin-top: 0.6em;
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  font-weight: var(--ae-w-regular);
+  letter-spacing: 0.14em;
+  color: var(--ae-ink-faint);
+}
+
+/* ── utilities ────────────────────────────────────────────────────── */
+
+/* present to assistive tech, invisible on paper — live regions and
+   labels the layout has no room to speak */
+.ae-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* ── small screens ────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .ae-bar,
+  .ae-stage {
+    width: calc(100% - 2.4rem);
+  }
+
+  .ae-group {
+    margin-bottom: var(--ae-space-6);
+  }
+
+  /* the shell folds to one column; compose a bar for the places the
+     rail held — the rail itself steps aside */
+  .ae-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .ae-rail {
+    display: none;
+  }
+
+  .ae-desk {
+    padding: 1.6em 1.2rem;
+  }
+}
+
+/* ── reduced motion: everything is instant ────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/crates/canary-server/static/dashboard/app.js
+++ b/crates/canary-server/static/dashboard/app.js
@@ -1,0 +1,887 @@
+(() => {
+  const KEY_STORAGE = "canary.dashboard.sessionKey";
+  const MODE_STORAGE = "canary.dashboard.mode";
+  const VIEWS = ["health", "incidents", "checks", "errors"];
+
+  const state = {
+    view: "health",
+    key: sessionStorage.getItem(KEY_STORAGE) || "",
+    mode: sessionStorage.getItem(MODE_STORAGE) || "",
+    loading: false,
+    error: "",
+    lastRefresh: null,
+    selectedIncidentId: "",
+    selectedTargetId: "",
+    data: {
+      status: null,
+      health: null,
+      incidents: null,
+      timeline: null,
+      errors: null,
+      targets: null,
+      monitors: null,
+      incidentDetail: null,
+      targetChecks: null,
+    },
+    optional: {
+      errorsProblem: "",
+      timelineProblem: "",
+      adminProblem: "",
+    },
+  };
+
+  const root = document.getElementById("view-root");
+  const keyInput = document.getElementById("api-key");
+  const connection = document.getElementById("connection-status");
+  const lastRefresh = document.getElementById("last-refresh");
+
+  function init() {
+    keyInput.value = state.key;
+    setMode(state.mode || preferredMode());
+    bindEvents();
+    syncViewFromHash();
+    render();
+    if (state.key) {
+      refresh();
+    }
+  }
+
+  function bindEvents() {
+    document.getElementById("session-form").addEventListener("submit", (event) => {
+      event.preventDefault();
+      state.key = keyInput.value.trim();
+      if (state.key) {
+        sessionStorage.setItem(KEY_STORAGE, state.key);
+      }
+      refresh();
+    });
+
+    document.getElementById("clear-key").addEventListener("click", () => {
+      state.key = "";
+      keyInput.value = "";
+      sessionStorage.removeItem(KEY_STORAGE);
+      state.data = {
+        status: null,
+        health: null,
+        incidents: null,
+        timeline: null,
+        errors: null,
+        targets: null,
+        monitors: null,
+        incidentDetail: null,
+        targetChecks: null,
+      };
+      state.error = "";
+      render();
+    });
+
+    document.getElementById("refresh").addEventListener("click", () => refresh());
+    document.getElementById("mode-toggle").addEventListener("click", () => {
+      setMode(document.documentElement.dataset.aeMode === "dark" ? "light" : "dark");
+    });
+
+    document.addEventListener("click", (event) => {
+      const viewButton = event.target.closest("[data-view]");
+      if (viewButton) {
+        event.preventDefault();
+        setView(viewButton.dataset.view);
+        return;
+      }
+
+      const incidentButton = event.target.closest("[data-incident-id]");
+      if (incidentButton) {
+        event.preventDefault();
+        state.selectedIncidentId = incidentButton.dataset.incidentId;
+        loadIncidentDetail().then(render).catch(showError);
+        return;
+      }
+
+      const targetButton = event.target.closest("[data-target-id]");
+      if (targetButton) {
+        event.preventDefault();
+        state.selectedTargetId = targetButton.dataset.targetId;
+        loadTargetChecks().then(render).catch(showError);
+      }
+    });
+
+    window.addEventListener("hashchange", () => {
+      syncViewFromHash();
+      render();
+    });
+  }
+
+  function preferredMode() {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  function setMode(mode) {
+    state.mode = mode === "dark" ? "dark" : "light";
+    document.documentElement.dataset.aeMode = state.mode;
+    sessionStorage.setItem(MODE_STORAGE, state.mode);
+  }
+
+  function syncViewFromHash() {
+    const next = window.location.hash.replace("#", "");
+    if (VIEWS.includes(next)) {
+      state.view = next;
+    }
+  }
+
+  function setView(view) {
+    if (!VIEWS.includes(view)) {
+      return;
+    }
+    state.view = view;
+    window.location.hash = view;
+    if (view === "incidents" && state.key && !state.data.incidentDetail) {
+      loadIncidentDetail().then(render).catch(showError);
+    }
+  }
+
+  async function refresh() {
+    if (!state.key) {
+      state.error = "Paste a bearer key to read Canary.";
+      render();
+      return;
+    }
+
+    state.loading = true;
+    state.error = "";
+    render();
+
+    try {
+      const [status, health, incidents] = await Promise.all([
+        api("/api/v1/status?window=24h"),
+        api("/api/v1/health-status"),
+        api("/api/v1/incidents"),
+      ]);
+
+      const [timeline, errors, targets, monitors] = await Promise.all([
+        optionalApi("/api/v1/timeline?window=7d&limit=100&event_type=incident.opened,incident.updated,incident.resolved"),
+        optionalApi("/api/v1/query?group_by=error_class&window=24h"),
+        optionalApi("/api/v1/targets"),
+        optionalApi("/api/v1/monitors"),
+      ]);
+
+      state.data.status = status;
+      state.data.health = health;
+      state.data.incidents = incidents;
+      state.data.timeline = timeline.value;
+      state.data.errors = errors.value;
+      state.data.targets = targets.value;
+      state.data.monitors = monitors.value;
+      state.optional.timelineProblem = timeline.problem;
+      state.optional.errorsProblem = errors.problem;
+      state.optional.adminProblem = [targets.problem, monitors.problem].filter(Boolean).join(" ");
+
+      const incidentIds = incidentChoices().map((incident) => incident.id);
+      if (!state.selectedIncidentId || !incidentIds.includes(state.selectedIncidentId)) {
+        state.selectedIncidentId = incidentIds[0] || "";
+      }
+      await loadIncidentDetail();
+
+      const targetsList = healthTargets();
+      if (!state.selectedTargetId || !targetsList.some((target) => target.id === state.selectedTargetId)) {
+        state.selectedTargetId = targetsList[0]?.id || "";
+      }
+      await loadTargetChecks();
+
+      state.lastRefresh = new Date();
+    } catch (error) {
+      state.error = error.message;
+    } finally {
+      state.loading = false;
+      render();
+    }
+  }
+
+  async function loadIncidentDetail() {
+    state.data.incidentDetail = null;
+    if (!state.key || !state.selectedIncidentId) {
+      return;
+    }
+    state.data.incidentDetail = await optionalApi(`/api/v1/incidents/${encodeURIComponent(state.selectedIncidentId)}`)
+      .then((result) => result.value || { problem: result.problem });
+  }
+
+  async function loadTargetChecks() {
+    state.data.targetChecks = null;
+    if (!state.key || !state.selectedTargetId) {
+      return;
+    }
+    state.data.targetChecks = await optionalApi(`/api/v1/targets/${encodeURIComponent(state.selectedTargetId)}/checks?window=24h`)
+      .then((result) => result.value || { problem: result.problem });
+  }
+
+  async function api(path) {
+    const response = await fetch(path, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${state.key}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(await problemMessage(response));
+    }
+    return response.json();
+  }
+
+  async function optionalApi(path) {
+    try {
+      return { value: await api(path), problem: "" };
+    } catch (error) {
+      return { value: null, problem: error.message };
+    }
+  }
+
+  async function problemMessage(response) {
+    const fallback = `${response.status} ${response.statusText}`;
+    try {
+      const body = await response.json();
+      return body.detail || body.title || body.code || fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function render() {
+    updateChrome();
+    updateNav();
+
+    if (!state.key) {
+      root.innerHTML = lockedView();
+      return;
+    }
+    if (state.loading && !state.data.status) {
+      root.innerHTML = loadingView();
+      return;
+    }
+    if (state.error) {
+      root.innerHTML = problemView(state.error);
+      return;
+    }
+
+    if (state.view === "incidents") {
+      root.innerHTML = renderIncidents();
+    } else if (state.view === "checks") {
+      root.innerHTML = renderChecks();
+    } else if (state.view === "errors") {
+      root.innerHTML = renderErrors();
+    } else {
+      root.innerHTML = renderHealth();
+    }
+  }
+
+  function updateChrome() {
+    connection.textContent = state.key ? "Session key loaded" : "No session key";
+    lastRefresh.textContent = state.lastRefresh
+      ? `Refreshed ${formatTime(state.lastRefresh.toISOString())}`
+      : "Not refreshed";
+  }
+
+  function updateNav() {
+    document.querySelectorAll("[data-view]").forEach((button) => {
+      const active = button.dataset.view === state.view;
+      button.toggleAttribute("aria-current", active);
+      button.classList.toggle("is-active", active);
+    });
+  }
+
+  function lockedView() {
+    return `
+      <section class="view">
+        <div class="view-head">
+          <div>
+            <h1 class="view-title">Canary dashboard</h1>
+            <p class="summary">Paste a scoped API key to read this instance.</p>
+          </div>
+        </div>
+        <div class="panel">
+          <p class="empty">The shell is public. Canary data is not read until the browser sends your session key to the existing API routes.</p>
+        </div>
+      </section>
+    `;
+  }
+
+  function loadingView() {
+    return `
+      <section class="view">
+        <h1 class="view-title">Reading Canary</h1>
+        <p class="summary">Loading current state.</p>
+      </section>
+    `;
+  }
+
+  function problemView(message) {
+    return `
+      <section class="view">
+        <h1 class="view-title">Canary rejected the read</h1>
+        <div class="problem">${escapeHtml(message)}</div>
+      </section>
+    `;
+  }
+
+  function renderHealth() {
+    const rows = serviceRows();
+    const status = state.data.status || {};
+    const counts = countServiceStates(rows);
+    return `
+      <section class="view">
+        <div class="view-head">
+          <div>
+            <h1 class="view-title">Production health</h1>
+            <p class="summary">${escapeHtml(status.summary || "No status summary returned.")}</p>
+          </div>
+          <dl class="metric-strip">
+            ${metric("Services", rows.length)}
+            ${metric("Up", counts.up)}
+            ${metric("Degraded", counts.degraded)}
+            ${metric("Down", counts.down)}
+          </dl>
+        </div>
+        <div class="wall">
+          ${rows.length ? rows.map(renderServiceRow).join("") : empty("No services configured.")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderServiceRow(row) {
+    return `
+      <article class="service-row status-${row.state}">
+        <div>
+          <div class="row-main">
+            <span class="status-mark">${statusGlyph(row.state)}</span>
+            <span class="strong">${escapeHtml(row.service)}</span>
+            <span class="tag">${escapeHtml(row.state)}</span>
+          </div>
+          <div class="meta">${escapeHtml(row.surfaceSummary)}</div>
+        </div>
+        <div>
+          <div>${escapeHtml(row.uptime)}</div>
+          <div class="meta">last ${escapeHtml(formatTime(row.lastProbe))}</div>
+          <div class="mini-sequence">${escapeHtml(row.sequence)}</div>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderIncidents() {
+    const incidents = incidentChoices();
+    const detail = state.data.incidentDetail;
+    return `
+      <section class="view">
+        <div class="view-head">
+          <div>
+            <h1 class="view-title">Incidents</h1>
+            <p class="summary">${escapeHtml(state.data.incidents?.summary || "No incident summary returned.")}</p>
+          </div>
+          <dl class="metric-strip">
+            ${metric("Open", state.data.incidents?.incidents?.length || 0)}
+            ${metric("History", incidentHistory().length)}
+            ${metric("Selected", state.selectedIncidentId || "none")}
+          </dl>
+        </div>
+        <div class="incident-layout">
+          <aside class="panel">
+            <div class="eyebrow">Open and recent</div>
+            ${incidents.length ? incidents.map(renderIncidentChoice).join("") : empty("No incidents in the returned window.")}
+          </aside>
+          <div class="panel">
+            ${renderIncidentDetail(detail)}
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderIncidentChoice(incident) {
+    const selected = incident.id === state.selectedIncidentId;
+    return `
+      <button class="select-row ${selected ? "is-selected" : ""}" type="button" data-incident-id="${escapeHtml(incident.id)}">
+        <span class="row-main">
+          <span class="status-mark ${incident.severity === "high" ? "err" : "warn"}">${incident.severity === "high" ? "x" : "!"}</span>
+          <span class="strong">${escapeHtml(incident.title || incident.service || incident.id)}</span>
+        </span>
+        <span class="meta">${escapeHtml(incident.id)} · ${escapeHtml(incident.state || "event")} · ${escapeHtml(formatTime(incident.opened_at || incident.created_at))}</span>
+      </button>
+    `;
+  }
+
+  function renderIncidentDetail(detail) {
+    if (!state.selectedIncidentId) {
+      return empty("Select an incident.");
+    }
+    if (!detail) {
+      return empty("Loading incident detail.");
+    }
+    if (detail.problem) {
+      return `<div class="problem">${escapeHtml(detail.problem)}</div>`;
+    }
+    const incident = detail.incident || {};
+    const claim = detail.action_brief?.current_claim || detail.claims?.find((item) => isActiveClaim(item.state));
+    return `
+      <div>
+        <div class="view-head">
+          <div>
+            <h2 class="view-title">${escapeHtml(incident.title || `${incident.service || "service"} incident`)}</h2>
+            <p class="summary">${escapeHtml(detail.summary || "")}</p>
+          </div>
+          <div class="meta">${escapeHtml(incident.id || "")}</div>
+        </div>
+        <dl class="detail-grid">
+          ${metric("State", incident.state || "unknown")}
+          ${metric("Severity", incident.severity || "unknown")}
+          ${metric("Opened", formatTime(incident.opened_at))}
+          ${metric("Resolution", incident.resolved_at ? formatTime(incident.resolved_at) : "open")}
+        </dl>
+        <div class="detail-columns">
+          <section>
+            <div class="eyebrow">Timeline</div>
+            ${detail.recent_timeline_events?.length ? detail.recent_timeline_events.map(renderTimelineEvent).join("") : empty("No recent timeline events.")}
+          </section>
+          <section>
+            <div class="eyebrow">Probe evidence</div>
+            ${detail.signals?.length ? detail.signals.map(renderSignal).join("") : empty("No bounded signals returned.")}
+          </section>
+          <section>
+            <div class="eyebrow">Agent activity</div>
+            ${renderClaim(claim)}
+            ${detail.annotations?.length ? detail.annotations.map(renderActivity).join("") : empty("No writeback annotations yet.")}
+          </section>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderTimelineEvent(event) {
+    return `
+      <div class="timeline-row">
+        <div class="time">${escapeHtml(formatTime(event.created_at))}</div>
+        <div>
+          <div class="event-name">${escapeHtml(event.event)}</div>
+          <div class="meta">${escapeHtml(event.summary || "")}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderSignal(signal) {
+    const title = signal.summary || signal.error_class || signal.target_name || signal.monitor_name || signal.signal_ref || signal.type;
+    const lines = [
+      ["type", signal.type],
+      ["state", signal.current_state],
+      ["count", signal.total_count],
+      ["target", signal.target_id],
+      ["monitor", signal.monitor_id],
+      ["group", signal.group_hash],
+      ["annotations", signal.annotation_count],
+    ].filter(([_key, value]) => value !== undefined && value !== null && value !== "");
+    return `
+      <div class="signal-row">
+        <div class="strong">${escapeHtml(title || "signal")}</div>
+        <div class="metadata">${escapeHtml(lines.map(([key, value]) => `${key}: ${value}`).join("\n"))}</div>
+      </div>
+    `;
+  }
+
+  function renderClaim(claim) {
+    if (!claim) {
+      return "";
+    }
+    const lines = [
+      ["claim", claim.id],
+      ["owner", claim.owner],
+      ["state", claim.state],
+      ["purpose", claim.purpose],
+      ["updated", formatTime(claim.updated_at)],
+    ];
+    return `
+      <div class="activity-row">
+        <div class="time">claim</div>
+        <div>
+          <div class="strong">${escapeHtml(claim.owner || "agent")}</div>
+          <div class="metadata">${escapeHtml(lines.map(([key, value]) => `${key}: ${value || "n/a"}`).join("\n"))}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderActivity(annotation) {
+    return `
+      <div class="activity-row">
+        <div class="time">${escapeHtml(formatTime(annotation.created_at))}</div>
+        <div>
+          <div class="strong">${escapeHtml(annotation.agent || "agent")}</div>
+          <div>${escapeHtml(annotation.action || "annotated")}</div>
+          ${annotation.metadata ? `<div class="metadata">${escapeHtml(JSON.stringify(annotation.metadata, null, 2))}</div>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderChecks() {
+    const targets = healthTargets();
+    const monitors = healthMonitors();
+    return `
+      <section class="view">
+        <div class="view-head">
+          <div>
+            <h1 class="view-title">Checks and monitors</h1>
+            <p class="summary">Current watched surfaces from Canary health-status.</p>
+          </div>
+          <dl class="metric-strip">
+            ${metric("Targets", targets.length)}
+            ${metric("Monitors", monitors.length)}
+            ${metric("Cadence", state.data.targets || state.data.monitors ? "exact" : "scoped")}
+          </dl>
+        </div>
+        <div class="checks-layout">
+          <section class="panel">
+            <div class="row-grid table-head">
+              <span>Surface</span><span>State</span><span>Cadence</span><span>Last result</span>
+            </div>
+            ${targets.map(renderTargetRow).join("")}
+            ${monitors.map(renderMonitorRow).join("")}
+            ${!targets.length && !monitors.length ? empty("No watched surfaces returned.") : ""}
+          </section>
+          <section class="panel">
+            <div class="eyebrow">Recent target checks</div>
+            ${renderTargetChecks()}
+          </section>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderTargetRow(target) {
+    const config = targetConfig(target.id);
+    return `
+      <button class="select-row" type="button" data-target-id="${escapeHtml(target.id)}">
+        <span class="row-grid">
+          <span><span class="strong">${escapeHtml(target.name)}</span><br><span class="meta">${escapeHtml(target.service)} · ${escapeHtml(target.url)}</span></span>
+          <span class="status-${surfaceState(target.state)}"><span class="status-mark">${statusGlyph(surfaceState(target.state))}</span> ${escapeHtml(target.state)}</span>
+          <span>${escapeHtml(config?.interval_ms ? duration(config.interval_ms) : inferredCadence(target.recent_checks))}</span>
+          <span>${escapeHtml(lastTargetResult(target))}</span>
+        </span>
+      </button>
+    `;
+  }
+
+  function renderMonitorRow(monitor) {
+    const config = monitorConfig(monitor.id);
+    return `
+      <div class="data-row row-grid">
+        <span><span class="strong">${escapeHtml(monitor.name)}</span><br><span class="meta">${escapeHtml(monitor.service)} · ${escapeHtml(monitor.mode)}</span></span>
+        <span class="status-${surfaceState(monitor.state)}"><span class="status-mark">${statusGlyph(surfaceState(monitor.state))}</span> ${escapeHtml(monitor.state)}</span>
+        <span>${escapeHtml(duration(config?.expected_every_ms || monitor.expected_every_ms))}</span>
+        <span>${escapeHtml(monitor.last_check_in_status || "none")}<br><span class="meta">${escapeHtml(formatTime(monitor.last_check_in_at || monitor.deadline_at))}</span></span>
+      </div>
+    `;
+  }
+
+  function renderTargetChecks() {
+    const checks = state.data.targetChecks?.checks || [];
+    if (state.data.targetChecks?.problem) {
+      return `<div class="problem">${escapeHtml(state.data.targetChecks.problem)}</div>`;
+    }
+    if (!checks.length) {
+      return empty("No recent target checks returned.");
+    }
+    return checks.map((check) => `
+      <div class="data-row">
+        <div class="row-main">
+          <span class="status-mark ${check.result === "success" ? "ok" : "err"}">${check.result === "success" ? "ok" : "x"}</span>
+          <span class="strong">${escapeHtml(check.result || "check")}</span>
+          <span class="meta">${escapeHtml(formatTime(check.checked_at))}</span>
+        </div>
+        <div class="meta">${escapeHtml(check.status_code || "no status")} · ${escapeHtml(check.latency_ms ? `${check.latency_ms}ms` : "no latency")}</div>
+      </div>
+    `).join("");
+  }
+
+  function renderErrors() {
+    const errors = state.data.errors;
+    const serviceErrors = state.data.status?.error_summary || [];
+    return `
+      <section class="view">
+        <div class="view-head">
+          <div>
+            <h1 class="view-title">Grouped errors</h1>
+            <p class="summary">${escapeHtml(errors?.summary || state.optional.errorsProblem || "No grouped error response returned.")}</p>
+          </div>
+          <dl class="metric-strip">
+            ${metric("Errors", errors?.total_errors ?? errorTotal(serviceErrors))}
+            ${metric("Classes", errors?.total_error_classes ?? "scoped")}
+            ${metric("Services", serviceErrors.length)}
+          </dl>
+        </div>
+        <div class="errors-layout">
+          <section class="panel">
+            <div class="row-grid table-head">
+              <span>Error class</span><span>Count</span><span>Services</span><span>Window</span>
+            </div>
+            ${errors?.groups?.length ? errors.groups.map((group) => `
+              <div class="data-row row-grid">
+                <span class="strong">${escapeHtml(group.error_class)}</span>
+                <span>${escapeHtml(group.total_count)}</span>
+                <span>${escapeHtml(group.service_count)}</span>
+                <span>${escapeHtml(errors.window || "24h")}</span>
+              </div>
+            `).join("") : empty("No error-class groups returned for this key.")}
+          </section>
+          <section class="panel">
+            <div class="eyebrow">Services with active errors</div>
+            ${serviceErrors.length ? serviceErrors.map((item) => `
+              <div class="data-row">
+                <div class="strong">${escapeHtml(item.service)}</div>
+                <div class="meta">${escapeHtml(item.total_count)} errors across ${escapeHtml(item.unique_classes)} classes</div>
+              </div>
+            `).join("") : empty("No active service errors in the status window.")}
+          </section>
+        </div>
+      </section>
+    `;
+  }
+
+  function serviceRows() {
+    const services = new Map();
+    for (const target of healthTargets()) {
+      const row = ensureService(services, target.service || target.name);
+      row.targets.push(target);
+      row.lastProbe = latest(row.lastProbe, target.last_checked_at);
+      row.states.push(surfaceState(target.state));
+      row.sequences.push(sequence(target.recent_checks));
+      row.checks.push(...(target.recent_checks || []));
+    }
+    for (const monitor of healthMonitors()) {
+      const row = ensureService(services, monitor.service || monitor.name);
+      row.monitors.push(monitor);
+      row.lastProbe = latest(row.lastProbe, monitor.last_check_in_at || monitor.deadline_at);
+      row.states.push(surfaceState(monitor.state));
+      row.sequences.push(monitor.last_check_in_status || "none");
+    }
+    for (const item of state.data.status?.error_summary || []) {
+      const row = ensureService(services, item.service);
+      row.errorCount += Number(item.total_count || 0);
+      row.errorClasses += Number(item.unique_classes || 0);
+    }
+    return [...services.values()].map((row) => {
+      row.state = row.states.includes("down")
+        ? "down"
+        : row.states.includes("degraded") || row.errorCount > 0
+          ? "degraded"
+          : row.states.length
+            ? "up"
+            : "unknown";
+      const totalChecks = row.checks.length;
+      const successes = row.checks.filter((check) => check.result === "success").length;
+      row.uptime = totalChecks ? `${Math.round((successes / totalChecks) * 1000) / 10}%` : "n/a";
+      row.sequence = row.sequences.filter(Boolean).join("  ") || "no recent checks";
+      row.surfaceSummary = `${row.targets.length} targets · ${row.monitors.length} monitors · ${row.errorCount} errors`;
+      return row;
+    }).sort((a, b) => stateWeight(a.state) - stateWeight(b.state) || a.service.localeCompare(b.service));
+  }
+
+  function ensureService(map, service) {
+    const key = service || "unknown";
+    if (!map.has(key)) {
+      map.set(key, {
+        service: key,
+        targets: [],
+        monitors: [],
+        states: [],
+        checks: [],
+        sequences: [],
+        errorCount: 0,
+        errorClasses: 0,
+        lastProbe: "",
+      });
+    }
+    return map.get(key);
+  }
+
+  function incidentChoices() {
+    const active = (state.data.incidents?.incidents || []).map((incident) => ({ ...incident, source: "open" }));
+    const known = new Set(active.map((incident) => incident.id));
+    const history = incidentHistory().filter((incident) => !known.has(incident.id));
+    return active.concat(history);
+  }
+
+  function incidentHistory() {
+    const rows = [];
+    const seen = new Set();
+    for (const event of state.data.timeline?.events || []) {
+      if (event.entity_type !== "incident" || !event.entity_ref || seen.has(event.entity_ref)) {
+        continue;
+      }
+      seen.add(event.entity_ref);
+      rows.push({
+        id: event.entity_ref,
+        service: event.service,
+        state: event.event.replace("incident.", ""),
+        severity: event.severity || "medium",
+        title: event.summary,
+        opened_at: event.created_at,
+        created_at: event.created_at,
+        source: "history",
+      });
+    }
+    return rows;
+  }
+
+  function healthTargets() {
+    return state.data.health?.targets || [];
+  }
+
+  function healthMonitors() {
+    return state.data.health?.monitors || [];
+  }
+
+  function targetConfig(id) {
+    return (state.data.targets?.targets || []).find((target) => target.id === id);
+  }
+
+  function monitorConfig(id) {
+    return (state.data.monitors?.monitors || []).find((monitor) => monitor.id === id);
+  }
+
+  function countServiceStates(rows) {
+    return rows.reduce((acc, row) => {
+      acc[row.state] = (acc[row.state] || 0) + 1;
+      return acc;
+    }, { up: 0, degraded: 0, down: 0, unknown: 0 });
+  }
+
+  function stateWeight(value) {
+    return { down: 0, degraded: 1, unknown: 2, up: 3 }[value] ?? 4;
+  }
+
+  function surfaceState(value) {
+    if (value === "up" || value === "healthy") {
+      return "up";
+    }
+    if (value === "down" || value === "unhealthy") {
+      return "down";
+    }
+    if (value === "degraded" || value === "warning") {
+      return "degraded";
+    }
+    return "unknown";
+  }
+
+  function statusGlyph(value) {
+    if (value === "up") {
+      return "ok";
+    }
+    if (value === "down") {
+      return "x";
+    }
+    if (value === "degraded") {
+      return "!";
+    }
+    return "-";
+  }
+
+  function sequence(checks) {
+    if (!checks || !checks.length) {
+      return "";
+    }
+    return checks.slice(0, 8).map((check) => check.result === "success" ? "ok" : "x").join(" ");
+  }
+
+  function lastTargetResult(target) {
+    const latestCheck = target.recent_checks?.[0];
+    if (!latestCheck) {
+      return target.last_checked_at ? `checked ${formatTime(target.last_checked_at)}` : "none";
+    }
+    return `${latestCheck.result || "check"} ${formatTime(latestCheck.checked_at)}`;
+  }
+
+  function inferredCadence(checks) {
+    if (!checks || checks.length < 2) {
+      return "scoped";
+    }
+    const first = Date.parse(checks[0].checked_at);
+    const second = Date.parse(checks[1].checked_at);
+    if (!Number.isFinite(first) || !Number.isFinite(second)) {
+      return "scoped";
+    }
+    return duration(Math.abs(first - second));
+  }
+
+  function latest(left, right) {
+    if (!right) {
+      return left;
+    }
+    if (!left) {
+      return right;
+    }
+    return Date.parse(right) > Date.parse(left) ? right : left;
+  }
+
+  function duration(ms) {
+    const value = Number(ms || 0);
+    if (!value) {
+      return "n/a";
+    }
+    const seconds = Math.round(value / 1000);
+    if (seconds < 60) {
+      return `${seconds}s`;
+    }
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes}m`;
+    }
+    return `${Math.round(minutes / 60)}h`;
+  }
+
+  function formatTime(value) {
+    if (!value) {
+      return "n/a";
+    }
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return String(value);
+    }
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).format(date);
+  }
+
+  function errorTotal(items) {
+    return items.reduce((total, item) => total + Number(item.total_count || 0), 0);
+  }
+
+  function isActiveClaim(value) {
+    return ["claimed", "investigating", "fix_proposed", "verified"].includes(value);
+  }
+
+  function metric(label, value) {
+    return `<div class="metric"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`;
+  }
+
+  function empty(message) {
+    return `<div class="empty">${escapeHtml(message)}</div>`;
+  }
+
+  function showError(error) {
+    state.error = error.message;
+    state.loading = false;
+    render();
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  init();
+})();

--- a/crates/canary-server/static/dashboard/dashboard.css
+++ b/crates/canary-server/static/dashboard/dashboard.css
@@ -1,0 +1,437 @@
+:root {
+  --ae-accent: #2643d0;
+  --ae-accent-dark: #8c9eff;
+}
+
+body {
+  overflow: hidden;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border-radius: 0;
+}
+
+.canary-shell {
+  height: 100dvh;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  background: var(--ae-surface);
+  color: var(--ae-ink);
+  overflow: hidden;
+}
+
+.canary-topbar,
+.canary-status {
+  display: grid;
+  grid-template-columns: auto auto minmax(16rem, 1fr) auto;
+  align-items: center;
+  gap: var(--ae-space-4) var(--ae-space-6);
+  padding: var(--ae-space-4) var(--ae-space-6);
+  border-bottom: 1px solid var(--ae-line);
+}
+
+.canary-status {
+  grid-template-columns: 1fr auto auto;
+  border-top: 1px solid var(--ae-line);
+  border-bottom: 0;
+  padding-block: var(--ae-space-3);
+}
+
+.brand-block {
+  border-right: 1px solid var(--ae-line);
+  padding-right: var(--ae-space-6);
+}
+
+.brand {
+  font-weight: var(--ae-w-black);
+  letter-spacing: 0;
+}
+
+.canary-nav {
+  gap: var(--ae-space-5);
+}
+
+.session-form {
+  display: grid;
+  grid-template-columns: auto minmax(9rem, 1fr) auto auto;
+  align-items: center;
+  gap: var(--ae-space-3);
+  justify-self: end;
+  min-width: min(31rem, 100%);
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+}
+
+.session-form input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--ae-line);
+  background: transparent;
+  color: var(--ae-ink);
+  padding: var(--ae-space-1) 0;
+  font-family: var(--ae-font-mono);
+}
+
+.session-form button,
+.canary-status button,
+.action-button {
+  border: 1px solid var(--ae-ink);
+  background: var(--ae-ink);
+  color: var(--ae-surface);
+  padding: var(--ae-space-1) var(--ae-space-3);
+  cursor: pointer;
+  font-weight: var(--ae-w-medium);
+  line-height: 1.6;
+}
+
+.session-form button[type='button'],
+.canary-status button,
+.action-button.secondary {
+  background: transparent;
+  color: var(--ae-ink);
+}
+
+.canary-main {
+  min-height: 0;
+  overflow: auto;
+  padding: var(--ae-space-6);
+}
+
+.view {
+  min-height: 100%;
+  animation: ae-enter var(--ae-soft) var(--ae-ease) both;
+}
+
+.view-head {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) auto;
+  align-items: start;
+  gap: var(--ae-space-6);
+  margin-bottom: var(--ae-space-6);
+}
+
+.view-title {
+  font-weight: var(--ae-w-black);
+}
+
+.summary {
+  color: var(--ae-ink-muted);
+  max-width: var(--ae-measure-wide);
+}
+
+.metric-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--ae-space-5);
+}
+
+.metric {
+  min-width: 7rem;
+  text-align: right;
+}
+
+.metric dt,
+.eyebrow,
+.meta,
+.row-label,
+.empty,
+.problem,
+.tag,
+.time {
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+}
+
+.metric dd,
+.strong {
+  font-weight: var(--ae-w-black);
+}
+
+.panel {
+  border-top: 1px solid var(--ae-line);
+  padding-top: var(--ae-space-4);
+}
+
+.panel + .panel {
+  margin-top: var(--ae-space-6);
+}
+
+.wall,
+.split,
+.checks-layout,
+.incident-layout,
+.errors-layout {
+  display: grid;
+  gap: var(--ae-space-6);
+}
+
+.wall {
+  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+}
+
+.split {
+  grid-template-columns: minmax(18rem, 0.85fr) minmax(28rem, 1.4fr);
+}
+
+.checks-layout {
+  grid-template-columns: minmax(24rem, 1fr) minmax(20rem, 0.9fr);
+}
+
+.incident-layout {
+  grid-template-columns: minmax(16rem, 0.45fr) minmax(42rem, 1.7fr);
+}
+
+.errors-layout {
+  grid-template-columns: minmax(26rem, 1.2fr) minmax(18rem, 0.8fr);
+}
+
+.service-row,
+.data-row,
+.incident-row,
+.activity-row,
+.timeline-row,
+.signal-row {
+  border-bottom: 1px solid var(--ae-line);
+  padding: var(--ae-space-3) 0;
+}
+
+.service-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--ae-space-4);
+}
+
+.row-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--ae-space-2) var(--ae-space-4);
+}
+
+.row-grid {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) minmax(7rem, 0.6fr) minmax(9rem, 0.8fr) minmax(8rem, 0.6fr);
+  gap: var(--ae-space-4);
+  align-items: start;
+}
+
+.table-head {
+  color: var(--ae-ink-muted);
+  font-size: 13px;
+  font-family: var(--ae-font-mono);
+}
+
+.status-mark {
+  font-family: var(--ae-font-mono);
+  font-weight: var(--ae-w-black);
+}
+
+.status-up .status-mark,
+.ok {
+  color: var(--ae-ok);
+}
+
+.status-degraded .status-mark,
+.warn {
+  color: var(--ae-warn);
+}
+
+.status-down .status-mark,
+.err {
+  color: var(--ae-err);
+}
+
+.status-unknown .status-mark {
+  color: var(--ae-ink-faint);
+}
+
+.mini-sequence {
+  font-family: var(--ae-font-mono);
+  color: var(--ae-ink-muted);
+  white-space: nowrap;
+}
+
+.select-row {
+  width: 100%;
+  display: block;
+  text-align: left;
+  background: transparent;
+  color: inherit;
+  border: 0;
+  border-bottom: 1px solid var(--ae-line);
+  padding: var(--ae-space-3) 0;
+  cursor: pointer;
+}
+
+.select-row:hover,
+.select-row.is-selected {
+  color: var(--ae-accent);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(8rem, 1fr));
+  gap: var(--ae-space-5);
+  border-top: 1px solid var(--ae-line);
+  border-bottom: 1px solid var(--ae-line);
+  padding-block: var(--ae-space-4);
+  margin-bottom: var(--ae-space-5);
+}
+
+.detail-grid dt {
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+}
+
+.detail-columns {
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.9fr) minmax(20rem, 1.05fr) minmax(17rem, 0.95fr);
+  gap: var(--ae-space-4);
+}
+
+.detail-columns > *,
+.row-grid > *,
+.service-row > *,
+.timeline-row > *,
+.signal-row > *,
+.activity-row > * {
+  min-width: 0;
+}
+
+.strong,
+.event-name,
+.summary,
+.meta,
+.signal-row,
+.timeline-row,
+.activity-row {
+  overflow-wrap: anywhere;
+}
+
+.event-name {
+  font-family: var(--ae-font-mono);
+  font-size: 13px;
+  font-weight: var(--ae-w-medium);
+}
+
+.activity-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: var(--ae-space-4);
+}
+
+.timeline-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: var(--ae-space-4);
+}
+
+.metadata {
+  margin-top: var(--ae-space-2);
+  padding-left: var(--ae-space-4);
+  border-left: 1px solid var(--ae-line);
+  color: var(--ae-ink-muted);
+  font-family: var(--ae-font-mono);
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.code-block {
+  border: 1px solid var(--ae-line);
+  padding: var(--ae-space-4);
+  font-family: var(--ae-font-mono);
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--ae-ink-muted);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.problem {
+  border-top: 1px solid var(--ae-line);
+  border-bottom: 1px solid var(--ae-line);
+  padding: var(--ae-space-4) 0;
+  color: var(--ae-err);
+}
+
+.empty {
+  border-top: 1px solid var(--ae-line);
+  padding-top: var(--ae-space-4);
+}
+
+@media (max-width: 1080px) {
+  .canary-topbar {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .session-form {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+  }
+
+  .split,
+  .checks-layout,
+  .incident-layout,
+  .errors-layout,
+  .detail-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .canary-topbar,
+  .canary-main,
+  .canary-status {
+    padding-inline: var(--ae-space-4);
+  }
+
+  .canary-topbar {
+    grid-template-columns: 1fr auto;
+  }
+
+  .brand-block {
+    border-right: 0;
+    padding-right: 0;
+  }
+
+  .canary-nav {
+    grid-column: 1 / -1;
+    overflow-x: auto;
+    padding-bottom: var(--ae-space-1);
+  }
+
+  .session-form {
+    grid-template-columns: 1fr;
+  }
+
+  .view-head,
+  .detail-grid,
+  .row-grid,
+  .activity-row,
+  .timeline-row {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-strip {
+    justify-content: flex-start;
+  }
+
+  .metric {
+    text-align: left;
+  }
+
+  .canary-status {
+    grid-template-columns: 1fr;
+  }
+}

--- a/crates/canary-server/static/dashboard/index.html
+++ b/crates/canary-server/static/dashboard/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Canary</title>
+    <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/ui/aesthetic.css">
+    <link rel="stylesheet" href="/ui/dashboard.css">
+    <script defer src="/ui/app.js"></script>
+  </head>
+  <body>
+    <div class="canary-shell" data-canary-dashboard>
+      <header class="canary-topbar">
+        <div class="brand-block" aria-label="Canary">
+          <div class="brand">CANARY</div>
+        </div>
+        <nav class="canary-nav ae-nav" aria-label="Dashboard views">
+          <button type="button" data-view="health" aria-current="page">Health</button>
+          <button type="button" data-view="incidents">Incidents</button>
+          <button type="button" data-view="checks">Checks</button>
+          <button type="button" data-view="errors">Errors</button>
+        </nav>
+        <form class="session-form" id="session-form">
+          <label for="api-key">Bearer key</label>
+          <input id="api-key" name="api-key" type="password" autocomplete="off" spellcheck="false" placeholder="paste bearer key">
+          <button type="submit">Use</button>
+          <button type="button" id="clear-key">Clear</button>
+        </form>
+        <button class="ae-mode" id="mode-toggle" type="button" aria-label="Toggle color mode">
+          <svg class="ae-icon ae-sun" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="4"></circle>
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+          </svg>
+          <svg class="ae-icon ae-moon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"></path>
+          </svg>
+        </button>
+      </header>
+
+      <main class="canary-main" id="view-root" tabindex="-1"></main>
+
+      <footer class="canary-status ae-chrome">
+        <span id="connection-status">No session key</span>
+        <span id="last-refresh">Not refreshed</span>
+        <button type="button" id="refresh">Refresh</button>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Serve a human dashboard shell at `/ui` from Canary itself.
- Vendor the Misty Step aesthetic kit byte-for-byte and layer a thin static client over existing same-origin API routes.
- Add focused route tests proving the shell/assets serve without embedded private data, and file v1 follow-up tickets for historical incident coverage and the dashboard read contract.

## Auth choice
Canary `canary-obs` is public, so v1 uses a session-key paste flow instead of keyless reads. `/ui` is unauthenticated static content only; it mints no keys, proxies no data, and embeds no private state. The browser stores the pasted key in `sessionStorage` and attaches `Authorization: Bearer ...` to all API reads. Optional admin-only target/monitor enrichments fail closed while the core read-only surfaces still render.

I filed `backlog.d/068-human-dashboard-read-contract.md` to make the read contract and any future env-gated private-network keyless mode explicit before loosening this.

## Evidence
- `cargo fmt --all --check`
- `cargo test -p canary-server dashboard_shell_serves_assets_without_private_data --locked`
- `cargo test -p canary-server canary_server_boots_public_and_authenticated_routes --locked`
- `node --check crates/canary-server/static/dashboard/app.js`
- `./bin/validate`
- `git push` pre-push `./bin/validate --strict` hook

## Visual QA
Playwright fallback was used because the in-app Browser backend had no available browser instances. A disposable local Canary on `127.0.0.1:4400` was seeded through the API with a real incident, claim, and `canary-ui-drill` writeback annotations.

Screenshots and QA packet:
- `/Users/phaedrus/artifacts/public/a/showcase/canary/ui/light-landing.png`
- `/Users/phaedrus/artifacts/public/a/showcase/canary/ui/dark-landing.png`
- `/Users/phaedrus/artifacts/public/a/showcase/canary/ui/light-incident-detail.png`
- `/Users/phaedrus/artifacts/public/a/showcase/canary/ui/dark-incident-detail.png`
- `/Users/phaedrus/artifacts/public/a/showcase/canary/ui/mobile-landing.png`
- `/Users/phaedrus/artifacts/public/a/showcase/canary/ui/qa-report.json`

## Follow-ups filed
- `backlog.d/067-human-dashboard-incident-history.md`
- `backlog.d/068-human-dashboard-read-contract.md`