### PR TITLE
fix(ci): isolate Dagger Rust target cache by checkout

### DIFF
--- a/bin/dagger
+++ b/bin/dagger
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SELF_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
 TRANSPORT="${CANARY_DAGGER_DOCKER_TRANSPORT:-auto}"
+CANARY_DAGGER_CACHE_SCOPE="${CANARY_DAGGER_CACHE_SCOPE:-$(cd "$ROOT" && pwd -P)}"
+export CANARY_DAGGER_CACHE_SCOPE
 
 . "$ROOT/bin/lib/docker_probe.sh"
 

--- a/dagger/scripts/ci_contract_validation.py
+++ b/dagger/scripts/ci_contract_validation.py
@@ -30,6 +30,7 @@ root = workspace_root()
 workflow = read_required_text(root / ".github/workflows/ci.yml", "GitHub workflow")
 dagger_source = read_required_text(root / "dagger/src/index.ts", "Dagger source")
 dagger_config = read_required_text(root / "dagger.json", "Dagger config")
+dagger_wrapper = read_required_text(root / "bin/dagger", "Dagger wrapper")
 source_argument_sync = root / "dagger/scripts/sync_source_arguments.py"
 real_path = os.environ.get("PATH", "")
 real_bash = shutil.which("bash", path=real_path) or "/bin/bash"
