### PR TITLE
feat(ui): kit-adoption mechanics — Geist, mode boot, the trail primitive

### DIFF
--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -818,7 +818,7 @@ mod tests {
             .await?;
         assert_eq!(aesthetic.status(), StatusCode::OK);
         let aesthetic_body = text_body(aesthetic).await?;
-        assert!(aesthetic_body.contains("aesthetic v2.8.1"));
+        assert!(aesthetic_body.contains("aesthetic v2.10.0"));
 
         Ok(())
     }

--- a/crates/canary-server/static/dashboard/aesthetic.css
+++ b/crates/canary-server/static/dashboard/aesthetic.css
@@ -1,5 +1,5 @@
 /* ═══════════════════════════════════════════════════════════════════
-   aesthetic v2.8.1
+   aesthetic v2.10.0
    The Misty Step design system. https://github.com/misty-step/aesthetic
 
    The law:
@@ -1174,6 +1174,76 @@ input.ae-switch:checked::before {
   border-top: 1px solid var(--ae-line);
   padding-top: 0.8em;
   margin-top: 1.1em;
+}
+
+/* the trail: a chronological run of events as the conversation it is —
+   a hairline spine, an ink tick per entry, time and actor in the
+   instrument register, the body in prose. Not a table: entries carry
+   variable-length bodies and states, so alignment comes from the spine,
+   not columns. The tick is a square, never a circle — the choice mark's
+   rule holds here too. Status, if an entry carries one, rides a glyph
+   in the body, never the tick or a filled pill. */
+.ae-trail {
+  list-style: none;
+  margin: 0 0 0 0.25em;
+  padding: 0;
+  border-left: 1px solid var(--ae-line);
+}
+
+.ae-trail-item {
+  position: relative;
+  padding: 0 0 1.3em 1.5em;
+}
+
+.ae-trail-item:last-child {
+  padding-bottom: 0;
+}
+
+.ae-trail-item::before {
+  content: '';
+  position: absolute;
+  left: -0.31em;
+  top: 0.5em;
+  width: 0.5em;
+  height: 0.5em;
+  background: var(--ae-ink-faint);
+}
+
+.ae-trail-item.is-active::before {
+  background: var(--ae-accent);
+}
+
+.ae-trail-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7em;
+  flex-wrap: wrap;
+  margin-bottom: 0.25em;
+}
+
+.ae-trail-time {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ae-ink-muted);
+}
+
+.ae-trail-who {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ae-ink-muted);
+  border: 1px solid currentColor;
+  padding: 0.1em 0.55em;
+}
+
+.ae-trail-body {
+  font-size: 13px;
+  color: var(--ae-ink);
+}
+
+.ae-trail-body .ae-dim {
+  color: var(--ae-ink-muted);
 }
 
 /* ── instruments: ink on a ruled line ─────────────────────────────── */

--- a/crates/canary-server/static/dashboard/app.js
+++ b/crates/canary-server/static/dashboard/app.js
@@ -304,10 +304,22 @@
   }
 
   function loadingView() {
+    const card = `
+      <div class="service-row">
+        <span class="ae-skeleton">status placeholder</span>
+        <span class="ae-skeleton">metric placeholder</span>
+      </div>
+    `;
     return `
       <section class="view">
-        <h1 class="view-title">Reading Canary</h1>
-        <p class="summary">Loading current state.</p>
+        <p class="ae-sr" role="status">Reading Canary — loading current state.</p>
+        <div class="view-head">
+          <div>
+            <h1 class="ae-skeleton view-title">Reading Canary</h1>
+            <p class="ae-skeleton summary">Loading current state, one moment.</p>
+          </div>
+        </div>
+        <div class="wall">${card}${card}${card}</div>
       </section>
     `;
   }
@@ -438,7 +450,7 @@
         <div class="detail-columns">
           <section>
             <div class="eyebrow">Timeline</div>
-            ${detail.recent_timeline_events?.length ? detail.recent_timeline_events.map(renderTimelineEvent).join("") : empty("No recent timeline events.")}
+            ${detail.recent_timeline_events?.length ? `<ol class="ae-trail">${detail.recent_timeline_events.map(renderTimelineEvent).join("")}</ol>` : empty("No recent timeline events.")}
           </section>
           <section>
             <div class="eyebrow">Probe evidence</div>
