### PR TITLE
chore(release): send Landmark webhook to Weave receiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,6 @@ jobs:
           synthesis: "true"
           synthesis-required: "false"
           healthcheck: "true"
+          webhook-url: ${{ secrets.LANDMARK_WEBHOOK_URL }}
+          webhook-secret: ${{ secrets.LANDMARK_WEBHOOK_SECRET }}
           product-description: "Canary is a self-hosted, agent-first production health ledger for errors, uptime, incidents, timelines, webhooks, and remediation claims."


### PR DESCRIPTION
## Summary

Wires Canary's primary Landmark release workflow to the shared Weave release-event receiver.

The workflow now passes:

- `webhook-url: ${{ secrets.LANDMARK_WEBHOOK_URL }}`
- `webhook-secret: ${{ secrets.LANDMARK_WEBHOOK_SECRET }}`

Secrets have already been set on `misty-step/canary`; values are intentionally not included here. I chose `.github/workflows/release.yml` rather than the release-published synthesis workflow to avoid duplicate release-event posts from a normal Canary release.

## Validation

- `./bin/validate`
- pre-push `dagger call strict` hook during `git push`

No release was cut for this test; receiver behavior was verified with a synthetic signed POST against the deployed Weave app.
