### PR TITLE
feat(agent-loop): close incident writeback loop

### DIFF
--- a/backlog.d/062-agent-loop-write-surface.md
+++ b/backlog.d/062-agent-loop-write-surface.md
@@ -40,6 +40,14 @@ decision that annotation write must be available through CLI/MCP. The older
 Canary vision was correct about readback and claims; this makes the write side
 operational for agents.
 
+2026-07-04 incident slice: this PR completes the incident loop end to end
+through CLI and MCP: incident list/detail, collision-safe remediation claim,
+annotation evidence writeback, claim release or terminal verification, and
+timeline replay of claim plus annotation writes with actor identity. It does not
+complete `048` rich-context redaction/read-audit requirements, safe browser
+capture, or monitor/check-specific write ergonomics. Those remain explicit
+follow-ups rather than being smuggled into the incident loop.
+
 ## Children
 1. Finish `048-responder-rich-context-safety-gate.md` or the narrow part needed
    for scoped responder keys.
@@ -49,3 +57,5 @@ operational for agents.
    trivia.
 5. Align OpenAPI agent guidance, CLI help, and MCP manifests around one loop.
 6. Add responder-loop conformance fixtures and a redacted receipt.
+7. Add monitor/check-specific write ergonomics only after the incident loop and
+   048 safety boundaries are reviewed.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -14,7 +14,7 @@ visible until a focused PR archives them with evidence.
 |---|------|----------|--------------|
 | 060 | Cold-operator deploy path | P0 | Shipped 2026-07-01. Folded in self-host docs, app-name dehardcoding, bootstrap-key docs, dogfood instance split, and clean-room receipt. |
 | 061 | Fleet plumb-in | P0 | Shipped 2026-07-02. Folded in Factory fleet integration docs, powder/BB live enrollment, bastion/powder/BB check-in readback, and check-in-aware dogfood strictness. |
-| 062 | Agent loop write surface | P0 | Next pickup: adds CLI/MCP annotation writeback and scoped responder-key loop; adopts 048. |
+| 062 | Agent loop write surface | P0 | In PR: completes the incident CLI/MCP loop and durable annotation timeline replay; leaves 048 rich-context safety and monitor/check ergonomics open. |
 | 063 | Triage contract hardening | P1 | Durable cooldown, dispatch budget caps, claim-gated delivery, and drills. |
 | 064 | Trustworthy release/upgrade | P1 | Absorbs 051; fixes release truth, npm/Docker claims, and upgrade docs. |
 | 065 | Runtime hardening | P1 | Absorbs 056/058/059 plus bcrypt-outside-mutex, tracing, and backup posture. |

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -533,6 +533,45 @@ pub fn summarize_incidents(value: &Value) -> Vec<String> {
     ]
 }
 
+/// Summarize one incident detail response.
+pub fn summarize_incident_detail(value: &Value) -> Vec<String> {
+    let incident = value.get("incident").unwrap_or(value);
+    let latest_claim = value
+        .get("claims")
+        .and_then(Value::as_array)
+        .and_then(|claims| claims.first());
+    vec![
+        format!("summary: {}", string_field(value, "summary")),
+        format!("incident_id: {}", string_field(incident, "id")),
+        format!("service: {}", string_field(incident, "service")),
+        format!("state: {}", string_field(incident, "state")),
+        format!("signals: {}", array_len(value, "signals")),
+        format!("annotations: {}", array_len(value, "annotations")),
+        format!("claims: {}", array_len(value, "claims")),
+        format!(
+            "timeline_events: {}",
+            array_len(value, "recent_timeline_events")
+        ),
+        format!(
+            "current_claim: {}",
+            claim_summary(value.pointer("/action_brief/current_claim"))
+        ),
+        format!("latest_claim: {}", claim_summary(latest_claim)),
+    ]
+}
+
+fn claim_summary(claim: Option<&Value>) -> String {
+    match claim {
+        Some(claim) if !claim.is_null() => format!(
+            "{}:{}:{}",
+            string_field(claim, "id"),
+            string_field(claim, "owner"),
+            string_field(claim, "state")
+        ),
+        _ => "none".to_owned(),
+    }
+}
+
 /// Summarize an incident escalate/deescalate response.
 pub fn summarize_incident_escalation(value: &Value) -> Vec<String> {
     let escalation = value.get("escalation").unwrap_or(value);
@@ -4331,6 +4370,17 @@ impl McpToolContext {
                     response,
                 ))
             }