@@ -446,8 +458,7 @@
           </section>
           <section>
             <div class="eyebrow">Agent activity</div>
-            ${renderClaim(claim)}
-            ${detail.annotations?.length ? detail.annotations.map(renderActivity).join("") : empty("No writeback annotations yet.")}
+            ${claim || detail.annotations?.length ? `<ol class="ae-trail">${renderClaim(claim)}${detail.annotations?.length ? detail.annotations.map(renderActivity).join("") : ""}</ol>` : empty("No writeback annotations yet.")}
           </section>
         </div>
       </div>
@@ -456,13 +467,13 @@
 
   function renderTimelineEvent(event) {
     return `
-      <div class="timeline-row">
-        <div class="time">${escapeHtml(formatTime(event.created_at))}</div>
-        <div>
-          <div class="event-name">${escapeHtml(event.event)}</div>
-          <div class="meta">${escapeHtml(event.summary || "")}</div>
+      <li class="ae-trail-item">
+        <div class="ae-trail-head">
+          <span class="ae-trail-time">${escapeHtml(formatTime(event.created_at))}</span>
+          <span class="ae-trail-who">${escapeHtml(event.event)}</span>
         </div>
-      </div>
+        <div class="ae-trail-body">${escapeHtml(event.summary || "")}</div>
+      </li>
     `;
   }
 
@@ -491,32 +502,31 @@
     }
     const lines = [
       ["claim", claim.id],
-      ["owner", claim.owner],
       ["state", claim.state],
       ["purpose", claim.purpose],
       ["updated", formatTime(claim.updated_at)],
     ];
     return `
-      <div class="activity-row">
-        <div class="time">claim</div>
-        <div>
-          <div class="strong">${escapeHtml(claim.owner || "agent")}</div>
-          <div class="metadata">${escapeHtml(lines.map(([key, value]) => `${key}: ${value || "n/a"}`).join("\n"))}</div>
+      <li class="ae-trail-item is-active">
+        <div class="ae-trail-head">
+          <span class="ae-trail-time">claim</span>
+          <span class="ae-trail-who">${escapeHtml(claim.owner || "agent")}</span>
         </div>
-      </div>
+        <div class="ae-trail-body metadata">${escapeHtml(lines.map(([key, value]) => `${key}: ${value || "n/a"}`).join("\n"))}</div>
+      </li>
     `;
   }
 
   function renderActivity(annotation) {
     return `
-      <div class="activity-row">
-        <div class="time">${escapeHtml(formatTime(annotation.created_at))}</div>
-        <div>
-          <div class="strong">${escapeHtml(annotation.agent || "agent")}</div>
-          <div>${escapeHtml(annotation.action || "annotated")}</div>
-          ${annotation.metadata ? `<div class="metadata">${escapeHtml(JSON.stringify(annotation.metadata, null, 2))}</div>` : ""}
+      <li class="ae-trail-item">
+        <div class="ae-trail-head">
+          <span class="ae-trail-time">${escapeHtml(formatTime(annotation.created_at))}</span>
+          <span class="ae-trail-who">${escapeHtml(annotation.agent || "agent")}</span>
         </div>
-      </div>
+        <div class="ae-trail-body">${escapeHtml(annotation.action || "annotated")}</div>
+        ${annotation.metadata ? `<div class="metadata">${escapeHtml(JSON.stringify(annotation.metadata, null, 2))}</div>` : ""}
+      </li>
     `;
   }
 

--- a/crates/canary-server/static/dashboard/dashboard.css
+++ b/crates/canary-server/static/dashboard/dashboard.css
@@ -1,4 +1,6 @@
 :root {
+  /* accent steering deferred to the Fable design-catalogue pass —
+     kit default (unchanged) until that direction lands */
   --ae-accent: #2643d0;
   --ae-accent-dark: #8c9eff;
 }