@@ -726,8 +727,29 @@ require(
     "Each Dagger dependency container must compute a platform cache key once",
 )
 require(
-    dagger_source.count("platformKey, imageKey, digest") == 4,
-    "Every Dagger cache volume must scope its key by platform, image, and lockfile digest",
+    dagger_source.count("platformKey, imageKey, digest") == 3,
+    "Every Dagger dependency cache volume must scope its key by platform, image, and lockfile digest",
+)
+require(
+    "async function sourceTreeDigest(source: Directory)" in dagger_source
+    and "return source.digest()" in dagger_source,
+    "dagger/src/index.ts must derive a full source-tree digest for source-sensitive cache fallback",
+)
+require(
+    'process.env.CANARY_DAGGER_CACHE_SCOPE?.trim()' in dagger_source
+    and 'createHash("sha256").update(scope).digest("hex")' in dagger_source
+    and "return sourceTreeDigest(source)" in dagger_source,
+    "dagger/src/index.ts must prefer a hashed checkout cache scope and fall back to source-tree digest",
+)
+require(
+    "const targetDigest = await rustTargetCacheDigest(source)" in dagger_source
+    and 'cacheVolumeName("canary-rust-target", platformKey, imageKey, targetDigest)' in dagger_source,
+    "Dagger must scope the Rust target cache by checkout/source identity to isolate concurrent divergent worktrees",
+)
+require(
+    'CANARY_DAGGER_CACHE_SCOPE="${CANARY_DAGGER_CACHE_SCOPE:-$(cd "$ROOT" && pwd -P)}"' in dagger_wrapper
+    and "export CANARY_DAGGER_CACHE_SCOPE" in dagger_wrapper,
+    "bin/dagger must provide a physical checkout path cache scope for local Dagger invocations",
 )
 require(
     "async function rustContainer(source: Directory)" in dagger_source

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -15,6 +15,7 @@ import {
   check,
   argument,
 } from "@dagger.io/dagger"
+import { createHash } from "node:crypto"
 
 const NODE_IMAGE =
   "node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94"
@@ -95,6 +96,20 @@ async function lockfileDigest(
   return source.file(path).digest({ excludeMetadata: true })
 }
 
+async function sourceTreeDigest(source: Directory): Promise<string> {
+  return source.digest()
+}
+
+async function rustTargetCacheDigest(source: Directory): Promise<string> {
+  const scope = process.env.CANARY_DAGGER_CACHE_SCOPE?.trim()
+
+  if (scope) {
+    return `${DIGEST_PREFIX}${createHash("sha256").update(scope).digest("hex")}`
+  }
+
+  return sourceTreeDigest(source)
+}
+
 async function nodeContainer(
   source: Directory,
   workdir: string,
@@ -120,6 +135,7 @@ async function nodeContainer(
 
 async function rustContainer(source: Directory): Promise<Container> {
   const digest = await lockfileDigest(source, "Cargo.lock")
+  const targetDigest = await rustTargetCacheDigest(source)
   const platformKey = await cachePlatformKey()
   const imageKey = imageIdentity(RUST_IMAGE)
   const registryCache = dag.cacheVolume(
@@ -129,7 +145,7 @@ async function rustContainer(source: Directory): Promise<Container> {
     cacheVolumeName("canary-rust-git", platformKey, imageKey, digest),
   )
   const targetCache = dag.cacheVolume(
-    cacheVolumeName("canary-rust-target", platformKey, imageKey, digest),
+    cacheVolumeName("canary-rust-target", platformKey, imageKey, targetDigest),
   )
 
   return dag


### PR DESCRIPTION
## Summary

- Scope the Rust `target` Dagger cache by a checkout-specific cache scope instead of the previous platform/image/`Cargo.lock` key.
- Keep Cargo registry/git caches keyed by platform/image/lockfile so dependency downloads remain shared and warm across worktrees.
- Add CI contract assertions that prevent regressing the target cache back to lockfile-only keying.

## Cache Key Choice

I chose worktree-path scoping for the local Rust `target` cache, with a source-digest fallback for direct Dagger module callers.

Why not source content hash as the primary key: it isolates divergent branches, but it also makes the Rust `target` cache cold on every source edit. That would protect concurrency while materially hurting the single-lane edit/check hot path.

Why path scope: `bin/dagger` already owns the local invocation boundary, including `dagger check`, which cannot take a custom function argument the way `dagger call fast` can. The wrapper exports `CANARY_DAGGER_CACHE_SCOPE` as the physical checkout path; the Dagger module hashes that value before using it in the cache volume name. If a caller bypasses the wrapper, the module falls back to `source.digest()`, which is still safe for hosted/direct module use.

## Verification

Focused red/green:

```text
$ python3 dagger/scripts/ci_contract_validation.py
Every Dagger dependency cache volume must scope its key by platform, image, and lockfile digest
dagger/src/index.ts must derive a full source-tree digest for source-sensitive caches
Dagger must scope the Rust target cache by source tree digest to isolate concurrent divergent worktrees
```

After implementation:

```text
$ python3 dagger/scripts/ci_contract_validation.py
# exit 0

$ ./bin/dagger call ci-contract
✔ .ciContract(...): Void 7.5s
```

Concurrent falsifier with divergent route literals:

```text
A markers:
156:        .route("/api/v1/cache-falsifier-a", get(status))
A has B marker?
no

B markers:
156:        .route("/api/v1/cache-falsifier-b", get(status))
B has A marker?
no
```

Both ran at the same time:

```text
$ (A) DAGGER_NO_NAG=1 /usr/bin/time -p ./bin/validate --fast
✔ .fast(source: Host.directory(path: "/Users/phaedrus/Development/canary-069-falsifier-a", ...)): Void 1m42s
real 104.04

$ (B) DAGGER_NO_NAG=1 /usr/bin/time -p ./bin/validate --fast
✔ .fast(source: Host.directory(path: "/Users/phaedrus/Development/canary-069-falsifier-b", ...)): Void 1m42s
real 104.69
```

Warm single-lane timing:

| Scenario | Command | Wall clock |
|---|---:|---:|
| baseline `origin/master` warmup | `bin/validate --fast` | 101.61s |
| baseline warm sample 1 | `bin/validate --fast` | 0.95s |
| baseline warm sample 2 | `bin/validate --fast` | 0.91s |
| patched checkout-scope warmup | `bin/validate --fast` | 61.64s |
| patched warm sample 1 | `bin/validate --fast` | 1.79s |
| patched warm sample 2 | `bin/validate --fast` | 1.71s |

Repo gate:

```text
$ DAGGER_NO_NAG=1 /usr/bin/time -p ./bin/validate
✔ ci:deterministic 3m5s ... OK
✔ ci:secrets-history 5.5s ... OK
real 187.06
```

Push hook:

```text
$ git push -u origin fix/dagger-worktree-cache
✔ .strict(...): Void 5m20s
```

## Residual Risk

- The falsifier used temporary divergent route literals in disposable worktrees because `origin/master` already contains the escalation routes from the original incident report.
- Direct `dagger` invocations that bypass `bin/dagger` cannot see the local checkout path; they use the safe source-digest fallback, which may be colder than the wrapper path. The canonical repo gate goes through `bin/dagger`.
