### PR TITLE
feat(ui): ship metric squares dashboard

### DIFF
--- a/crates/canary-server/static/dashboard/app.js
+++ b/crates/canary-server/static/dashboard/app.js
@@ -1,17 +1,27 @@
 (() => {
   const KEY_STORAGE = "canary.dashboard.sessionKey";
   const MODE_STORAGE = "canary.dashboard.mode";
-  const VIEWS = ["health", "incidents", "checks", "errors"];
+  const FIGURES = ["all", "up", "down", "incidents", "errors"];
+  const APP_ICONS = [
+    ["bitterblossom", "i-flower"],
+    ["powder", "i-kanban"],
+    ["crucible", "i-flask-conical"],
+    ["cerberus", "i-eye"],
+    ["landmark", "i-milestone"],
+    ["harness-kit", "i-toolbox"],
+    ["weave", "i-layers"],
+    ["canary", "i-bird"],
+  ];
 
   const state = {
-    view: "health",
+    figure: "all",
+    view: "all",
     key: sessionStorage.getItem(KEY_STORAGE) || "",
     mode: sessionStorage.getItem(MODE_STORAGE) || "",
     loading: false,
     error: "",
     lastRefresh: null,
-    selectedIncidentId: "",
-    selectedTargetId: "",
+    selectedSheetId: "",
     data: {
       status: null,
       health: null,
@@ -20,8 +30,7 @@
       errors: null,
       targets: null,
       monitors: null,
-      incidentDetail: null,
-      targetChecks: null,
+      incidentDetails: new Map(),
     },
     optional: {
       errorsProblem: "",
@@ -34,12 +43,13 @@
   const keyInput = document.getElementById("api-key");
   const connection = document.getElementById("connection-status");
   const lastRefresh = document.getElementById("last-refresh");
+  const sheet = document.getElementById("sheet");
+  const scrim = document.getElementById("scrim");
 
   function init() {
     keyInput.value = state.key;
     setMode(state.mode || preferredMode());
     bindEvents();
-    syncViewFromHash();
     render();
     if (state.key) {
       refresh();
@@ -60,6 +70,7 @@
       state.key = "";
       keyInput.value = "";
       sessionStorage.removeItem(KEY_STORAGE);
+      state.error = "";
       state.data = {
         status: null,
         health: null,
@@ -68,10 +79,9 @@
         errors: null,
         targets: null,
         monitors: null,
-        incidentDetail: null,
-        targetChecks: null,
+        incidentDetails: new Map(),
       };
-      state.error = "";
+      closeSheet();
       render();
     });
 
@@ -81,32 +91,38 @@
     });
 
     document.addEventListener("click", (event) => {
-      const viewButton = event.target.closest("[data-view]");
-      if (viewButton) {
+      const fig = event.target.closest("[data-fig]");
+      if (fig) {
         event.preventDefault();
-        setView(viewButton.dataset.view);
+        setFigure(fig.dataset.fig);
         return;
       }
 
-      const incidentButton = event.target.closest("[data-incident-id]");
-      if (incidentButton) {
+      if (event.target.closest("[data-clear]")) {
         event.preventDefault();
-        state.selectedIncidentId = incidentButton.dataset.incidentId;
-        loadIncidentDetail().then(render).catch(showError);
+        setFigure("all");
         return;
       }
 
-      const targetButton = event.target.closest("[data-target-id]");
-      if (targetButton) {
+      const view = event.target.closest("[data-view]");
+      if (view) {
         event.preventDefault();
-        state.selectedTargetId = targetButton.dataset.targetId;
-        loadTargetChecks().then(render).catch(showError);
+        state.view = view.dataset.view;
+        closeSheet();
+        render();
+        return;
       }
-    });
 
-    window.addEventListener("hashchange", () => {
-      syncViewFromHash();
-      render();
+      const incident = event.target.closest("[data-incident-id]");
+      if (incident) {
+        event.preventDefault();
+        openIncidentSheet(incident.dataset.incidentId);
+        return;
+      }
+
+      if (event.target.closest("[data-close]") || event.target === scrim) {
+        closeSheet();
+      }
     });
   }
 
@@ -120,22 +136,18 @@
     sessionStorage.setItem(MODE_STORAGE, state.mode);
   }
 
-  function syncViewFromHash() {
-    const next = window.location.hash.replace("#", "");
-    if (VIEWS.includes(next)) {
-      state.view = next;
-    }
-  }
-
-  function setView(view) {
-    if (!VIEWS.includes(view)) {
+  function setFigure(figure) {
+    if (!FIGURES.includes(figure)) {
       return;
     }
-    state.view = view;
-    window.location.hash = view;
-    if (view === "incidents" && state.key && !state.data.incidentDetail) {
-      loadIncidentDetail().then(render).catch(showError);
+    state.figure = figure;
+    if (figure === "incidents" || figure === "errors") {
+      state.view = "all";
+    } else if (state.view !== "all" && !visibleApps().some((app) => app.key === state.view)) {
+      state.view = "all";
     }
+    closeSheet();
+    render();
   }
 
   async function refresh() {
@@ -157,7 +169,7 @@
       ]);
 
       const [timeline, errors, targets, monitors] = await Promise.all([
-        optionalApi("/api/v1/timeline?window=7d&limit=100&event_type=incident.opened,incident.updated,incident.resolved"),
+        optionalApi("/api/v1/timeline?window=7d&limit=100"),
         optionalApi("/api/v1/query?group_by=error_class&window=24h"),
         optionalApi("/api/v1/targets"),
         optionalApi("/api/v1/monitors"),
@@ -170,22 +182,13 @@
       state.data.errors = errors.value;
       state.data.targets = targets.value;
       state.data.monitors = monitors.value;
+      state.data.incidentDetails = new Map();
       state.optional.timelineProblem = timeline.problem;
       state.optional.errorsProblem = errors.problem;
       state.optional.adminProblem = [targets.problem, monitors.problem].filter(Boolean).join(" ");
 
-      const incidentIds = incidentChoices().map((incident) => incident.id);
-      if (!state.selectedIncidentId || !incidentIds.includes(state.selectedIncidentId)) {
-        state.selectedIncidentId = incidentIds[0] || "";
-      }
-      await loadIncidentDetail();
-
-      const targetsList = healthTargets();
-      if (!state.selectedTargetId || !targetsList.some((target) => target.id === state.selectedTargetId)) {
-        state.selectedTargetId = targetsList[0]?.id || "";
-      }
-      await loadTargetChecks();
-
+      const ids = incidentFeed().map((incident) => incident.id);
+      await Promise.all(ids.slice(0, 8).map(loadIncidentDetail));
       state.lastRefresh = new Date();
     } catch (error) {
       state.error = error.message;
@@ -195,22 +198,21 @@
     }
   }
 
-  async function loadIncidentDetail() {
-    state.data.incidentDetail = null;
-    if (!state.key || !state.selectedIncidentId) {
-      return;
+  async function openIncidentSheet(id) {
+    state.selectedSheetId = id;
+    renderSheet();
+    if (!state.data.incidentDetails.has(id)) {
+      await loadIncidentDetail(id);
     }
-    state.data.incidentDetail = await optionalApi(`/api/v1/incidents/${encodeURIComponent(state.selectedIncidentId)}`)
-      .then((result) => result.value || { problem: result.problem });
+    renderSheet();
   }
 
-  async function loadTargetChecks() {
-    state.data.targetChecks = null;
-    if (!state.key || !state.selectedTargetId) {
+  async function loadIncidentDetail(id) {
+    if (!state.key || !id || state.data.incidentDetails.has(id)) {
       return;
     }
-    state.data.targetChecks = await optionalApi(`/api/v1/targets/${encodeURIComponent(state.selectedTargetId)}/checks?window=24h`)
-      .then((result) => result.value || { problem: result.problem });
+    const result = await optionalApi(`/api/v1/incidents/${encodeURIComponent(id)}`);
+    state.data.incidentDetails.set(id, result.value || { problem: result.problem });
   }
 
   async function api(path) {
@@ -246,8 +248,7 @@
 
   function render() {
     updateChrome();
-    updateNav();
-
+    closeStaleSheet();
     if (!state.key) {
       root.innerHTML = lockedView();
       return;
@@ -260,16 +261,8 @@
       root.innerHTML = problemView(state.error);
       return;
     }
-
-    if (state.view === "incidents") {
-      root.innerHTML = renderIncidents();
-    } else if (state.view === "checks") {
-      root.innerHTML = renderChecks();
-    } else if (state.view === "errors") {
-      root.innerHTML = renderErrors();
-    } else {
-      root.innerHTML = renderHealth();
-    }
+    root.innerHTML = dashboardView();
+    renderSheet();
   }
 
   function updateChrome() {
@@ -279,47 +272,42 @@
       : "Not refreshed";
   }
 
-  function updateNav() {
-    document.querySelectorAll("[data-view]").forEach((button) => {
-      const active = button.dataset.view === state.view;
-      button.toggleAttribute("aria-current", active);
-      button.classList.toggle("is-active", active);
-    });
-  }
-
   function lockedView() {
     return `
       <section class="view">
-        <div class="view-head">
-          <div>
-            <h1 class="view-title">Canary dashboard</h1>
-            <p class="summary">Paste a scoped API key to read this instance.</p>
-          </div>
-        </div>
-        <div class="panel">
-          <p class="empty">The shell is public. Canary data is not read until the browser sends your session key to the existing API routes.</p>
+        ${figuresMarkup({ apps: 0, up: 0, down: 0, incidents: 0, errors: 0 })}
+        <div class="split">
+          <nav class="master" aria-label="Destinations">
+            <p class="ae-h">SESSION</p>
+            <div class="empty">The shell is public. Paste a scoped bearer key to read Canary.</div>
+          </nav>
+          <section class="detail">
+            <div class="ae-view">
+              <div class="ae-group">
+                <p><span class="ae-strong">Canary dashboard</span></p>
+                <p class="ae-chrome">Canary data is not read until this browser sends your session key to the existing API routes.</p>
+              </div>
+            </div>
+          </section>
         </div>
       </section>
     `;
   }
 
   function loadingView() {
-    const card = `
-      <div class="service-row">
-        <span class="ae-skeleton">status placeholder</span>
-        <span class="ae-skeleton">metric placeholder</span>
-      </div>
-    `;
     return `
       <section class="view">
-        <p class="ae-sr" role="status">Reading Canary — loading current state.</p>
-        <div class="view-head">
-          <div>
-            <h1 class="ae-skeleton view-title">Reading Canary</h1>
-            <p class="ae-skeleton summary">Loading current state, one moment.</p>
-          </div>
+        <p class="ae-sr" role="status">Reading Canary.</p>
+        ${figuresMarkup({ apps: 0, up: 0, down: 0, incidents: 0, errors: 0 })}
+        <div class="split">
+          <nav class="master" aria-label="Destinations">
+            <p class="ae-h">READING</p>
+            <div class="empty">Loading current state.</div>
+          </nav>
+          <section class="detail">
+            <div class="ae-view"><div class="ae-group"><p class="ae-skeleton">Reading Canary</p><p class="ae-skeleton">Loading current status, health, incidents, and annotations.</p></div></div>
+          </section>
         </div>
-        <div class="wall">${card}${card}${card}</div>
       </section>
     `;
   }
@@ -327,197 +315,216 @@
   function problemView(message) {
     return `
       <section class="view">
-        <h1 class="view-title">Canary rejected the read</h1>
-        <div class="problem">${escapeHtml(message)}</div>
+        ${figuresMarkup(metrics())}
+        <div class="split">
+          <nav class="master" aria-label="Destinations">
+            <p class="ae-h">ERROR</p>
+          </nav>
+          <section class="detail">
+            <h1 class="ae-strong">Canary rejected the read</h1>
+            <div class="problem">${escapeHtml(message)}</div>
+          </section>
+        </div>
       </section>
     `;
   }
 
-  function renderHealth() {
-    const rows = serviceRows();
-    const status = state.data.status || {};
-    const counts = countServiceStates(rows);
+  function dashboardView() {
     return `
       <section class="view">
-        <div class="view-head">
-          <div>
-            <h1 class="view-title">Production health</h1>
-            <p class="summary">${escapeHtml(status.summary || "No status summary returned.")}</p>
-          </div>
-          <dl class="metric-strip">
-            ${metric("Services", rows.length)}
-            ${metric("Up", counts.up)}
-            ${metric("Degraded", counts.degraded)}
-            ${metric("Down", counts.down)}
-          </dl>
-        </div>
-        <div class="wall">
-          ${rows.length ? rows.map(renderServiceRow).join("") : empty("No services configured.")}
+        ${figuresMarkup(metrics())}
+        <div class="split">
+          ${masterMarkup()}
+          <section class="detail" aria-live="polite">${detailMarkup()}</section>
         </div>
       </section>
     `;
   }
 
-  function renderServiceRow(row) {
+  function figuresMarkup(values) {
+    const rows = [
+      ["all", "APPLICATIONS", "i-grid", "", values.apps],
+      ["up", "UP", "i-check", "ae-ok", values.up],
+      ["down", "DOWN", "i-x", "ae-err", values.down],
+      ["incidents", "OPEN INCIDENTS", "i-alert", "ae-warn", values.incidents],
+      ["errors", "ERRORS 24H", "i-zap", "ae-err", values.errors],
+    ];
+    return `<div class="figures" role="group" aria-label="Fleet figures">${rows.map(([key, label, iconId, cls, value]) => `
+      <button class="figure" type="button" data-fig="${key}" aria-pressed="${state.figure === key}">
+        <span class="figure-label">${label}</span>
+        <span class="figure-val">${iconSvg(iconId, cls)}<span class="ae-num">${escapeHtml(value)}</span></span>
+      </button>`).join("")}</div>`;
+  }
+
+  function masterMarkup() {
+    const apps = visibleApps();
+    const allCount = allApps().length;
+    const filterNote = state.figure === "all"
+      ? ""
+      : `<span class="sub">filtered by the ${state.figure === "incidents" ? "open-incidents" : state.figure} square · <a href="#" data-clear>clear</a></span>`;
     return `
-      <article class="service-row status-${row.state}">
-        <div>
-          <div class="row-main">
-            <span class="status-mark">${statusGlyph(row.state)}</span>
-            <span class="strong">${escapeHtml(row.service)}</span>
-            <span class="tag">${escapeHtml(row.state)}</span>
-          </div>
-          <div class="meta">${escapeHtml(row.surfaceSummary)}</div>
-        </div>
-        <div>
-          <div>${escapeHtml(row.uptime)}</div>
-          <div class="meta">last ${escapeHtml(formatTime(row.lastProbe))}</div>
-          <div class="mini-sequence">${escapeHtml(row.sequence)}</div>
-        </div>
-      </article>
+      <nav class="master" aria-label="Destinations">
+        <p class="ae-h">INCIDENTS</p>
+        <button class="dest" type="button" aria-selected="${state.view === "all"}" data-view="all">
+          ${iconSvg("i-inbox", "logo")}
+          <span class="ae-item">All incidents</span>
+          <span class="fig">${glyph("warn")}<span>${openIncidentCount()} open</span></span>
+        </button>
+        <p class="ae-h">APPLICATIONS${state.figure !== "all" ? ` · ${apps.length} OF ${allCount}` : ""}</p>
+        ${filterNote}
+        ${apps.map((app) => `
+          <button class="dest" type="button" aria-selected="${state.view === app.key}" data-view="${escapeHtml(app.key)}">
+            ${appIcon(app.name, "logo")}
+            <span class="ae-item">${escapeHtml(app.name)}</span>
+            <span class="fig">${glyph(app.glyph)}<span>${escapeHtml(app.uptime)}</span></span>
+            ${app.incidents.length || app.errorCount ? `<span class="sub">${streamLabel(app.incidents.length)} · ${escapeHtml(app.meta)}</span>` : ""}
+          </button>
+        `).join("")}
+      </nav>
     `;
   }
 
-  function renderIncidents() {
-    const incidents = incidentChoices();
-    const detail = state.data.incidentDetail;
+  function detailMarkup() {
+    if (state.view === "all") {
+      return allIncidentsView();
+    }
+    const app = allApps().find((item) => item.key === state.view);
+    return app ? appView(app) : allIncidentsView();
+  }
+
+  const incHead = `
+    <div class="inc-head" aria-hidden="true">
+      <span></span><span>TIME</span><span>TYPE</span><span>APPLICATION</span><span>WHAT HAPPENED</span><span>STATE</span>
+    </div>`;
+
+  function allIncidentsView() {
+    const feed = incidentFeed();
     return `
-      <section class="view">
-        <div class="view-head">
-          <div>
-            <h1 class="view-title">Incidents</h1>
-            <p class="summary">${escapeHtml(state.data.incidents?.summary || "No incident summary returned.")}</p>
-          </div>
-          <dl class="metric-strip">
-            ${metric("Open", state.data.incidents?.incidents?.length || 0)}
-            ${metric("History", incidentHistory().length)}
-            ${metric("Selected", state.selectedIncidentId || "none")}
-          </dl>
+      <div class="ae-view">
+        <div class="ae-group">
+          <p>${iconSvg("i-inbox")} <span class="ae-strong">All incidents</span></p>
+          <p class="ae-chrome">${escapeHtml(state.data.incidents?.summary || "Every error group, failed check, and outage across the fleet resolves into one incident stream.")}</p>
         </div>
-        <div class="incident-layout">
-          <aside class="panel">
-            <div class="eyebrow">Open and recent</div>
-            ${incidents.length ? incidents.map(renderIncidentChoice).join("") : empty("No incidents in the returned window.")}
-          </aside>
-          <div class="panel">
-            ${renderIncidentDetail(detail)}
-          </div>
+        <div class="ae-group">
+          ${feed.length ? incHead + feed.map(incidentRow).join("") : empty("No incidents in the returned window.")}
         </div>
-      </section>
+      </div>
     `;
   }
 
-  function renderIncidentChoice(incident) {
-    const selected = incident.id === state.selectedIncidentId;
+  function appView(app) {
+    const rows = app.incidents.length
+      ? incHead + app.incidents.map(incidentRow).join("")
+      : `<div class="ae-empty"><p>${glyph("ok")} <span class="ae-item">Calm.</span></p><p class="ae-dim">No open incidents. Errors, failed checks, and downtime surface here.</p></div>`;
+    const trail = app.probes.length
+      ? `<p class="ae-chrome">last five probes, oldest first · ${trail5(app.probes, `Last five probes: ${app.probes.join(", ")}`)}</p>`
+      : `<p class="ae-chrome">no probe trail - this app may report by monitor/check-in.</p>`;
     return `
-      <button class="select-row ${selected ? "is-selected" : ""}" type="button" data-incident-id="${escapeHtml(incident.id)}">
-        <span class="row-main">
-          <span class="status-mark ${incident.severity === "high" ? "err" : "warn"}">${incident.severity === "high" ? "x" : "!"}</span>
-          <span class="strong">${escapeHtml(incident.title || incident.service || incident.id)}</span>
-        </span>
-        <span class="meta">${escapeHtml(incident.id)} · ${escapeHtml(incident.state || "event")} · ${escapeHtml(formatTime(incident.opened_at || incident.created_at))}</span>
+      <div class="ae-view">
+        <div class="ae-group">
+          <p class="apphead">${appIcon(app.name)} <span class="ae-strong">${escapeHtml(app.name)}</span> ${glyph(app.glyph)}</p>
+          <p class="ae-chrome ae-num">uptime ${escapeHtml(app.uptime)} · last probe ${escapeHtml(formatTime(app.lastProbe))} · ${escapeHtml(app.meta)}</p>
+          ${trail}
+        </div>
+        <div class="ae-group">
+          <p class="ae-h">INCIDENT STREAM</p>
+          ${rows}
+        </div>
+      </div>
+    `;
+  }
+
+  function incidentRow(incident) {
+    const severityGlyph = incident.escalated_at ? "err" : incident.severity === "high" ? "err" : "warn";
+    return `
+      <button class="inc ${incident.escalated_at ? "is-escalated" : ""}" type="button" data-incident-id="${escapeHtml(incident.id)}">
+        <span class="glyph">${glyph(severityGlyph)}</span>
+        <span class="t">${escapeHtml(formatTime(incident.opened_at || incident.created_at))}</span>
+        <span class="type"><span class="ae-tag">${escapeHtml(incidentType(incident))}</span></span>
+        <span class="app">${appIcon(incident.service, "")}${escapeHtml(incident.service || "unknown")}</span>
+        <span class="ae-item">${escapeHtml(incident.title || incident.summary || incident.id)}</span>
+        <span class="state">${escapeHtml(incident.escalated_at ? "ESCALATED" : incident.state || "open")}</span>
       </button>
     `;
   }
 
-  function renderIncidentDetail(detail) {
-    if (!state.selectedIncidentId) {
-      return empty("Select an incident.");
+  function renderSheet() {
+    if (!state.selectedSheetId) {
+      closeSheet();
+      return;
     }
-    if (!detail) {
-      return empty("Loading incident detail.");
-    }
-    if (detail.problem) {
-      return `<div class="problem">${escapeHtml(detail.problem)}</div>`;
-    }
-    const incident = detail.incident || {};
-    const claim = detail.action_brief?.current_claim || detail.claims?.find((item) => isActiveClaim(item.state));
-    return `
-      <div>
-        <div class="view-head">
-          <div>
-            <h2 class="view-title">${escapeHtml(incident.title || `${incident.service || "service"} incident`)}</h2>
-            <p class="summary">${escapeHtml(detail.summary || "")}</p>
-          </div>
-          <div class="meta">${escapeHtml(incident.id || "")}</div>
-        </div>
-        <dl class="detail-grid">
-          ${metric("State", incident.state || "unknown")}
-          ${metric("Severity", incident.severity || "unknown")}
-          ${metric("Opened", formatTime(incident.opened_at))}
-          ${metric("Resolution", incident.resolved_at ? formatTime(incident.resolved_at) : "open")}
-        </dl>
-        <div class="detail-columns">
-          <section>
-            <div class="eyebrow">Timeline</div>
-            ${detail.recent_timeline_events?.length ? `<ol class="ae-trail">${detail.recent_timeline_events.map(renderTimelineEvent).join("")}</ol>` : empty("No recent timeline events.")}
-          </section>
-          <section>
-            <div class="eyebrow">Probe evidence</div>
-            ${detail.signals?.length ? detail.signals.map(renderSignal).join("") : empty("No bounded signals returned.")}
-          </section>
-          <section>
-            <div class="eyebrow">Agent activity</div>
-            ${claim || detail.annotations?.length ? `<ol class="ae-trail">${renderClaim(claim)}${detail.annotations?.length ? detail.annotations.map(renderActivity).join("") : ""}</ol>` : empty("No writeback annotations yet.")}
-          </section>
-        </div>
-      </div>
-    `;
+    const incident = incidentFeed().find((item) => item.id === state.selectedSheetId);
+    const detail = state.data.incidentDetails.get(state.selectedSheetId);
+    sheet.innerHTML = sheetMarkup(incident, detail);
+    sheet.classList.add("is-on");
+    scrim.classList.add("is-on");
   }
 
-  function renderTimelineEvent(event) {
-    return `
-      <li class="ae-trail-item">
-        <div class="ae-trail-head">
-          <span class="ae-trail-time">${escapeHtml(formatTime(event.created_at))}</span>
-          <span class="ae-trail-who">${escapeHtml(event.event)}</span>
+  function sheetMarkup(incident, detail) {
+    if (!incident) {
+      return `${sheetClose()}<div class="problem">Incident no longer appears in the current feed.</div>`;
+    }
+    if (detail?.problem) {
+      return `${sheetClose()}<div class="problem">${escapeHtml(detail.problem)}</div>`;
+    }
+    const richIncident = { ...incident, ...(detail?.incident || {}) };
+    const signals = detail?.signals || incident.signals || [];
+    const annotations = detail?.annotations || [];
+    const events = detail?.recent_timeline_events || [];
+    const claim = detail?.action_brief?.current_claim || detail?.claims?.find((item) => isActiveClaim(item.state));
+    return `${sheetClose()}
+      <div class="ae-group sheet-state">
+        <p>${glyph(richIncident.escalated_at || incident.escalated_at ? "err" : "warn")} <span class="ae-strong ae-num">${escapeHtml(richIncident.id || incident.id)}</span></p>
+        <p class="ae-chrome">
+          <span class="ae-tag">${escapeHtml(incidentType(richIncident))}</span>
+          <span class="ae-tag">severity ${escapeHtml(richIncident.severity || "medium")}</span>
+          <span class="ae-tag">${escapeHtml(richIncident.state || "open")}</span>
+          <span class="ae-num">opened ${escapeHtml(formatTime(richIncident.opened_at))} · ${signals.length || richIncident.signal_count || 0} signals · ${richIncident.escalated_at ? `escalated ${formatTime(richIncident.escalated_at)}` : "not escalated"}</span>
+        </p>
+      </div>
+      <div class="ae-group">
+        <div class="ae-plate">
+          <p class="ae-plate-cap">ORIGIN CONTEXT · WHAT CANARY SAW</p>
+          ${signals.length ? signals.map(signalLine).join("") : `<div class="evi">${glyph("warn")}<span>No bounded signals returned for this incident.</span></div>`}
+          <p class="ae-plate-note">${escapeHtml(detail?.summary || richIncident.title || incident.title || "")}</p>
         </div>
-        <div class="ae-trail-body">${escapeHtml(event.summary || "")}</div>
-      </li>
-    `;
+      </div>
+      <div class="ae-group">
+        <p class="ae-h">AGENT WORK LOG</p>
+        ${claim || annotations.length || events.length ? `<ol class="ae-trail">${renderClaim(claim)}${annotations.map(renderAnnotation).join("")}${events.map(renderTimelineEvent).join("")}</ol>` : `<div class="ae-empty"><p>No agent writeback yet.</p><p class="ae-dim">Annotations and claims from the real API render here.</p></div>`}
+      </div>
+      <div class="ae-group">
+        <p class="ae-h">RESOLUTION</p>
+        <p class="ae-dim">${richIncident.resolved_at ? `Resolved ${formatTime(richIncident.resolved_at)}` : "No proof of resolution yet."}</p>
+        <p class="ae-chrome">escalation: ${richIncident.escalated_at ? `live overlay set ${formatTime(richIncident.escalated_at)}` : "not escalated"}</p>
+      </div>`;
   }
 
-  function renderSignal(signal) {
-    const title = signal.summary || signal.error_class || signal.target_name || signal.monitor_name || signal.signal_ref || signal.type;
-    const lines = [
-      ["type", signal.type],
-      ["state", signal.current_state],
-      ["count", signal.total_count],
-      ["target", signal.target_id],
-      ["monitor", signal.monitor_id],
-      ["group", signal.group_hash],
-      ["annotations", signal.annotation_count],
-    ].filter(([_key, value]) => value !== undefined && value !== null && value !== "");
-    return `
-      <div class="signal-row">
-        <div class="strong">${escapeHtml(title || "signal")}</div>
-        <div class="metadata">${escapeHtml(lines.map(([key, value]) => `${key}: ${value}`).join("\n"))}</div>
-      </div>
-    `;
+  function signalLine(signal) {
+    const text = signal.summary || signal.error_class || signal.target_name || signal.monitor_name || signal.signal_ref || signal.type || signal.signal_type || "signal";
+    const right = [
+      signal.total_count ? `count ${signal.total_count}` : "",
+      signal.consecutive_failures ? `${signal.consecutive_failures} consecutive failures` : "",
+      signal.annotation_count != null ? `${signal.annotation_count} annotations` : "",
+    ].filter(Boolean).join(" · ");
+    return `<div class="evi">${glyph(signal.type === "error_group" || signal.signal_type === "error_group" ? "err" : "warn")}<span>${escapeHtml(text)}</span><span class="ae-chrome ae-num" style="margin-left:auto">${escapeHtml(right || formatTime(signal.attached_at))}</span></div>`;
   }
 
   function renderClaim(claim) {
     if (!claim) {
       return "";
     }
-    const lines = [
-      ["claim", claim.id],
-      ["state", claim.state],
-      ["purpose", claim.purpose],
-      ["updated", formatTime(claim.updated_at)],
-    ];
     return `
       <li class="ae-trail-item is-active">
         <div class="ae-trail-head">
-          <span class="ae-trail-time">claim</span>
+          <span class="ae-trail-time">${escapeHtml(formatTime(claim.updated_at))}</span>
           <span class="ae-trail-who">${escapeHtml(claim.owner || "agent")}</span>
         </div>
-        <div class="ae-trail-body metadata">${escapeHtml(lines.map(([key, value]) => `${key}: ${value || "n/a"}`).join("\n"))}</div>
-      </li>
-    `;
+        <div class="ae-trail-body">${escapeHtml(claim.purpose || claim.state || "claimed incident")}</div>
+      </li>`;
   }
 
-  function renderActivity(annotation) {
+  function renderAnnotation(annotation) {
     return `
       <li class="ae-trail-item">
         <div class="ae-trail-head">
@@ -526,183 +533,103 @@
         </div>
         <div class="ae-trail-body">${escapeHtml(annotation.action || "annotated")}</div>
         ${annotation.metadata ? `<div class="metadata">${escapeHtml(JSON.stringify(annotation.metadata, null, 2))}</div>` : ""}
-      </li>
-    `;
+      </li>`;
   }
 
-  function renderChecks() {
-    const targets = healthTargets();
-    const monitors = healthMonitors();
+  function renderTimelineEvent(event) {
     return `
-      <section class="view">
-        <div class="view-head">
-          <div>
-            <h1 class="view-title">Checks and monitors</h1>
-            <p class="summary">Current watched surfaces from Canary health-status.</p>
-          </div>
-          <dl class="metric-strip">
-            ${metric("Targets", targets.length)}
-            ${metric("Monitors", monitors.length)}
-            ${metric("Cadence", state.data.targets || state.data.monitors ? "exact" : "scoped")}
-          </dl>
+      <li class="ae-trail-item">
+        <div class="ae-trail-head">
+          <span class="ae-trail-time">${escapeHtml(formatTime(event.created_at))}</span>
+          <span class="ae-trail-who">${escapeHtml(event.event || "timeline")}</span>
         </div>
-        <div class="checks-layout">
-          <section class="panel">
-            <div class="row-grid table-head">
-              <span>Surface</span><span>State</span><span>Cadence</span><span>Last result</span>
-            </div>
-            ${targets.map(renderTargetRow).join("")}
-            ${monitors.map(renderMonitorRow).join("")}
-            ${!targets.length && !monitors.length ? empty("No watched surfaces returned.") : ""}
-          </section>
-          <section class="panel">
-            <div class="eyebrow">Recent target checks</div>
-            ${renderTargetChecks()}
-          </section>
-        </div>
-      </section>
-    `;
+        <div class="ae-trail-body">${escapeHtml(event.summary || "")}</div>
+      </li>`;
   }
 
-  function renderTargetRow(target) {
-    const config = targetConfig(target.id);
-    return `
-      <button class="select-row" type="button" data-target-id="${escapeHtml(target.id)}">
-        <span class="row-grid">
-          <span><span class="strong">${escapeHtml(target.name)}</span><br><span class="meta">${escapeHtml(target.service)} · ${escapeHtml(target.url)}</span></span>
-          <span class="status-${surfaceState(target.state)}"><span class="status-mark">${statusGlyph(surfaceState(target.state))}</span> ${escapeHtml(target.state)}</span>
-          <span>${escapeHtml(config?.interval_ms ? duration(config.interval_ms) : inferredCadence(target.recent_checks))}</span>
-          <span>${escapeHtml(lastTargetResult(target))}</span>
-        </span>
-      </button>
-    `;
+  function sheetClose() {
+    return `<button class="sheet-x" type="button" data-close aria-label="Close ticket">${iconSvg("i-x")}</button>`;
   }
 
-  function renderMonitorRow(monitor) {
-    const config = monitorConfig(monitor.id);
-    return `
-      <div class="data-row row-grid">
-        <span><span class="strong">${escapeHtml(monitor.name)}</span><br><span class="meta">${escapeHtml(monitor.service)} · ${escapeHtml(monitor.mode)}</span></span>
-        <span class="status-${surfaceState(monitor.state)}"><span class="status-mark">${statusGlyph(surfaceState(monitor.state))}</span> ${escapeHtml(monitor.state)}</span>
-        <span>${escapeHtml(duration(config?.expected_every_ms || monitor.expected_every_ms))}</span>
-        <span>${escapeHtml(monitor.last_check_in_status || "none")}<br><span class="meta">${escapeHtml(formatTime(monitor.last_check_in_at || monitor.deadline_at))}</span></span>
-      </div>
-    `;
+  function closeSheet() {
+    state.selectedSheetId = "";
+    sheet.classList.remove("is-on");
+    scrim.classList.remove("is-on");
+    sheet.innerHTML = "";
   }
 
-  function renderTargetChecks() {
-    const checks = state.data.targetChecks?.checks || [];
-    if (state.data.targetChecks?.problem) {
-      return `<div class="problem">${escapeHtml(state.data.targetChecks.problem)}</div>`;
+  function closeStaleSheet() {
+    if (state.selectedSheetId && !incidentFeed().some((item) => item.id === state.selectedSheetId)) {
+      closeSheet();
     }
-    if (!checks.length) {
-      return empty("No recent target checks returned.");
+  }
+
+  function metrics() {
+    const apps = allApps();
+    return {
+      apps: apps.length,
+      up: apps.filter((app) => app.state === "up").length,
+      down: apps.filter((app) => app.state === "down" || app.state === "degraded").length,
+      incidents: openIncidentCount(),
+      errors: Number(state.data.errors?.total_errors ?? errorTotal(state.data.status?.error_summary || [])),
+    };
+  }
+
+  function visibleApps() {
+    const apps = allApps();
+    if (state.figure === "up") {
+      return apps.filter((app) => app.state === "up");
     }
-    return checks.map((check) => `
-      <div class="data-row">
-        <div class="row-main">
-          <span class="status-mark ${check.result === "success" ? "ok" : "err"}">${check.result === "success" ? "ok" : "x"}</span>
-          <span class="strong">${escapeHtml(check.result || "check")}</span>
-          <span class="meta">${escapeHtml(formatTime(check.checked_at))}</span>
-        </div>
-        <div class="meta">${escapeHtml(check.status_code || "no status")} · ${escapeHtml(check.latency_ms ? `${check.latency_ms}ms` : "no latency")}</div>
-      </div>
-    `).join("");
+    if (state.figure === "down") {
+      return apps.filter((app) => app.state !== "up");
+    }
+    if (state.figure === "incidents") {
+      return apps.filter((app) => app.incidents.length);
+    }
+    if (state.figure === "errors") {
+      return apps.filter((app) => app.errorCount > 0);
+    }
+    return apps;
   }
 
-  function renderErrors() {
-    const errors = state.data.errors;
-    const serviceErrors = state.data.status?.error_summary || [];
-    return `
-      <section class="view">
-        <div class="view-head">
-          <div>
-            <h1 class="view-title">Grouped errors</h1>
-            <p class="summary">${escapeHtml(errors?.summary || state.optional.errorsProblem || "No grouped error response returned.")}</p>
-          </div>
-          <dl class="metric-strip">
-            ${metric("Errors", errors?.total_errors ?? errorTotal(serviceErrors))}
-            ${metric("Classes", errors?.total_error_classes ?? "scoped")}
-            ${metric("Services", serviceErrors.length)}
-          </dl>
-        </div>
-        <div class="errors-layout">
-          <section class="panel">
-            <div class="row-grid table-head">
-              <span>Error class</span><span>Count</span><span>Services</span><span>Window</span>
-            </div>
-            ${errors?.groups?.length ? errors.groups.map((group) => `
-              <div class="data-row row-grid">
-                <span class="strong">${escapeHtml(group.error_class)}</span>
-                <span>${escapeHtml(group.total_count)}</span>
-                <span>${escapeHtml(group.service_count)}</span>
-                <span>${escapeHtml(errors.window || "24h")}</span>
-              </div>
-            `).join("") : empty("No error-class groups returned for this key.")}
-          </section>
-          <section class="panel">
-            <div class="eyebrow">Services with active errors</div>
-            ${serviceErrors.length ? serviceErrors.map((item) => `
-              <div class="data-row">
-                <div class="strong">${escapeHtml(item.service)}</div>
-                <div class="meta">${escapeHtml(item.total_count)} errors across ${escapeHtml(item.unique_classes)} classes</div>
-              </div>
-            `).join("") : empty("No active service errors in the status window.")}
-          </section>
-        </div>
-      </section>
-    `;
-  }
-
-  function serviceRows() {
+  function allApps() {
     const services = new Map();
     for (const target of healthTargets()) {
       const row = ensureService(services, target.service || target.name);
       row.targets.push(target);
       row.lastProbe = latest(row.lastProbe, target.last_checked_at);
       row.states.push(surfaceState(target.state));
-      row.sequences.push(sequence(target.recent_checks));
-      row.checks.push(...(target.recent_checks || []));
+      row.probes.push(...probeGlyphs(target.recent_checks));
     }
     for (const monitor of healthMonitors()) {
       const row = ensureService(services, monitor.service || monitor.name);
       row.monitors.push(monitor);
       row.lastProbe = latest(row.lastProbe, monitor.last_check_in_at || monitor.deadline_at);
       row.states.push(surfaceState(monitor.state));
-      row.sequences.push(monitor.last_check_in_status || "none");
     }
     for (const item of state.data.status?.error_summary || []) {
       const row = ensureService(services, item.service);
       row.errorCount += Number(item.total_count || 0);
       row.errorClasses += Number(item.unique_classes || 0);
     }
-    return [...services.values()].map((row) => {
-      row.state = row.states.includes("down")
-        ? "down"
-        : row.states.includes("degraded") || row.errorCount > 0
-          ? "degraded"
-          : row.states.length
-            ? "up"
-            : "unknown";
-      const totalChecks = row.checks.length;
-      const successes = row.checks.filter((check) => check.result === "success").length;
-      row.uptime = totalChecks ? `${Math.round((successes / totalChecks) * 1000) / 10}%` : "n/a";
-      row.sequence = row.sequences.filter(Boolean).join("  ") || "no recent checks";
-      row.surfaceSummary = `${row.targets.length} targets · ${row.monitors.length} monitors · ${row.errorCount} errors`;
-      return row;
-    }).sort((a, b) => stateWeight(a.state) - stateWeight(b.state) || a.service.localeCompare(b.service));
+    for (const incident of incidentFeed()) {
+      const row = ensureService(services, incident.service || "unknown");
+      row.incidents.push(incident);
+    }
+    return [...services.values()].map(finalizeService).sort((a, b) => stateWeight(a.state) - stateWeight(b.state) || a.name.localeCompare(b.name));
   }
 
   function ensureService(map, service) {
-    const key = service || "unknown";
+    const key = String(service || "unknown");
     if (!map.has(key)) {
       map.set(key, {
-        service: key,
+        key,
+        name: key,
         targets: [],
         monitors: [],
         states: [],
-        checks: [],
-        sequences: [],
+        probes: [],
+        incidents: [],
         errorCount: 0,
         errorClasses: 0,
         lastProbe: "",
@@ -711,33 +638,68 @@
     return map.get(key);
   }
 
-  function incidentChoices() {
-    const active = (state.data.incidents?.incidents || []).map((incident) => ({ ...incident, source: "open" }));
-    const known = new Set(active.map((incident) => incident.id));
-    const history = incidentHistory().filter((incident) => !known.has(incident.id));
-    return active.concat(history);
+  function finalizeService(row) {
+    row.state = row.states.includes("down")
+      ? "down"
+      : row.states.includes("degraded") || row.errorCount > 0 || row.incidents.some((incident) => incident.severity === "high")
+        ? "degraded"
+        : row.states.length
+          ? "up"
+          : "unknown";
+    const targetChecks = row.targets.flatMap((target) => target.recent_checks || []);
+    const successes = targetChecks.filter((check) => check.result === "success").length;
+    row.uptime = targetChecks.length ? `${Math.round((successes / targetChecks.length) * 1000) / 10}%` : "n/a";
+    row.glyph = row.state === "up" ? "ok" : row.state === "down" ? "err" : "warn";
+    row.probes = row.probes.slice(-5);
+    row.meta = `${row.targets.length} targets · ${row.monitors.length} monitors · ${row.errorCount} errors 24h`;
+    return row;
   }
 
-  function incidentHistory() {
-    const rows = [];
-    const seen = new Set();
+  function incidentFeed() {
+    const active = (state.data.incidents?.incidents || []).map((incident) => ({ ...incident, source: "open" }));
+    const known = new Set(active.map((incident) => incident.id));
+    const history = [];
+    const escalations = escalationMap();
     for (const event of state.data.timeline?.events || []) {
-      if (event.entity_type !== "incident" || !event.entity_ref || seen.has(event.entity_ref)) {
+      if (event.entity_type !== "incident" || !event.entity_ref || known.has(event.entity_ref)) {
         continue;
       }
-      seen.add(event.entity_ref);
-      rows.push({
+      history.push({
         id: event.entity_ref,
         service: event.service,
-        state: event.event.replace("incident.", ""),
+        state: event.event?.replace("incident.", "") || "event",
         severity: event.severity || "medium",
         title: event.summary,
         opened_at: event.created_at,
         created_at: event.created_at,
         source: "history",
       });
+      known.add(event.entity_ref);
     }
-    return rows;
+    return active.concat(history).map((incident) => {
+      const detail = state.data.incidentDetails.get(incident.id);
+      return { ...incident, escalated_at: incident.escalated_at || detail?.incident?.escalated_at || detail?.escalated_at || escalations.get(incident.id) || null };
+    });
+  }
+
+  function escalationMap() {
+    const map = new Map();
+    const events = [...(state.data.timeline?.events || [])].sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+    for (const event of events) {
+      if (event.entity_type !== "incident" || !event.entity_ref) {
+        continue;
+      }
+      if (event.event === "incident.escalated") {
+        map.set(event.entity_ref, event.created_at);
+      } else if (event.event === "incident.deescalated" || event.event === "incident.resolved") {
+        map.delete(event.entity_ref);
+      }
+    }
+    return map;
+  }
+
+  function openIncidentCount() {
+    return state.data.incidents?.incidents?.length || 0;
   }
 
   function healthTargets() {
@@ -748,23 +710,8 @@
     return state.data.health?.monitors || [];
   }
 
-  function targetConfig(id) {
-    return (state.data.targets?.targets || []).find((target) => target.id === id);
-  }
-
-  function monitorConfig(id) {
-    return (state.data.monitors?.monitors || []).find((monitor) => monitor.id === id);
-  }
-
-  function countServiceStates(rows) {
-    return rows.reduce((acc, row) => {
-      acc[row.state] = (acc[row.state] || 0) + 1;
-      return acc;
-    }, { up: 0, degraded: 0, down: 0, unknown: 0 });
-  }
-
-  function stateWeight(value) {
-    return { down: 0, degraded: 1, unknown: 2, up: 3 }[value] ?? 4;
+  function probeGlyphs(checks) {
+    return (checks || []).slice(0, 5).reverse().map((check) => check.result === "success" ? "ok" : "err");
   }
 
   function surfaceState(value) {
@@ -780,44 +727,18 @@
     return "unknown";
   }
 
-  function statusGlyph(value) {
-    if (value === "up") {
-      return "ok";
-    }
-    if (value === "down") {
-      return "x";
-    }
-    if (value === "degraded") {
-      return "!";
-    }
-    return "-";
+  function stateWeight(value) {
+    return { down: 0, degraded: 1, unknown: 2, up: 3 }[value] ?? 4;
   }
 
-  function sequence(checks) {
-    if (!checks || !checks.length) {
-      return "";
+  function incidentType(incident) {
+    if (incident.signals?.some((signal) => signal.signal_type === "error_group" || signal.type === "error_group")) {
+      return "error";
     }
-    return checks.slice(0, 8).map((check) => check.result === "success" ? "ok" : "x").join(" ");
-  }
-
-  function lastTargetResult(target) {
-    const latestCheck = target.recent_checks?.[0];
-    if (!latestCheck) {
-      return target.last_checked_at ? `checked ${formatTime(target.last_checked_at)}` : "none";
+    if (incident.signals?.some((signal) => signal.signal_type === "health_transition" || signal.type === "health_transition")) {
+      return "health";
     }
-    return `${latestCheck.result || "check"} ${formatTime(latestCheck.checked_at)}`;
-  }
-
-  function inferredCadence(checks) {
-    if (!checks || checks.length < 2) {
-      return "scoped";
-    }
-    const first = Date.parse(checks[0].checked_at);
-    const second = Date.parse(checks[1].checked_at);
-    if (!Number.isFinite(first) || !Number.isFinite(second)) {
-      return "scoped";
-    }
-    return duration(Math.abs(first - second));
+    return incident.source === "history" ? "event" : "incident";
   }
 
   function latest(left, right) {
@@ -830,20 +751,54 @@
     return Date.parse(right) > Date.parse(left) ? right : left;
   }
 
-  function duration(ms) {
-    const value = Number(ms || 0);
-    if (!value) {
-      return "n/a";
+  function errorTotal(items) {
+    return items.reduce((total, item) => total + Number(item.total_count || 0), 0);
+  }
+
+  function incidentLabel(count) {
+    if (!count) {
+      return "0 open incidents";
     }
-    const seconds = Math.round(value / 1000);
-    if (seconds < 60) {
-      return `${seconds}s`;
+    return `${count} open incident${count === 1 ? "" : "s"}`;
+  }
+
+  function streamLabel(count) {
+    if (!count) {
+      return "0 incidents";
     }
-    const minutes = Math.round(seconds / 60);
-    if (minutes < 60) {
-      return `${minutes}m`;
+    return `${count} incident${count === 1 ? "" : "s"}`;
+  }
+
+  function isActiveClaim(value) {
+    return ["claimed", "investigating", "fix_proposed", "verified"].includes(value);
+  }
+
+  function trail5(probes, label) {
+    return `<span class="trail5" role="img" aria-label="${escapeHtml(label)}">${probes.map(glyph).join("")}</span>`;
+  }
+
+  function glyph(kind) {
+    if (kind === "ok") {
+      return iconSvg("i-check", "ae-ok");
     }
-    return `${Math.round(minutes / 60)}h`;
+    if (kind === "err") {
+      return iconSvg("i-x", "ae-err");
+    }
+    return iconSvg("i-alert", "ae-warn");
+  }
+
+  function appIcon(name, cls = "") {
+    const normalized = String(name || "").toLowerCase();
+    const icon = APP_ICONS.find(([needle]) => normalized.includes(needle))?.[1] || "i-dot";
+    return iconSvg(icon, cls);
+  }
+
+  function iconSvg(id, cls = "") {
+    return `<svg class="ae-icon ${escapeHtml(cls)}" aria-hidden="true"><use href="#${escapeHtml(id)}"></use></svg>`;
+  }
+
+  function empty(message) {
+    return `<div class="empty">${escapeHtml(message)}</div>`;
   }
 
   function formatTime(value) {
@@ -860,28 +815,6 @@
       second: "2-digit",
       hour12: false,
     }).format(date);
-  }
-
-  function errorTotal(items) {
-    return items.reduce((total, item) => total + Number(item.total_count || 0), 0);
-  }
-
-  function isActiveClaim(value) {
-    return ["claimed", "investigating", "fix_proposed", "verified"].includes(value);
-  }
-
-  function metric(label, value) {
-    return `<div class="metric"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`;
-  }
-
-  function empty(message) {
-    return `<div class="empty">${escapeHtml(message)}</div>`;
-  }
-
-  function showError(error) {
-    state.error = error.message;
-    state.loading = false;
-    render();
   }
 
   function escapeHtml(value) {

--- a/crates/canary-server/static/dashboard/dashboard.css
+++ b/crates/canary-server/static/dashboard/dashboard.css
@@ -1,6 +1,4 @@
 :root {
-  /* accent steering deferred to the Fable design-catalogue pass —
-     kit default (unchanged) until that direction lands */
   --ae-accent: #2643d0;
   --ae-accent-dark: #8c9eff;
 }
@@ -16,6 +14,10 @@ input {
 
 button {
   border-radius: 0;
+}
+
+.icon-defs {
+  display: none;
 }
 
 .canary-shell {
@@ -49,15 +51,6 @@ button {
   padding-right: var(--ae-space-6);
 }
 
-.brand {
-  font-weight: var(--ae-w-black);
-  letter-spacing: 0;
-}
-
-.canary-nav {
-  gap: var(--ae-space-5);
-}
-
 .session-form {
   display: grid;
   grid-template-columns: auto minmax(9rem, 1fr) auto auto;
@@ -81,8 +74,7 @@ button {
 }
 
 .session-form button,
-.canary-status button,
-.action-button {
+.canary-status button {
   border: 1px solid var(--ae-ink);
   background: var(--ae-ink);
   color: var(--ae-surface);
@@ -93,225 +85,321 @@ button {
 }
 
 .session-form button[type='button'],
-.canary-status button,
-.action-button.secondary {
+.canary-status button {
   background: transparent;
   color: var(--ae-ink);
 }
 
 .canary-main {
   min-height: 0;
-  overflow: auto;
-  padding: var(--ae-space-6);
+  overflow: hidden;
+  padding: var(--ae-space-6) 0 0;
 }
 
 .view {
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   animation: ae-enter var(--ae-soft) var(--ae-ease) both;
 }
 
-.view-head {
+.figures {
+  width: min(var(--ae-measure-wide), 100% - 5rem);
+  margin-inline: auto;
   display: grid;
-  grid-template-columns: minmax(18rem, 1fr) auto;
-  align-items: start;
-  gap: var(--ae-space-6);
-  margin-bottom: var(--ae-space-6);
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  border: 1px solid var(--ae-line);
+  margin-bottom: 0;
 }
 
-.view-title {
+.figure {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1em;
+  background: transparent;
+  border: 0;
+  border-left: 1px solid var(--ae-line);
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
+  color: var(--ae-ink);
+  padding: 1em 1.4em 0.9em;
+  cursor: pointer;
+  transition: background-color var(--ae-quick) var(--ae-ease);
+}
+
+.figure:first-child {
+  border-left: 0;
+}
+
+.figure:hover,
+.figure[aria-pressed='true'] {
+  background: var(--ae-wash);
+}
+
+.figure[aria-pressed='true'] {
+  box-shadow: inset 0 2px 0 var(--ae-ink);
+}
+
+.figure-label,
+.inc-head,
+.inc .state,
+.ae-h {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--ae-ink-muted);
+}
+
+.figure-val {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
   font-weight: var(--ae-w-black);
 }
 
-.summary {
-  color: var(--ae-ink-muted);
-  max-width: var(--ae-measure-wide);
+.figure-val .ae-icon {
+  width: 1em;
+  height: 1em;
+  flex: none;
 }
 
-.metric-strip {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+.split {
+  flex: 1;
+  min-height: 0;
+  width: min(var(--ae-measure-wide), 100% - 5rem);
+  margin-inline: auto;
+  display: grid;
+  grid-template-columns: 23rem minmax(0, 1fr);
+  border: 1px solid var(--ae-line);
+  border-top: 0;
+}
+
+.master {
+  border-right: 1px solid var(--ae-line);
+  overflow-y: auto;
+  padding: var(--ae-space-5) var(--ae-space-4) var(--ae-space-5) 0;
+}
+
+.detail {
+  min-width: 0;
+  overflow-y: auto;
+  padding: var(--ae-space-5) var(--ae-space-5) var(--ae-space-6) var(--ae-space-6);
+}
+
+.dest {
+  display: grid;
+  grid-template-columns: 1.35em minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: var(--ae-space-3);
+  width: 100%;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
+  color: var(--ae-ink);
+  padding: 0.55em var(--ae-space-3);
+  cursor: pointer;
+  transition: background-color var(--ae-quick) var(--ae-ease);
+}
+
+.dest:hover,
+.dest[aria-selected='true'] {
+  background: var(--ae-wash);
+}
+
+.dest[aria-selected='true'] {
+  box-shadow: inset 2px 0 0 var(--ae-ink);
+}
+
+.dest .logo {
+  width: 1.15em;
+  height: 1.15em;
+  flex: none;
+  color: var(--ae-ink-muted);
+}
+
+.dest[aria-selected='true'] .logo {
+  color: var(--ae-ink);
+}
+
+.dest .fig {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55em;
+  font-family: var(--ae-font-mono);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ae-ink-muted);
+  padding-left: var(--ae-space-3);
+}
+
+.dest .fig .ae-icon {
+  width: 0.95em;
+  height: 0.95em;
+}
+
+.dest .sub {
+  grid-column: 2 / 4;
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+  overflow-wrap: anywhere;
+}
+
+.master .ae-h {
+  padding-left: var(--ae-space-3);
+  margin-top: var(--ae-space-5);
+}
+
+.master .ae-h:first-child {
+  margin-top: 0;
+}
+
+.ae-view {
+  display: grid;
   gap: var(--ae-space-5);
 }
 
-.metric {
-  min-width: 7rem;
-  text-align: right;
-}
-
-.metric dt,
-.eyebrow,
-.meta,
-.row-label,
-.empty,
-.problem,
-.tag {
-  font-size: 13px;
-  color: var(--ae-ink-muted);
-}
-
-.metric dd,
-.strong {
-  font-weight: var(--ae-w-black);
-}
-
-.panel {
+.ae-group {
   border-top: 1px solid var(--ae-line);
   padding-top: var(--ae-space-4);
 }
 
-.panel + .panel {
-  margin-top: var(--ae-space-6);
+.ae-group:first-child {
+  border-top: 0;
+  padding-top: 0;
 }
 
-.wall,
-.split,
-.checks-layout,
-.incident-layout,
-.errors-layout {
+.inc-head,
+.inc {
   display: grid;
-  gap: var(--ae-space-6);
-}
-
-.wall {
-  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
-}
-
-.split {
-  grid-template-columns: minmax(18rem, 0.85fr) minmax(28rem, 1.4fr);
-}
-
-.checks-layout {
-  grid-template-columns: minmax(24rem, 1fr) minmax(20rem, 0.9fr);
-}
-
-.incident-layout {
-  grid-template-columns: minmax(16rem, 0.45fr) minmax(42rem, 1.7fr);
-}
-
-.errors-layout {
-  grid-template-columns: minmax(26rem, 1.2fr) minmax(18rem, 0.8fr);
-}
-
-.service-row,
-.data-row,
-.incident-row,
-.signal-row {
-  border-bottom: 1px solid var(--ae-line);
-  padding: var(--ae-space-3) 0;
-}
-
-.service-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: var(--ae-space-4);
-}
-
-.row-main {
-  display: flex;
-  flex-wrap: wrap;
+  grid-template-columns: 1.35em 3.7em 6.8em 10rem minmax(0, 1fr) auto;
   align-items: baseline;
-  gap: var(--ae-space-2) var(--ae-space-4);
+  column-gap: var(--ae-space-3);
 }
 
-.row-grid {
-  display: grid;
-  grid-template-columns: minmax(10rem, 1fr) minmax(7rem, 0.6fr) minmax(9rem, 0.8fr) minmax(8rem, 0.6fr);
-  gap: var(--ae-space-4);
-  align-items: start;
+.inc-head {
+  padding: 0 var(--ae-space-2) 0.5em;
 }
 
-.table-head {
-  color: var(--ae-ink-muted);
+.inc {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--ae-line);
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
+  color: var(--ae-ink);
+  padding: 0.65em var(--ae-space-2);
+  cursor: pointer;
+  transition: background-color var(--ae-quick) var(--ae-ease);
+}
+
+.inc:last-of-type {
+  border-bottom: 1px solid var(--ae-line);
+}
+
+.inc:hover {
+  background: var(--ae-wash);
+}
+
+.inc.is-escalated {
+  box-shadow: inset 3px 0 0 var(--ae-err);
+}
+
+.inc .glyph {
+  align-self: center;
+}
+
+.inc .t {
+  font-family: var(--ae-font-mono);
   font-size: 13px;
-  font-family: var(--ae-font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--ae-ink-muted);
 }
 
-.status-mark {
-  font-family: var(--ae-font-mono);
-  font-weight: var(--ae-w-black);
+.inc .app {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  min-width: 0;
+  font-size: 13px;
+  color: var(--ae-ink-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.status-up .status-mark,
-.ok {
-  color: var(--ae-ok);
+.inc .app .ae-icon {
+  width: 1em;
+  height: 1em;
+  flex: none;
 }
 
-.status-degraded .status-mark,
-.warn {
-  color: var(--ae-warn);
+.apphead {
+  display: flex;
+  align-items: center;
+  gap: var(--ae-space-3);
+  flex-wrap: wrap;
 }
 
-.status-down .status-mark,
-.err {
+.apphead .ae-icon {
+  width: 1.4em;
+  height: 1.4em;
+}
+
+.trail5 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  vertical-align: -0.1em;
+}
+
+.trail5 .ae-icon {
+  width: 0.95em;
+  height: 0.95em;
+}
+
+.evi {
+  display: flex;
+  align-items: baseline;
+  gap: var(--ae-space-3);
+  padding: 0.45em 0;
+}
+
+.evi + .evi {
+  border-top: 1px solid var(--ae-line);
+}
+
+.evi .ae-icon {
+  flex: none;
+  width: 1em;
+  height: 1em;
+  align-self: center;
+}
+
+.meta,
+.empty,
+.problem,
+.ae-dim,
+.ae-chrome {
+  color: var(--ae-ink-muted);
+}
+
+.problem {
+  border-top: 1px solid var(--ae-line);
+  border-bottom: 1px solid var(--ae-line);
+  padding: var(--ae-space-4) 0;
   color: var(--ae-err);
 }
 
-.status-unknown .status-mark {
-  color: var(--ae-ink-faint);
-}
-
-.mini-sequence {
-  font-family: var(--ae-font-mono);
-  color: var(--ae-ink-muted);
-  white-space: nowrap;
-}
-
-.select-row {
-  width: 100%;
-  display: block;
-  text-align: left;
-  background: transparent;
-  color: inherit;
-  border: 0;
-  border-bottom: 1px solid var(--ae-line);
-  padding: var(--ae-space-3) 0;
-  cursor: pointer;
-}
-
-.select-row:hover,
-.select-row.is-selected {
-  color: var(--ae-accent);
-}
-
-.detail-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(8rem, 1fr));
-  gap: var(--ae-space-5);
+.empty,
+.ae-empty {
   border-top: 1px solid var(--ae-line);
-  border-bottom: 1px solid var(--ae-line);
-  padding-block: var(--ae-space-4);
-  margin-bottom: var(--ae-space-5);
-}
-
-.detail-grid dt {
-  font-size: 13px;
-  color: var(--ae-ink-muted);
-}
-
-.detail-columns {
-  display: grid;
-  grid-template-columns: minmax(16rem, 0.9fr) minmax(20rem, 1.05fr) minmax(17rem, 0.95fr);
-  gap: var(--ae-space-4);
-}
-
-.detail-columns > *,
-.row-grid > *,
-.service-row > *,
-.signal-row > * {
-  min-width: 0;
-}
-
-.strong,
-.summary,
-.meta,
-.signal-row {
-  overflow-wrap: anywhere;
-}
-
-.ae-trail-body,
-.ae-trail-who {
-  overflow-wrap: anywhere;
+  padding-top: var(--ae-space-4);
 }
 
 .metadata {
@@ -325,30 +413,74 @@ button {
   overflow-wrap: anywhere;
 }
 
-.code-block {
-  border: 1px solid var(--ae-line);
-  padding: var(--ae-space-4);
-  font-family: var(--ae-font-mono);
-  font-size: 13px;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.18);
+  z-index: var(--ae-z-toast);
+  display: none;
+}
+
+.scrim.is-on {
+  display: block;
+}
+
+.sheet {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(42rem, 92vw);
+  background: var(--ae-surface);
+  border-left: 1px solid var(--ae-line);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 12px 36px rgba(0, 0, 0, 0.09);
+  z-index: calc(var(--ae-z-toast) + 1);
+  overflow-y: auto;
+  padding: var(--ae-space-6);
+  transform: translateX(102%);
+  transition: transform var(--ae-soft) var(--ae-ease);
+  visibility: hidden;
+}
+
+.sheet.is-on {
+  transform: none;
+  visibility: visible;
+}
+
+.dark .sheet,
+[data-ae-mode='dark'] .sheet {
+  background: var(--ae-wash);
+  box-shadow: none;
+}
+
+.sheet-x {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  background: transparent;
+  border: 0;
+  padding: 0.3em;
+  min-width: 32px;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--ae-ink-muted);
+  cursor: pointer;
+  transition: color var(--ae-quick) var(--ae-ease);
 }
 
-.hidden {
-  display: none !important;
+.sheet-x:hover {
+  color: var(--ae-ink);
 }
 
-.problem {
-  border-top: 1px solid var(--ae-line);
-  border-bottom: 1px solid var(--ae-line);
-  padding: var(--ae-space-4) 0;
-  color: var(--ae-err);
+.sheet-x .ae-icon {
+  width: 1.1em;
+  height: 1.1em;
 }
 
-.empty {
-  border-top: 1px solid var(--ae-line);
-  padding-top: var(--ae-space-4);
+.sheet-state {
+  padding-right: 2.5rem;
 }
 
 @media (max-width: 1080px) {
@@ -361,18 +493,14 @@ button {
     justify-self: stretch;
   }
 
-  .split,
-  .checks-layout,
-  .incident-layout,
-  .errors-layout,
-  .detail-columns {
-    grid-template-columns: 1fr;
+  .figures,
+  .split {
+    width: calc(100% - 2.4rem);
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 760px) {
   .canary-topbar,
-  .canary-main,
   .canary-status {
     padding-inline: var(--ae-space-4);
   }
@@ -386,31 +514,46 @@ button {
     padding-right: 0;
   }
 
-  .canary-nav {
-    grid-column: 1 / -1;
-    overflow-x: auto;
-    padding-bottom: var(--ae-space-1);
-  }
-
-  .session-form {
-    grid-template-columns: 1fr;
-  }
-
-  .view-head,
-  .detail-grid,
-  .row-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .metric-strip {
-    justify-content: flex-start;
-  }
-
-  .metric {
-    text-align: left;
-  }
-
+  .session-form,
   .canary-status {
     grid-template-columns: 1fr;
+  }
+
+  .figure {
+    border-left: 0;
+    border-top: 1px solid var(--ae-line);
+  }
+
+  .figure:first-child {
+    border-top: 0;
+  }
+
+  .split {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .master {
+    border-right: 0;
+    border-bottom: 1px solid var(--ae-line);
+    padding-right: 0;
+    max-height: 30dvh;
+  }
+
+  .detail {
+    padding-left: var(--ae-space-3);
+  }
+
+  .inc-head {
+    display: none;
+  }
+
+  .inc {
+    grid-template-columns: 1.35em 3.7em minmax(0, 1fr) auto;
+  }
+
+  .inc .type,
+  .inc .app {
+    display: none;
   }
 }

--- a/crates/canary-server/static/dashboard/index.html
+++ b/crates/canary-server/static/dashboard/index.html
@@ -21,17 +21,34 @@
     <script defer src="/ui/app.js"></script>
   </head>
   <body>
+    <svg class="icon-defs" aria-hidden="true">
+      <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></symbol>
+      <symbol id="i-alert" viewBox="0 0 24 24"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 20h16a2 2 0 0 0 1.73-2Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></symbol>
+      <symbol id="i-bird" viewBox="0 0 24 24"><path d="M16 7h.01"/><path d="M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20"/><path d="m20 7 2 .5-2 .5"/><path d="M10 18v3"/><path d="M14 17.75V21"/><path d="M7 18a6 6 0 0 0 3.84-10.61"/></symbol>
+      <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+      <symbol id="i-dot" viewBox="0 0 24 24"><circle cx="12" cy="12" r="2.5"/></symbol>
+      <symbol id="i-eye" viewBox="0 0 24 24"><path d="M2.06 12.35a1 1 0 0 1 0-.7A10.75 10.75 0 0 1 12 5a10.75 10.75 0 0 1 9.94 6.65 1 1 0 0 1 0 .7A10.75 10.75 0 0 1 12 19a10.75 10.75 0 0 1-9.94-6.65Z"/><circle cx="12" cy="12" r="3"/></symbol>
+      <symbol id="i-flask-conical" viewBox="0 0 24 24"><path d="M10 2v7.31"/><path d="M14 9.3V2"/><path d="M8.5 2h7"/><path d="M14 9.3a6.5 6.5 0 1 1-4 0"/><path d="M5.58 16h12.85"/></symbol>
+      <symbol id="i-flower" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 16.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 1 1 12 7.5a4.5 4.5 0 1 1 4.5 4.5 4.5 4.5 0 1 1-4.5 4.5"/><path d="M12 7.5V9"/><path d="M7.5 12H9"/><path d="M16.5 12H15"/><path d="M12 16.5V15"/></symbol>
+      <symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></symbol>
+      <symbol id="i-inbox" viewBox="0 0 24 24"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11Z"/></symbol>
+      <symbol id="i-kanban" viewBox="0 0 24 24"><path d="M6 5v11"/><path d="M12 5v6"/><path d="M18 5v14"/><rect width="18" height="18" x="3" y="3" rx="2"/></symbol>
+      <symbol id="i-layers" viewBox="0 0 24 24"><path d="m12.83 2.18 8.89 4.44a1 1 0 0 1 0 1.79l-8.89 4.44a1.86 1.86 0 0 1-1.66 0L2.28 8.41a1 1 0 0 1 0-1.79l8.89-4.44a1.86 1.86 0 0 1 1.66 0Z"/><path d="m22 12.5-9.17 4.59a1.86 1.86 0 0 1-1.66 0L2 12.5"/><path d="m22 17.5-9.17 4.59a1.86 1.86 0 0 1-1.66 0L2 17.5"/></symbol>
+      <symbol id="i-milestone" viewBox="0 0 24 24"><path d="M12 13v8"/><path d="M12 3v3"/><path d="M3 6h18l-4 4 4 4H3l4-4Z"/></symbol>
+      <symbol id="i-moon" viewBox="0 0 24 24"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></symbol>
+      <symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></symbol>
+      <symbol id="i-toolbox" viewBox="0 0 24 24"><path d="M10 6V5a2 2 0 0 1 2-2h0a2 2 0 0 1 2 2v1"/><path d="M10 14h4"/><path d="M5 6h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2Z"/></symbol>
+      <symbol id="i-x" viewBox="0 0 24 24"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></symbol>
+      <symbol id="i-zap" viewBox="0 0 24 24"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></symbol>
+    </svg>
+
     <div class="canary-shell" data-canary-dashboard>
       <header class="canary-topbar">
-        <div class="brand-block" aria-label="Canary">
-          <div class="brand">CANARY</div>
-        </div>
-        <nav class="canary-nav ae-nav" aria-label="Dashboard views">
-          <button type="button" data-view="health" aria-current="page">Health</button>
-          <button type="button" data-view="incidents">Incidents</button>
-          <button type="button" data-view="checks">Checks</button>
-          <button type="button" data-view="errors">Errors</button>
-        </nav>
+        <span class="ae-logo brand-block">
+          <span class="ae-app-mark"><svg class="ae-icon" aria-hidden="true"><use href="#i-bird"/></svg></span>
+          <span class="ae-name">CANARY</span>
+        </span>
+        <span class="ae-chrome ae-num" id="connection-status">No session key</span>
         <form class="session-form" id="session-form">
           <label for="api-key">Bearer key</label>
           <input id="api-key" name="api-key" type="password" autocomplete="off" spellcheck="false" placeholder="paste bearer key">
@@ -39,23 +56,21 @@
           <button type="button" id="clear-key">Clear</button>
         </form>
         <button class="ae-mode" id="mode-toggle" type="button" aria-label="Toggle color mode">
-          <svg class="ae-icon ae-sun" viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="4"></circle>
-            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
-          </svg>
-          <svg class="ae-icon ae-moon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"></path>
-          </svg>
+          <svg class="ae-icon ae-sun" aria-hidden="true"><use href="#i-sun"/></svg>
+          <svg class="ae-icon ae-moon" aria-hidden="true"><use href="#i-moon"/></svg>
         </button>
       </header>
 
       <main class="canary-main" id="view-root" tabindex="-1"></main>
 
       <footer class="canary-status ae-chrome">
-        <span id="connection-status">No session key</span>
         <span id="last-refresh">Not refreshed</span>
+        <span>squares filter the ledger · click a row for the work trail</span>
         <button type="button" id="refresh">Refresh</button>
       </footer>
     </div>
+
+    <div class="scrim" id="scrim"></div>
+    <aside class="sheet" id="sheet" role="dialog" aria-modal="true" aria-label="Incident ticket"></aside>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- replaces the existing `/ui` dashboard with the r3 v02 metric-squares-forward master/detail shell
- binds the shell to live Canary API reads: status, health, incidents, details, timeline, query summaries, targets, and monitors
- renders All Incidents plus per-app streams, designed metric squares, decomposed incident rows, Lucide-style app marks, escalation overlays, annotation work logs, and click-away/closeable incident sheets
- preserves the public shell + bearer-read auth story and both light/dark themes

## Verification

- `node --check crates/canary-server/static/dashboard/app.js`
- `cargo test -p canary-server dashboard --locked`
- `./bin/validate --fast`
- `./bin/validate`
- pre-push `./bin/validate --strict` hook passed
- Browser QA against local disposable Canary DB at `/ui` with real API-seeded apps/incidents/annotations/escalation:
  - DOM proof: escalation visible, metric squares rendered, annotation trail rendered
  - screenshots: `/Users/phaedrus/artifacts/public/a/showcase/canary/ui-v2/local-light.png`, `/Users/phaedrus/artifacts/public/a/showcase/canary/ui-v2/local-dark.png`, `/Users/phaedrus/artifacts/public/a/showcase/canary/ui-v2/local-sheet.png`
  - feed post draft: `/Users/phaedrus/artifacts/public/a/showcase/canary/ui-v2/feed-post.md`

## Notes

Pre-existing local doc/backlog changes were preserved and are not part of this PR: `AGENTS.md`, `CLAUDE.md`, `backlog.d/070-adopt-lucide-bird-as-the-canary-wordmark-icon.md`.

Agent: codex-implementer
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: canary-ship r3 v02 metric squares forward