+            "canary_incident_get" => {
+                let client = self.read_client()?;
+                let incident_id = required_string(arguments, "incident_id")?;
+                let response =
+                    client.get_auth_json(&format!("/api/v1/incidents/{}", encode(&incident_id)))?;
+                Ok(json_envelope(
+                    "canary_incident_get",
+                    client.endpoint(),
+                    response,
+                ))
+            }
             "canary_timeline" => {
                 let client = self.read_client()?;
                 let window = window_argument(arguments, "window", "24h")?;
@@ -4785,8 +4835,13 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "canary_incidents",
-            description: "Inspect active incidents from `bin/canary incidents`; use this after doctor reports an open Canary incident.",
+            description: "List active incidents from `bin/canary incidents`; use this after doctor reports an open Canary incident.",
             input_schema: json!({"type":"object","properties":{"open":{"type":"boolean","default":true}}}),
+        },
+        ToolSpec {
+            name: "canary_incident_get",
+            description: "Read one incident detail by id, including bounded signals, annotations, remediation claims, and recent timeline events.",
+            input_schema: json!({"type":"object","required":["incident_id"],"properties":{"incident_id":{"type":"string"}}}),
         },
         ToolSpec {
             name: "canary_timeline",
@@ -6054,6 +6109,7 @@ Vercel CLI completed
         assert!(names.contains("canary_integrate_patch"));
         assert!(names.contains("canary_integrate_enroll"));
         assert!(names.contains("canary_event_capture"));
+        assert!(names.contains("canary_incident_get"));
         assert!(names.contains("canary_claims_list"));
         assert!(names.contains("canary_claim_get"));
         assert!(names.contains("canary_claim_create"));
@@ -6073,6 +6129,10 @@ Vercel CLI completed
         assert_eq!(
             tool_by_name["canary_claim_get"].input_schema["required"],
             json!(["claim_id"])
+        );
+        assert_eq!(
+            tool_by_name["canary_incident_get"].input_schema["required"],
+            json!(["incident_id"])
         );
         assert_eq!(
             tool_by_name["canary_event_capture"].input_schema["required"],

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -14,9 +14,9 @@ use canary_cli::{
     integration_plan, integration_status, json_envelope, mcp_tool_manifest, print_json,
     print_lines, resolve_endpoint_without_config, run_dogfood_inventory, summarize_annotations,
     summarize_claims, summarize_doctor, summarize_dogfood, summarize_dogfood_value,
-    summarize_event, summarize_incident_escalation, summarize_incidents, summarize_integration,
-    summarize_monitors, summarize_query, summarize_report, summarize_services, summarize_targets,
-    summarize_timeline, tool_manifest,
+    summarize_event, summarize_incident_detail, summarize_incident_escalation, summarize_incidents,
+    summarize_integration, summarize_monitors, summarize_query, summarize_report,
+    summarize_services, summarize_targets, summarize_timeline, tool_manifest,
 };
 use clap::{Args, Parser, Subcommand};
 use serde_json::{Value, json};
@@ -47,7 +47,7 @@ enum Commands {
     Services(ServicesArgs),
     /// Inspect recent errors for one service.
     Errors(ServiceWindowArgs),
-    /// List, escalate, or deescalate incidents.
+    /// List, read, escalate, or deescalate incidents.
     Incidents(IncidentsArgs),
     /// Inspect timeline events.
     Timeline(TimelineArgs),
@@ -104,6 +104,8 @@ struct IncidentsArgs {
 enum IncidentsCommand {
     /// List active incidents.
     List(IncidentsListArgs),
+    /// Read one incident detail by id.
+    Get(IncidentGetArgs),
     /// Escalate one incident for human paging.
     Escalate(IncidentEscalateArgs),
     /// Clear a false-positive escalation.
@@ -114,6 +116,11 @@ enum IncidentsCommand {
 struct IncidentsListArgs {
     #[arg(long)]
     open: bool,
+}
+
+#[derive(Debug, Args)]
+struct IncidentGetArgs {
+    incident_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -987,6 +994,18 @@ fn run_incidents_command(
                 response,
                 mode,
                 summarize_incidents,
+            )
+        }
+        IncidentsCommand::Get(args) => {
+            let client = ApiClient::new(Config::resolve(endpoint, api_key, config_path)?)?;
+            let response = client
+                .get_auth_json(&format!("/api/v1/incidents/{}", encode(&args.incident_id)))?;
+            render(
+                "incidents get",
+                client.endpoint(),
+                response,
+                mode,
+                summarize_incident_detail,
             )
         }
         IncidentsCommand::Escalate(args) => {

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -1,9 +1,9 @@
 //! Fixture-backed parser tests for the Canary CLI.
 
 use canary_cli::{
-    dogfood_strict_failure_count, summarize_doctor, summarize_dogfood, summarize_incidents,
-    summarize_monitors, summarize_query, summarize_report, summarize_targets, summarize_timeline,
-    tool_manifest,
+    dogfood_strict_failure_count, summarize_doctor, summarize_dogfood, summarize_incident_detail,
+    summarize_incidents, summarize_monitors, summarize_query, summarize_report, summarize_targets,
+    summarize_timeline, tool_manifest,
 };
 use serde_json::{Value, json};
 
@@ -40,6 +40,48 @@ fn parses_incidents_fixture() -> Result<(), Box<dyn std::error::Error>> {
     let lines = summarize_incidents(&value);
     assert!(lines.iter().any(|line| line == "incidents: 1"));
     Ok(())
+}
+
+#[test]
+fn summarizes_incident_detail_for_agent_loop() {
+    let value = json!({
+        "summary": "incident INC-loop: api incident",
+        "action_brief": {
+            "current_claim": {
+                "id": "CLM-current",
+                "owner": "codex",
+                "state": "claimed"
+            }
+        },
+        "incident": {
+            "id": "INC-loop",
+            "service": "api",
+            "state": "investigating"
+        },
+        "signals": [{}],
+        "annotations": [{}],
+        "claims": [{
+            "id": "CLM-latest",
+            "owner": "codex",
+            "state": "released"
+        }],
+        "recent_timeline_events": [{}, {}]
+    });
+
+    let lines = summarize_incident_detail(&value);
+    assert!(lines.iter().any(|line| line == "incident_id: INC-loop"));
+    assert!(lines.iter().any(|line| line == "annotations: 1"));
+    assert!(lines.iter().any(|line| line == "timeline_events: 2"));
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "current_claim: CLM-current:codex:claimed")
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "latest_claim: CLM-latest:codex:released")
+    );
 }
 
 #[test]
@@ -323,6 +365,7 @@ fn mcp_manifest_exposes_operator_drilldowns() {
     for name in [
         "canary_services",
         "canary_incidents",
+        "canary_incident_get",
         "canary_timeline",
         "canary_targets",
         "canary_monitors",

--- a/crates/canary-cli/tests/mcp_stdio.rs
+++ b/crates/canary-cli/tests/mcp_stdio.rs
@@ -1,9 +1,12 @@
 //! Stdio MCP smoke tests for the Canary CLI adapter.
 
 use std::{
-    io::Write,
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
 };
 
 use serde_json::{Value, json};
@@ -133,10 +136,447 @@ fn mcp_stdio_lists_and_calls_cli_backed_tools() -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+#[test]
+fn cli_incidents_get_reads_incident_detail() -> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(incident_detail_body())])?;
+    let output = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args([
+            "--endpoint",
+            server.endpoint(),
+            "--api-key",
+            "read-key",
+            "--json",
+            "incidents",
+            "get",
+            "INC-loop",
+        ])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(response["command"], json!("incidents get"));
+    assert_eq!(response["response"]["incident"]["id"], json!("INC-loop"));
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].path, "/api/v1/incidents/INC-loop");
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer read-key")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mcp_stdio_exercises_incident_loop_tools() -> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![
+        FixtureResponse::ok(incident_detail_body()),
+        FixtureResponse::created(claim_body("claimed")),
+        FixtureResponse::created(annotation_body()),
+        FixtureResponse::ok(claim_body("released")),
+    ])?;
+    let repo_root = repo_root()?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args(["--endpoint", server.endpoint(), "mcp-server"])
+        .current_dir(&repo_root)
+        .env("CANARY_RESPONDER_KEY", "mcp-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("child stdin unavailable"))?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "canary-loop-test", "version": "0"}
+            }
+        })
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_incident_get",
+                "arguments": {"incident_id": "INC-loop"}
+            }
+        })
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_claim_create",
+                "arguments": {
+                    "subject_type": "incident",
+                    "subject_id": "INC-loop",
+                    "owner": "codex",
+                    "purpose": "triage",
+                    "ttl_ms": 900000,
+                    "idempotency_key": "run-loop"
+                }
+            }
+        })
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_annotation_create",
+                "arguments": {
+                    "subject_type": "incident",
+                    "subject_id": "INC-loop",
+                    "agent": "codex",
+                    "action": "fix-verified",
+                    "metadata": {
+                        "claim_id": "CLM-loop",
+                        "evidence": "https://example.com/proof"
+                    }
+                }
+            }
+        })
+    )?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_claim_release",
+                "arguments": {
+                    "claim_id": "CLM-loop",
+                    "owner": "codex"
+                }
+            }
+        })
+    )?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let responses = String::from_utf8(output.stdout)?
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(responses.len(), 5);
+    assert_eq!(
+        responses[1]["result"]["structuredContent"]["command"],
+        json!("canary_incident_get")
+    );
+    assert_eq!(
+        responses[1]["result"]["structuredContent"]["response"]["incident"]["id"],
+        json!("INC-loop")
+    );
+    assert_eq!(
+        responses[2]["result"]["structuredContent"]["response"]["state"],
+        json!("claimed")
+    );
+    assert_eq!(
+        responses[3]["result"]["structuredContent"]["response"]["action"],
+        json!("fix-verified")
+    );
+    assert_eq!(
+        responses[4]["result"]["structuredContent"]["response"]["state"],
+        json!("released")
+    );
+
+    let requests = server.join()?;
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| (request.method.as_str(), request.path.as_str()))
+            .collect::<Vec<_>>(),
+        [
+            ("GET", "/api/v1/incidents/INC-loop"),
+            ("POST", "/api/v1/claims"),
+            ("POST", "/api/v1/annotations"),
+            ("POST", "/api/v1/claims/CLM-loop/release")
+        ]
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.authorization.as_deref() == Some("Bearer mcp-key"))
+    );
+    assert!(requests[1].body.contains("\"subject_type\":\"incident\""));
+    assert!(requests[2].body.contains("\"action\":\"fix-verified\""));
+
+    Ok(())
+}
+
 fn repo_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(2)
         .map(Path::to_path_buf)
         .ok_or_else(|| std::io::Error::other("repo root not found").into())