@@ -143,8 +145,7 @@ button {
 .row-label,
 .empty,
 .problem,
-.tag,
-.time {
+.tag {
   font-size: 13px;
   color: var(--ae-ink-muted);
 }
@@ -195,8 +196,6 @@ button {
 .service-row,
 .data-row,
 .incident-row,
-.activity-row,
-.timeline-row,
 .signal-row {
   border-bottom: 1px solid var(--ae-line);
   padding: var(--ae-space-3) 0;
@@ -299,38 +298,20 @@ button {
 .detail-columns > *,
 .row-grid > *,
 .service-row > *,
-.timeline-row > *,
-.signal-row > *,
-.activity-row > * {
+.signal-row > * {
   min-width: 0;
 }
 
 .strong,
-.event-name,
 .summary,
 .meta,
-.signal-row,
-.timeline-row,
-.activity-row {
+.signal-row {
   overflow-wrap: anywhere;
 }
 
-.event-name {
-  font-family: var(--ae-font-mono);
-  font-size: 13px;
-  font-weight: var(--ae-w-medium);
-}
-
-.activity-row {
-  display: grid;
-  grid-template-columns: 8rem 1fr;
-  gap: var(--ae-space-4);
-}
-
-.timeline-row {
-  display: grid;
-  grid-template-columns: 8rem 1fr;
-  gap: var(--ae-space-4);
+.ae-trail-body,
+.ae-trail-who {
+  overflow-wrap: anywhere;
 }
 
 .metadata {
@@ -417,9 +398,7 @@ button {
 
   .view-head,
   .detail-grid,
-  .row-grid,
-  .activity-row,
-  .timeline-row {
+  .row-grid {
     grid-template-columns: 1fr;
   }
 

--- a/crates/canary-server/static/dashboard/index.html
+++ b/crates/canary-server/static/dashboard/index.html
@@ -5,8 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Canary</title>
     <link rel="icon" href="data:,">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap">
     <link rel="stylesheet" href="/ui/aesthetic.css">
     <link rel="stylesheet" href="/ui/dashboard.css">
+    <script>
+      try {
+        var m = sessionStorage.getItem("canary.dashboard.mode");
+        if (m === "dark" || m === "light") {
+          document.documentElement.dataset.aeMode = m;
+        }
+      } catch (e) {}
+    </script>
     <script defer src="/ui/app.js"></script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
Pure kit-adoption mechanics, no visual reidentity (accent/color decisions deferred to the Fable design-catalogue pass — confirmed this PR carries no accent override, kit default `--ae-accent` untouched):

- Load Geist + Geist Mono (ADOPTING.md step 2 — was missing entirely, so the dashboard was rendering in system-ui and losing the type identity the kit is built around).
- Boot the mode pre-paint from the existing `sessionStorage` key to kill the flash (bug fix, not a style choice).
- Render the incident Timeline and Agent activity as `.ae-trail` — a new kit primitive (misty-step/aesthetic#7, released as v2.10.0): a class swap from the ad hoc `.activity-row`/`.timeline-row` grid to the kit's primitive, current claim marked `.is-active`. Deletes the now-dead `activity-row`/`timeline-row`/`event-name` rules from `dashboard.css`.
- Loading view composed from the kit's existing `.ae-skeleton` + `.ae-sr` primitives instead of a bare sentence — wiring only, no new color or type decisions.
- Re-vendor `aesthetic.css` byte-for-byte from misty-step/aesthetic@v2.10.0 (#7 + #8's list-style-reset fix) so the trail actually renders styled; updates the vendored-asset test's version-string assertion to match.

## Publishing note
This branch was pushed via the GitHub Git Data API rather than `git push`, after the local `.githooks/pre-push` (which runs `bin/validate --fast` in a local Dagger container) repeatedly failed under cross-lane resource contention with the concurrent escalation-overlay work in this same repo — confirmed via the failure signature (the escalation lane's in-flight routes leaking into this diff's OpenAPI contract test, which this diff never touches) and via clean, repeated `cargo test -p canary-server --lib` passes (227/227, including from a `cargo clean` rebuild) outside the container. Explicitly authorized by the lane owner: remote CI on this PR is the real gate and must be fully green before merge.

## Test plan
- [x] `node --check crates/canary-server/static/dashboard/app.js`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p canary-server --lib` — 227/227, including `dashboard_shell_serves_assets_without_private_data` with the updated vendored-version assertion
- [ ] Remote CI (this PR) — must be fully green before merge