+}
+
+#[derive(Debug)]
+struct FixtureServer {
+    endpoint: String,
+    handle: thread::JoinHandle<Result<Vec<RecordedRequest>, String>>,
+}
+
+impl FixtureServer {
+    fn spawn(responses: Vec<FixtureResponse>) -> Result<Self, Box<dyn std::error::Error>> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let endpoint = format!("http://{}", listener.local_addr()?);
+        let handle = thread::spawn(move || serve_fixture(listener, responses));
+        Ok(Self { endpoint, handle })
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    fn join(self) -> Result<Vec<RecordedRequest>, Box<dyn std::error::Error>> {
+        let result = self
+            .handle
+            .join()
+            .map_err(|_| std::io::Error::other("fixture server thread failed"))?;
+        result.map_err(|message| std::io::Error::other(message).into())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FixtureResponse {
+    status: u16,
+    body: Value,
+}
+
+impl FixtureResponse {
+    fn ok(body: Value) -> Self {
+        Self { status: 200, body }
+    }
+
+    fn created(body: Value) -> Self {
+        Self { status: 201, body }
+    }
+}
+
+#[derive(Debug)]
+struct RecordedRequest {
+    method: String,
+    path: String,
+    authorization: Option<String>,
+    body: String,
+}
+
+fn serve_fixture(
+    listener: TcpListener,
+    responses: Vec<FixtureResponse>,
+) -> Result<Vec<RecordedRequest>, String> {
+    let mut requests = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    for response in responses {
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _addr)) => {
+                    let request = read_request(&mut stream).map_err(|error| error.to_string())?;
+                    write_response(&mut stream, response).map_err(|error| error.to_string())?;
+                    requests.push(request);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() > deadline {
+                        return Err(format!(
+                            "timed out waiting for request {}",
+                            requests.len() + 1
+                        ));
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+    }
+    Ok(requests)
+}
+
+fn read_request(stream: &mut TcpStream) -> std::io::Result<RecordedRequest> {
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let mut bytes = Vec::new();
+    let mut header_end = None;
+    let mut content_length = 0;
+    loop {
+        let mut buffer = [0_u8; 1024];
+        let count = stream.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+        if header_end.is_none()
+            && let Some(position) = find_header_end(&bytes)
+        {
+            content_length = parse_content_length(&bytes[..position]);
+            header_end = Some(position);
+        }
+        if let Some(position) = header_end
+            && bytes.len() >= position + 4 + content_length
+        {
+            break;
+        }
+    }
+
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().unwrap_or_default().to_owned();
+    let path = request_parts.next().unwrap_or_default().to_owned();
+    let authorization = text
+        .split("\r\n")
+        .find_map(|line| {
+            line.strip_prefix("authorization: ")
+                .or_else(|| line.strip_prefix("Authorization: "))
+        })
+        .map(str::to_owned);
+    let body = header_end
+        .and_then(|position| bytes.get(position + 4..))
+        .map(|body| String::from_utf8_lossy(body).to_string())
+        .unwrap_or_default();
+
+    Ok(RecordedRequest {
+        method,
+        path,
+        authorization,
+        body,
+    })
+}
+
+fn write_response(stream: &mut TcpStream, response: FixtureResponse) -> std::io::Result<()> {
+    let body = response.body.to_string();
+    let reason = match response.status {
+        200 => "OK",
+        201 => "Created",
+        _ => "OK",
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        response.status,
+        reason,
+        body.len(),
+        body
+    )
+}
+
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn parse_content_length(headers: &[u8]) -> usize {
+    String::from_utf8_lossy(headers)
+        .split("\r\n")
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}
+
+fn incident_detail_body() -> Value {
+    json!({
+        "summary": "incident INC-loop: api incident",
+        "incident": {
+            "id": "INC-loop",
+            "service": "api",
+            "state": "investigating",
+            "severity": "medium",
+            "title": "api incident",
+            "opened_at": "2026-05-28T20:00:00Z",
+            "resolved_at": null,
+            "signal_count": 1
+        },
+        "signals": [],
+        "signals_truncated": false,
+        "annotations": [],
+        "annotations_truncated": false,
+        "claims": [],
+        "recent_timeline_events": []
+    })
+}
+
+fn claim_body(state: &str) -> Value {
+    json!({
+        "id": "CLM-loop",
+        "tenant_id": "TENANT-bootstrap",
+        "project_id": "PROJECT-bootstrap",
+        "service": "api",
+        "subject_type": "incident",
+        "subject_id": "INC-loop",
+        "owner": "codex",
+        "purpose": "triage",
+        "state": state,
+        "idempotency_key": "run-loop",
+        "evidence_links": [],
+        "created_at": "2026-05-28T20:01:00Z",
+        "updated_at": "2026-05-28T20:02:00Z",
+        "expires_at": "2026-05-28T20:16:00Z",
+        "released_at": if state == "released" { json!("2026-05-28T20:02:00Z") } else { Value::Null },
+        "completed_at": if state == "released" { json!("2026-05-28T20:02:00Z") } else { Value::Null }
+    })
+}
+
+fn annotation_body() -> Value {
+    json!({
+        "id": "ANN-loop",
+        "subject_type": "incident",
+        "subject_id": "INC-loop",
+        "incident_id": "INC-loop",
+        "group_hash": null,
+        "agent": "codex",
+        "action": "fix-verified",
+        "metadata": {
+            "claim_id": "CLM-loop",
+            "evidence": "https://example.com/proof"
+        },
+        "created_at": "2026-05-28T20:03:00Z"
+    })
 }

--- a/crates/canary-server/src/annotations.rs
+++ b/crates/canary-server/src/annotations.rs
@@ -286,6 +286,7 @@ fn create_annotation_request(
         }
         let annotation = match store.create_annotation(AnnotationInsert {
             id: canary_core::ids::AnnotationId::generate().into_string(),
+            event_id: canary_core::ids::EventId::generate().into_string(),
             tenant_id: tenant_id.clone(),
             project_id: project_id.clone(),
             service: service.clone(),

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -6099,6 +6099,7 @@ mod tests {
             for service in ["billing", "payments"] {
                 store.create_annotation(AnnotationInsert {
                     id: format!("ANN-{service}"),
+                    event_id: format!("EVT-ann-{service}"),
                     tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
                     project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
                     service: None,

--- a/crates/canary-store/src/annotations.rs
+++ b/crates/canary-store/src/annotations.rs
@@ -7,7 +7,7 @@ use canary_core::query::{
     encode_annotation_cursor,
 };
 use rusqlite::{Connection, OptionalExtension, params};
-use serde_json::Value;
+use serde_json::{Value, json};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 /// Result type returned by annotation read/write models.
@@ -38,6 +38,8 @@ pub enum AnnotationError {
 pub struct AnnotationInsert {
     /// Stable annotation id.
     pub id: String,
+    /// Stable timeline event id for the annotation write.
+    pub event_id: String,
     /// Tenant namespace.
     pub tenant_id: String,
     /// Project namespace.
@@ -128,15 +130,20 @@ pub const fn subject_types() -> &'static [&'static str] {
 }
 
 pub(crate) fn create(
-    connection: &Connection,
+    connection: &mut Connection,
     insert: AnnotationInsert,
 ) -> AnnotationResult<Annotation> {
     let subject_type = parse_subject_type(&insert.subject_type)?;
+    let annotation_id = insert.id.clone();
+    let event_id = insert.event_id.clone();
+    let tenant_id = insert.tenant_id.clone();
+    let project_id = insert.project_id.clone();
+    let transaction = connection.transaction()?;
     let subject_service = require_subject(
-        connection,
+        &transaction,
         subject_type,
         &insert.subject_id,
-        Some((&insert.tenant_id, &insert.project_id)),
+        Some((&tenant_id, &project_id)),
         None,
     )?;
     let service = insert.service.or(subject_service);
@@ -144,27 +151,36 @@ pub(crate) fn create(
     let (incident_id, group_hash) = legacy_keys(subject_type, &insert.subject_id);
     let metadata_json = metadata_to_storage(insert.metadata)?;
 
-    connection.execute(
+    transaction.execute(
         "INSERT INTO annotations (
              id, tenant_id, project_id, service, incident_id, group_hash, agent, action, metadata, created_at, subject_type, subject_id
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         params![
-            insert.id,
-            insert.tenant_id,
-            insert.project_id,
-            service,
+            annotation_id.as_str(),
+            tenant_id.as_str(),
+            project_id.as_str(),
+            service.as_deref(),
             incident_id,
             group_hash,
-            insert.agent,
-            insert.action,
+            insert.agent.as_str(),
+            insert.action.as_str(),
             metadata_json,
-            insert.created_at,
+            insert.created_at.as_str(),
             subject_type.as_str(),
-            insert.subject_id,
+            insert.subject_id.as_str(),
         ],
     )?;
 
-    let row = row_by_id(connection, &insert.id)?.ok_or(AnnotationError::NotFound)?;
+    let row = row_by_id(&transaction, &annotation_id)?.ok_or(AnnotationError::NotFound)?;
+    insert_event(
+        &transaction,
+        &event_id,
+        &row,
+        &tenant_id,
+        &project_id,
+        service.as_deref(),
+    )?;
+    transaction.commit()?;
     Ok(row)
 }
 
@@ -494,6 +510,49 @@ fn annotation_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Annotation> 
         metadata: metadata.map(decode_metadata),
         created_at: row.get(8)?,
     })
+}
+
+fn insert_event(
+    connection: &Connection,
+    event_id: &str,
+    annotation: &Annotation,
+    tenant_id: &str,
+    project_id: &str,
+    service: Option<&str>,
+) -> AnnotationResult<()> {
+    let service = service.unwrap_or("unknown");
+    let payload = json!({
+        "event": "annotation.added",
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "service": service,
+        "annotation": annotation,
+        "timestamp": annotation.created_at,
+    });
+    connection.execute(
+        "INSERT INTO service_events (
+             id, tenant_id, project_id, service, event, entity_type, entity_ref, severity, summary, payload, created_at
+         ) VALUES (?1, ?2, ?3, ?4, 'annotation.added', ?5, ?6, NULL, ?7, ?8, ?9)",
+        params![
+            event_id,
+            tenant_id,
+            project_id,
+            service,
+            annotation.subject_type.as_str(),
+            annotation.subject_id.as_str(),
+            annotation_summary(annotation),
+            payload.to_string(),
+            annotation.created_at.as_str(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn annotation_summary(annotation: &Annotation) -> String {
+    format!(
+        "{} annotated {} {} with {}.",
+        annotation.agent, annotation.subject_type, annotation.subject_id, annotation.action
+    )
 }
 
 fn decode_metadata(value: String) -> Value {

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -863,7 +863,7 @@ impl Store {
         &mut self,
         insert: AnnotationInsert,
     ) -> AnnotationResult<canary_core::query::Annotation> {
-        annotations::create(&self.connection, insert)
+        annotations::create(&mut self.connection, insert)
     }
 
     /// List annotations for legacy incident and error-group routes.
@@ -2093,6 +2093,7 @@ mod tests {
         ] {
             store.create_annotation(AnnotationInsert {
                 id: id.to_owned(),
+                event_id: EventId::generate().into_string(),
                 tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
                 project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
                 service: None,
@@ -2215,6 +2216,71 @@ mod tests {
             }),
             Err(AnnotationError::NotFound)
         ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn annotation_create_records_incident_timeline_event_with_actor_identity()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        insert_incident(&store, "INC-loop", "api", "2026-05-28T20:00:00Z")?;
+
+        let annotation = store.create_annotation(AnnotationInsert {
+            id: "ANN-loop".to_owned(),
+            event_id: "EVT-ann-loop".to_owned(),
+            tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
+            project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
+            service: None,
+            subject_type: "incident".to_owned(),
+            subject_id: "INC-loop".to_owned(),
+            agent: "codex".to_owned(),
+            action: "fix-verified".to_owned(),
+            metadata: Some(json!({
+                "evidence": "https://example.com/proof",
+                "claim_id": "CLM-loop"
+            })),
+            created_at: "2026-05-28T20:05:00Z".to_owned(),
+        })?;
+
+        assert_eq!(annotation.subject_type, "incident");
+        let event: (String, String, String, String, String, String) = store.connection.query_row(
+            "SELECT service, event, entity_type, entity_ref, summary, payload
+                 FROM service_events WHERE id = 'EVT-ann-loop'",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )?;
+        assert_eq!(event.0, "api");
+        assert_eq!(event.1, "annotation.added");
+        assert_eq!(event.2, "incident");
+        assert_eq!(event.3, "INC-loop");
+        assert_eq!(
+            event.4,
+            "codex annotated incident INC-loop with fix-verified."
+        );
+        let payload: Value = serde_json::from_str(&event.5)?;
+        assert_eq!(payload["annotation"]["agent"], "codex");
+        assert_eq!(payload["annotation"]["action"], "fix-verified");
+        assert_eq!(payload["annotation"]["metadata"]["claim_id"], "CLM-loop");
+
+        let detail = store
+            .incident_detail("INC-loop")?
+            .ok_or(StoreError::Sqlite(rusqlite::Error::QueryReturnedNoRows))?;
+        assert_eq!(detail.recent_timeline_events.len(), 1);
+        assert_eq!(detail.recent_timeline_events[0].event, "annotation.added");
+        assert_eq!(
+            detail.recent_timeline_events[0].summary,
+            "codex annotated incident INC-loop with fix-verified."
+        );
 
         Ok(())
     }

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -43,13 +43,15 @@ bin/canary summary --window 24h
 bin/canary services --state down --json
 bin/canary errors chrondle --window 24h
 bin/canary incidents list --open
+bin/canary incidents get INC-example --json
 bin/canary incidents escalate INC-example --reason "iteration guard exhausted" --owner bitterblossom/canary-triage --purpose triage_escalation --idempotency-key run-1:INC-example:escalate
 bin/canary incidents deescalate INC-example --owner operator@example.com --reason "false positive"
 bin/canary timeline --service chrondle --window 7d --limit 20
-bin/canary claims list --subject-type target --subject-id TGT-chrondle --json
-bin/canary claims claim --subject-type target --subject-id TGT-chrondle --owner codex --purpose "verify fix" --json
-bin/canary annotations list --subject-type target --subject-id TGT-chrondle --json
-bin/canary annotations create --subject-type target --subject-id TGT-chrondle --agent codex --action fix-verified --metadata pr=https://github.com/example/repo/pull/1 --json
+bin/canary claims list --subject-type incident --subject-id INC-example --json
+bin/canary claims claim --subject-type incident --subject-id INC-example --owner codex --purpose "verify fix" --json
+bin/canary annotations list --subject-type incident --subject-id INC-example --json
+bin/canary annotations create --subject-type incident --subject-id INC-example --agent codex --action fix-verified --metadata pr=https://github.com/example/repo/pull/1 --json
+bin/canary claims release CLM-example --owner codex --json
 bin/canary targets
 bin/canary monitors
 bin/canary dogfood audit --strict
@@ -75,6 +77,12 @@ Every command supports `--json`. JSON output is wrapped in a stable envelope:
 ```
 
 Text output is deliberately compact for agent transcripts.
+
+For the incident responder loop, start with `incidents list`, drill into
+`incidents get <id>`, then use the generic `claims` and `annotations` commands
+with `--subject-type incident --subject-id <id>`. Claim, annotation, transition,
+and release writes are replayable from the incident detail timeline and the
+service timeline.
 
 `dogfood audit --strict --json` still prints the JSON report before exiting
 nonzero when coverage gaps remain, so agents can inspect the failure details.
@@ -290,9 +298,9 @@ with `input_schema`. The checked-in snapshot at `priv/mcp/canary-cli-tools.json`
 is gated against `tool_manifest()` so it cannot drift from the runtime list.
 
 The manifest covers the drill-down surfaces an agent needs after
-`canary_doctor`: summary, services, errors, incidents, timeline, targets,
-monitors, dogfood audit, dogfood value receipts, witness, DR status, event
-capture, remediation claims, annotations, and integration
+`canary_doctor`: summary, services, errors, incident list and incident detail,
+timeline, targets, monitors, dogfood audit, dogfood value receipts, witness, DR
+status, event capture, remediation claims, annotations, and integration
 discovery/status/plan/patch/enroll. The MCP server implements those tools
 directly through the CLI-backed adapter; it does not define separate route
 semantics.

--- a/docs/api-key-rotation.md
+++ b/docs/api-key-rotation.md
@@ -75,8 +75,10 @@ curl -X POST $CANARY_ENDPOINT/api/v1/keys \
 2. Store the returned raw key as `CANARY_RESPONDER_KEY` or
    `CANARY_RESPONDER_API_KEY` in the responder runtime.
 3. Verify the replacement can read and write only the bound service:
-   - `bin/canary annotations list --subject-type target --subject-id TGT-billing-api --json` returns `200`
-   - `bin/canary annotations create --subject-type target --subject-id TGT-billing-api --agent rotation-check --action verified --json` returns `201`
+   - `bin/canary incidents get INC-billing-api --json` succeeds for a bound-service incident
+   - `bin/canary claims claim --subject-type incident --subject-id INC-billing-api --owner rotation-check --purpose key-rotation --json` succeeds
+   - `bin/canary annotations list --subject-type target --subject-id TGT-billing-api --json` succeeds
+   - `bin/canary annotations create --subject-type target --subject-id TGT-billing-api --agent rotation-check --action verified --json` succeeds
    - the same create call against another service's target returns RFC 9457 `403`
 4. Revoke the previous responder key after the runtime is confirmed on the new
    key.

--- a/docs/architecture/agent-loop-write-surface-incident-loop-2026-07-04.md
+++ b/docs/architecture/agent-loop-write-surface-incident-loop-2026-07-04.md
@@ -1,0 +1,173 @@
+# Agent Loop Write Surface: Incident Conformance Receipt
+
+Date: 2026-07-04
+Scope: `backlog.d/062` incident slice only.
+
+## Outcome
+
+A cold agent can complete the incident loop through the CLI and through MCP
+against a local Canary server:
+
+1. list and read an incident
+2. create a collision-safe remediation claim
+3. annotate the incident with evidence links and actor identity
+4. release the claim through CLI or verify it through MCP
+5. replay the writes from incident detail and the service timeline
+
+Responder keys remain service-bound. A responder key for `loop-api` could read
+and mutate the `loop-api` incident and received RFC 9457 `403 insufficient_scope`
+when attempting to annotate a `loop-other` incident.
+
+Raw admin and responder secrets were redacted from this receipt. Key ids are
+included only where they appear in durable audit/timeline evidence.
+
+## Local Driver
+
+```bash
+CANARY_DB_PATH=/tmp/canary-062-loop.db \
+CANARY_DISCLOSE_BOOTSTRAP_KEY=false \
+PORT=4712 \
+cargo run -q -p canary-server
+```
+
+Seeded durable subject:
+
+```text
+endpoint: http://127.0.0.1:4712
+service: loop-api
+incident_id: INC-hwe7en7qbxr0
+responder_key_id: KEY-82xpkc5lh7hx
+```
+
+## CLI Transcript
+
+```bash
+bin/canary --endpoint http://127.0.0.1:4712 --api-key "$RESPONDER_KEY" --json incidents list --open
+bin/canary --endpoint http://127.0.0.1:4712 --api-key "$RESPONDER_KEY" --json incidents get INC-hwe7en7qbxr0
+bin/canary --endpoint http://127.0.0.1:4712 --api-key "$RESPONDER_KEY" --json claims claim \
+  --subject-type incident \
+  --subject-id INC-hwe7en7qbxr0 \
+  --owner codex-cli \
+  --purpose "live incident loop proof" \
+  --ttl-ms 900000 \
+  --idempotency-key canary-062-cli-primary \
+  --evidence-link https://example.com/canary/062/claim
+```
+
+Claim result:
+
+```text
+claim_id: CLM-2m20vkapkbda
+state: claimed
+owner: codex-cli
+subject: incident/INC-hwe7en7qbxr0
+```
+
+Second claimant was refused by the existing remediation-claim primitive:
+
+```text
+POST /api/v1/claims returned 409 Conflict
+code: claim_conflict
+current_claim.owner: codex-cli
+current_claim.state: claimed
+```
+
+Cross-service mutation was refused with the responder key bound to `loop-api`:
+
+```text
+POST /api/v1/annotations returned 403 Forbidden
+code: insufficient_scope
+bound_service: loop-api
+requested_service: loop-other
+```
+
+The same CLI identity then wrote evidence and released the claim:
+
+```bash
+bin/canary --endpoint http://127.0.0.1:4712 --api-key "$RESPONDER_KEY" --json annotations create \
+  --subject-type incident \
+  --subject-id INC-hwe7en7qbxr0 \
+  --agent codex-cli \
+  --action fix-verified \
+  --metadata claim_id=CLM-2m20vkapkbda \
+  --metadata evidence=https://example.com/canary/062/cli-proof \
+  --metadata note="cli loop wrote durable evidence"
+
+bin/canary --endpoint http://127.0.0.1:4712 --api-key "$RESPONDER_KEY" --json claims release \
+  CLM-2m20vkapkbda \
+  --owner codex-cli
+```
+
+Readback from `incidents get` after release:
+
+```text
+annotations: 1
+claims: 1
+claim state: released
+recent_timeline_events:
+  remediation_claim.released
+  annotation.added
+  remediation_claim.created
+  incident.opened
+```
+
+## MCP Transcript
+
+The MCP server was driven over stdio with `CANARY_RESPONDER_KEY` and no raw HTTP
+calls by the client. Tool calls:
+
+```text
+canary_incident_get incident_id=INC-hwe7en7qbxr0
+canary_claim_create subject_type=incident subject_id=INC-hwe7en7qbxr0 owner=codex-mcp
+canary_annotation_create subject_type=incident subject_id=INC-hwe7en7qbxr0 agent=codex-mcp action=mcp-fix-verified
+canary_claim_transition state=verified owner=codex-mcp evidence_link=https://example.com/canary/062/mcp-proof
+canary_incident_get incident_id=INC-hwe7en7qbxr0
+```
+
+MCP response summary:
+
+```text
+id=2 command=canary_incident_get incident=INC-hwe7en7qbxr0
+id=3 command=canary_claim_create state=claimed incident=INC-hwe7en7qbxr0
+id=4 command=canary_annotation_create action=mcp-fix-verified incident=INC-hwe7en7qbxr0
+id=2 command=canary_claim_transition state=verified incident=INC-hwe7en7qbxr0
+id=3 command=canary_incident_get incident=INC-hwe7en7qbxr0 timeline=5
+```
+
+## Durable Timeline Readback
+
+`bin/canary timeline --service loop-api --window 1h --limit 20 --json` replayed
+the actor-bearing writes:
+
+```text
+remediation_claim.updated  incident INC-hwe7en7qbxr0  codex-mcp set incident INC-hwe7en7qbxr0 to verified.
+annotation.added           incident INC-hwe7en7qbxr0  codex-mcp annotated incident INC-hwe7en7qbxr0 with mcp-fix-verified.
+remediation_claim.created  incident INC-hwe7en7qbxr0  codex-mcp claimed incident INC-hwe7en7qbxr0.
+remediation_claim.released incident INC-hwe7en7qbxr0  codex-cli released incident INC-hwe7en7qbxr0.
+annotation.added           incident INC-hwe7en7qbxr0  codex-cli annotated incident INC-hwe7en7qbxr0 with fix-verified.
+remediation_claim.created  incident INC-hwe7en7qbxr0  codex-cli claimed incident INC-hwe7en7qbxr0.
+incident.opened            incident INC-hwe7en7qbxr0  loop-api: incident opened
+```
+
+## Oracle Verdicts
+
+- MCP-only incident loop: pass for incidents. MCP read, claim, annotation, and
+  verified transition succeeded through declared tools.
+- CLI loop: pass for incidents. JSON envelopes used the same HTTP authority
+  model and RFC 9457 failures surfaced as CLI errors.
+- Service-bound responder key: pass for incident loop. Same-service reads/writes
+  succeeded; cross-service annotation failed with `403 insufficient_scope`.
+- MCP manifest authority wording: pass. The manifest now includes
+  `canary_incident_get`; existing claim and annotation write tools remain the
+  mutation path.
+- Rich-context minimization/read audit from `048`: out of scope for this PR and
+  still open. The incident slice does not widen responder read authority.
+
+## Residuals
+
+- `048-responder-rich-context-safety-gate.md` remains the P0 redaction and
+  read-audit gate for richer responder context.
+- Monitor/check-specific write ergonomics are intentionally deferred until the
+  incident loop and `048` safety boundary are reviewed.
+- Browser or screenshot evidence attachment is not part of this incident slice;
+  annotations accept durable text/link metadata.

--- a/docs/architecture/agent-loop-write-surface-plan-2026-07-04.html
+++ b/docs/architecture/agent-loop-write-surface-plan-2026-07-04.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en" data-ae-mode="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Canary 062 Incident Loop Plan</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v2.5.1/aesthetic.css">
+  <style>
+    .ae-stage, .ae-bar { width: min(88rem, 100% - 4rem); }
+    .hero { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(24rem, .72fr); gap: 2rem; align-items: end; }
+    .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; background: var(--ae-line); margin-top: 1px; }
+    .grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .cell { background: var(--ae-surface); padding: 1rem 1.2rem; }
+    .wash { background: var(--ae-wash); }
+    .phase { border-top: 1px solid var(--ae-line); padding-top: .9rem; margin-top: .9rem; display: grid; grid-template-columns: 8rem minmax(0, 1fr); gap: 1rem; }
+    .phase:first-child { border-top: 0; margin-top: 0; padding-top: 0; }
+    @media (max-width: 900px) { .hero, .grid, .grid.three, .phase { grid-template-columns: 1fr; } .ae-stage, .ae-bar { width: min(100% - 2rem, 88rem); } }
+  </style>
+</head>
+<body>
+<div class="ae-screen">
+  <header class="ae-bar">
+    <a class="ae-name" href="#">CANARY / BACKLOG 062</a>
+    <p class="ae-chrome">incident loop write surface plan</p>
+  </header>
+  <main class="ae-stage ae-stage-scroll">
+    <article class="ae-view">
+      <section class="hero">
+        <div>
+          <p class="ae-chrome">GOAL</p>
+          <h1 class="ae-strong">Make the incident read -&gt; claim -&gt; annotate -&gt; release or verify loop replayable through CLI and MCP.</h1>
+          <p class="ae-lede">The chosen slice completes incidents, not monitors/checks: add the missing durable annotation timeline event and incident detail-by-id adapter, then prove service-bound responder-write authority through a local server transcript.</p>
+        </div>
+        <aside class="ae-panel">
+          <h2 class="ae-h">QUALITY SYSTEM</h2>
+          <p><strong>Standards:</strong> Rust-only code, existing Store single-writer, RFC 9457 server errors, current bearer/actor identity, no widened responder reads.</p>
+          <p><strong>Proof:</strong> store tests, CLI/MCP stdio integration smoke, live local server transcript, fresh-context critic, then <code>./bin/validate</code>.</p>
+          <p><strong>Stop:</strong> halt if resolving incidents requires changing source-signal semantics or if 048 redaction/audit work becomes necessary for this slice.</p>
+        </aside>
+      </section>
+
+      <section class="grid" aria-label="contract">
+        <article class="cell">
+          <h2 class="ae-h">ACCEPT</h2>
+          <p>Cold agents can list/read incident detail, claim it, see a second claimant refused, annotate evidence, then release or verify the claim.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">DURABLE</h2>
+          <p>Claim and annotation writes both append timeline rows with actor identity, subject, service, payload, and timestamp.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">AUTH</h2>
+          <p>Service-bound <code>responder-write</code> can only read/write its service and gets RFC 9457 denial outside the boundary.</p>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">OUT</h2>
+          <p>048 rich-context redaction, read-audit envelopes, monitor/check write helpers, and browser/public-ingest relay are follow-ups.</p>
+        </article>
+      </section>
+
+      <section class="grid three" aria-label="anchors">
+        <article class="cell">
+          <h2 class="ae-h">ANCHORS</h2>
+          <p><code>backlog.d/062-agent-loop-write-surface.md</code>, <code>VISION.md</code>, <code>crates/canary-store/src/annotations.rs</code>, <code>crates/canary-cli/src/lib.rs</code>, <code>crates/canary-cli/tests/mcp_stdio.rs</code>.</p>
+        </article>
+        <article class="cell">
+          <h2 class="ae-h">CHANGE</h2>
+          <p>Store annotation timeline persistence, CLI <code>incidents get</code>, MCP <code>canary_incident_get</code>, manifest/doc alignment, and conformance receipt.</p>
+        </article>
+        <article class="cell wash">
+          <h2 class="ae-h">LIVE ORACLE</h2>
+          <p>Disposable SQLite server, service-bound responder key, CLI transcript, MCP JSON-RPC transcript, timeline/detail readback, receipt at <code>/tmp/lane-canary-062-receipt.md</code>.</p>
+        </article>
+      </section>
+
+      <section class="ae-panel" style="margin-top: 2rem">
+        <h2 class="ae-h">EXECUTION</h2>
+        <div class="phase"><strong class="ae-accent">1 tests</strong><p>Add failing store proof for annotation timeline rows and failing CLI/MCP proof for incident detail and loop tools.</p></div>
+        <div class="phase"><strong class="ae-accent">2 code</strong><p>Patch the smallest store and CLI surfaces; regenerate the MCP manifest snapshot.</p></div>
+        <div class="phase"><strong class="ae-accent">3 verify</strong><p>Run focused Rust tests, live local server CLI/MCP transcript, fresh critic, then repo gate.</p></div>
+        <div class="phase"><strong class="ae-accent">4 pr</strong><p>Update backlog/docs honestly, commit, push, open PR, and write the lane receipt with residuals.</p></div>
+      </section>
+    </article>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/remediation-claims.md
+++ b/docs/remediation-claims.md
@@ -43,9 +43,10 @@ The canonical routes are:
 - `POST /api/v1/claims/{id}/transition`
 - `POST /api/v1/claims/{id}/release`
 
-Mutations require an `admin` key. Reads require `read-only` or `admin`.
-Service-bound read keys can only see subjects in their service authority;
-service-bound admin keys are rejected for mutations.
+Mutations require `responder-write` or `admin` authority. Reads require
+`read-only`, `responder-write`, or `admin`. Service-bound responder keys can
+only read and mutate subjects in their service authority; cross-service claim
+and annotation attempts fail with RFC 9457 Problem Details.
 
 Claim lifecycle writes durable timeline events:
 
@@ -58,6 +59,10 @@ Timeline rows are the durable source of truth. Webhooks mirror the same claim
 lifecycle hints for downstream responders; downstream systems own repository
 mutation, issue creation, and LLM triage.
 
+Annotation writes also append `annotation.added` timeline rows for the same
+subject. For an incident, this means `GET /api/v1/incidents/{id}` can replay the
+claim and evidence notes an agent left without requiring a separate dashboard.
+
 Existing agent read surfaces expose bounded claim state:
 
 - incident lists and incident detail include `current_claim`
@@ -68,9 +73,11 @@ Existing agent read surfaces expose bounded claim state:
 The CLI exposes the same flow:
 
 ```bash
+bin/canary incidents get INC-example --json
 bin/canary claims list --subject-type incident --subject-id INC-example --limit 20
 bin/canary claims get CLM-example
 bin/canary claims claim --subject-type incident --subject-id INC-example --owner codex --purpose triage --ttl-ms 900000 --idempotency-key run-123
-bin/canary claims transition CLM-example --owner codex --state investigating
+bin/canary annotations create --subject-type incident --subject-id INC-example --agent codex --action fix-verified --metadata evidence=https://example.com/proof
+bin/canary claims transition CLM-example --owner codex --state verified --evidence-link https://example.com/proof
 bin/canary claims release CLM-example --owner codex
 ```

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -74,7 +74,7 @@
       "name": "canary_services"
     },
     {
-      "description": "Inspect active incidents from `bin/canary incidents`; use this after doctor reports an open Canary incident.",
+      "description": "List active incidents from `bin/canary incidents`; use this after doctor reports an open Canary incident.",
       "input_schema": {
         "properties": {
           "open": {
@@ -85,6 +85,21 @@
         "type": "object"
       },
       "name": "canary_incidents"
+    },
+    {
+      "description": "Read one incident detail by id, including bounded signals, annotations, remediation claims, and recent timeline events.",
+      "input_schema": {
+        "properties": {
+          "incident_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "incident_id"
+        ],
+        "type": "object"
+      },
+      "name": "canary_incident_get"
     },
     {
       "description": "Inspect timeline events globally or for one service.",


### PR DESCRIPTION
## Summary

Completes the `backlog.d/062` incident slice: a cold agent can close the incident loop through CLI or MCP without raw route trivia.

- Adds `canary incidents get <incident_id>` and MCP `canary_incident_get` for bounded incident detail reads.
- Persists `annotation.added` as a durable `service_events` timeline row in the same SQLite transaction as annotation creation, including actor identity and evidence metadata.
- Exercises the incident loop with store tests, CLI/MCP stdio smoke tests, manifest parity, and a redacted local conformance receipt.
- Leaves `048` rich-context redaction/read-audit and monitor/check-specific write ergonomics as explicit follow-ups.

## Cold-Agent Loop Evidence

Checked-in receipt: `docs/architecture/agent-loop-write-surface-incident-loop-2026-07-04.md`

Local server:

```bash
CANARY_DB_PATH=/tmp/canary-062-loop.db \
CANARY_DISCLOSE_BOOTSTRAP_KEY=false \
PORT=4712 \
cargo run -q -p canary-server
```

CLI loop against `INC-hwe7en7qbxr0`:

```text
incidents list --open -> incident visible
incidents get INC-hwe7en7qbxr0 -> bounded detail visible
claims claim --subject-type incident --subject-id INC-hwe7en7qbxr0 --owner codex-cli -> CLM-2m20vkapkbda claimed
second claims claim by codex-collision -> 409 claim_conflict
annotations create --agent codex-cli --action fix-verified --metadata evidence=... -> annotation persisted
claims release CLM-2m20vkapkbda --owner codex-cli -> released
incidents get INC-hwe7en7qbxr0 -> annotation plus released claim visible
```

MCP loop over stdio with `CANARY_RESPONDER_KEY`:

```text
canary_incident_get -> incident=INC-hwe7en7qbxr0
canary_claim_create -> state=claimed owner=codex-mcp
canary_annotation_create -> action=mcp-fix-verified
canary_claim_transition -> state=verified evidence_link=https://example.com/canary/062/mcp-proof
canary_incident_get -> timeline includes claim + annotation writes
```

Service-bound responder check:

```text
loop-api responder key annotating loop-other incident -> 403 insufficient_scope
```

Timeline replay showed actor-bearing writes:

```text
remediation_claim.updated  incident INC-hwe7en7qbxr0  codex-mcp set incident INC-hwe7en7qbxr0 to verified.
annotation.added           incident INC-hwe7en7qbxr0  codex-mcp annotated incident INC-hwe7en7qbxr0 with mcp-fix-verified.
remediation_claim.created  incident INC-hwe7en7qbxr0  codex-mcp claimed incident INC-hwe7en7qbxr0.
remediation_claim.released incident INC-hwe7en7qbxr0  codex-cli released incident INC-hwe7en7qbxr0.
annotation.added           incident INC-hwe7en7qbxr0  codex-cli annotated incident INC-hwe7en7qbxr0 with fix-verified.
remediation_claim.created  incident INC-hwe7en7qbxr0  codex-cli claimed incident INC-hwe7en7qbxr0.
```

## Verification

```bash
cargo fmt --all -- --check
cargo test -p canary-store annotation_create_records_incident_timeline_event_with_actor_identity --locked
cargo test -p canary-store annotation --locked
cargo test -p canary-cli --test fixtures --locked
cargo test -p canary-cli --test mcp_stdio --locked
cargo test -p canary-server annotations_create_list_paginate_and_emit_webhook_effect --locked
cargo test -p canary-server responder_write_key_claims_and_annotates_only_bound_service --locked
git diff --check
./bin/validate
```

`./bin/validate` result: `ci:deterministic` OK, `ci:secrets-history` OK.

Push hook also ran `./bin/validate --strict` successfully before publishing the branch.

Fresh-context critic: no blocking issues. One usability note about the default text `incidents get` summary was addressed before this PR was opened by adding `current_claim` and `latest_claim` text fields.

## Oracle Verdicts

- MCP-only incident loop: pass for incidents.
- CLI loop and JSON/error envelopes: pass for incidents.
- Service-bound responder key cannot mutate another service: pass.
- MCP manifest names the incident detail tool and write tools remain scoped to responder-write/admin authority: pass.
- `048` rich-context minimization/read-audit: not in this PR, still open by design.

## Residuals

- `backlog.d/048-responder-rich-context-safety-gate.md` remains the P0 redaction/read-audit gate.
- Monitor/check-specific write ergonomics are deferred until the incident loop and `048` safety boundary are reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way to view incident details by ID in both the CLI and MCP tool surface.
  * Incident detail output now includes a concise summary with key counts, recent timeline activity, and current claim status.
  * Annotation creation now records timeline activity with actor identity for better replayability.

* **Bug Fixes**
  * Improved annotation writes to be more reliable and keep related data consistent.
  * Updated tests and examples to reflect the incident-focused workflow end to end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->