### PR TITLE
feat(sdk): make @canary-obs/sdk publish-ready + npm publish pipeline

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,79 @@
+name: Publish SDK
+
+on:
+  push:
+    tags:
+      - "sdk-v*"
+  workflow_dispatch:
+
+concurrency:
+  group: sdk-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: clients/typescript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify tag matches package.json version
+        if: github.event_name == 'push'
+        run: |
+          tag_version="${GITHUB_REF_NAME#sdk-v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [[ "$tag_version" != "$pkg_version" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match clients/typescript/package.json version ${pkg_version}. Bump package.json and re-tag."
+            exit 1
+          fi
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Check NPM_TOKEN availability
+        id: npm_token
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "::warning::NPM_TOKEN secret is not set on this repo. The SDK built, tested, and packed cleanly, but publish is SKIPPED — no package was pushed to the registry. Operator action: create the @canary-obs npm org (free for public packages, see docs/compatibility-policy.md), mint an automation token with publish rights, add it as the NPM_TOKEN repo secret, then re-run this workflow via workflow_dispatch (no need to re-tag)."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: steps.npm_token.outputs.present == 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/clients/typescript/INTEGRATION.md
+++ b/clients/typescript/INTEGRATION.md
@@ -22,20 +22,29 @@ targets, monitors, webhooks, query readback, and dogfood registry evidence.
 
 ## Step 1: Install
 
-The SDK is not yet published to npm (tracked in #051). Until publication,
-install from source:
-
 ```bash
-# From the Canary repo, build the SDK:
-cd clients/typescript && npm install && npm run build
-
-# In your app, link it via file: (adjust the relative path):
-npm install file:../path/to/canary/clients/typescript
+npm install @canary-obs/sdk
 ```
 
-`bin/canary integrate patch` adds `"@canary-obs/sdk": "^0.1.0"` to your
-`package.json` dependencies; replace that version specifier with the `file:`
-path above before running `npm install`, or the install will 404.
+> **Not resolving yet?** `.github/workflows/sdk-publish.yml` builds, tests,
+> and publishes this package with npm provenance on every `sdk-v*` tag, but
+> the first publish is held pending an operator step (creating the
+> `@canary-obs` npm org and adding its publish token — see
+> `docs/compatibility-policy.md`). Until that first release lands, build and
+> link from source instead:
+>
+> ```bash
+> # From the Canary repo, build the SDK:
+> cd clients/typescript && npm install && npm run build
+>
+> # In your app, link it via file: (adjust the relative path):
+> npm install file:../path/to/canary/clients/typescript
+> ```
+
+`bin/canary integrate patch` adds `"@canary-obs/sdk": "^1.0.0"` to your
+`package.json` dependencies. Until the first tagged release publishes (see the
+callout above), replace that version specifier with the `file:` path instead,
+or the install will 404.
 
 ## Step 2: Add env vars
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,43 @@
+# @canary-obs/sdk
+
+Error reporting and check-in SDK for [Canary](https://github.com/misty-step/canary),
+a self-hosted production health ledger for errors, uptime, incidents, and
+webhooks.
+
+## Install
+
+```bash
+npm install @canary-obs/sdk
+```
+
+## Usage
+
+```typescript
+import { initCanary, captureException } from "@canary-obs/sdk";
+
+initCanary({
+  endpoint: "https://your-canary.example",
+  apiKey: process.env.CANARY_API_KEY!,
+  service: "my-app",
+  environment: process.env.NODE_ENV ?? "production",
+});
+
+try {
+  await riskyOperation();
+} catch (err) {
+  captureException(err, { severity: "error" });
+}
+```
+
+Next.js apps get a dedicated subpath (`@canary-obs/sdk/nextjs`) with
+`onRequestError`, error-boundary helpers, browser error observers, a
+Sentry-event bridge, and a health-check route helper.
+
+See [`INTEGRATION.md`](./INTEGRATION.md) for the full Next.js setup (server
+init, client-side error boundaries, non-HTTP monitor check-ins, Sentry
+dual-write migration) and the compatibility guarantees in
+[`docs/compatibility-policy.md`](https://github.com/misty-step/canary/blob/master/docs/compatibility-policy.md).
+
+## License
+
+MIT

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "@canary-obs/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@canary-obs/sdk",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.3",
         "tsup": "^8.0.0",
         "typescript": "^5.8.0",
         "vitest": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=18.18"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -712,9 +715,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -732,9 +732,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,9 +749,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -772,9 +766,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,9 +783,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -812,9 +800,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canary-obs/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Canary error reporting SDK for TypeScript/Next.js",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -21,6 +21,31 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/misty-step/canary.git",
+    "directory": "clients/typescript"
+  },
+  "homepage": "https://github.com/misty-step/canary/blob/master/clients/typescript/INTEGRATION.md",
+  "bugs": {
+    "url": "https://github.com/misty-step/canary/issues"
+  },
+  "keywords": [
+    "canary",
+    "error-tracking",
+    "observability",
+    "nextjs",
+    "monitoring",
+    "sdk"
+  ],
+  "author": "Misty Step",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "prepare": "tsup",
@@ -38,6 +63,5 @@
   "overrides": {
     "esbuild": "^0.28.1",
     "postcss": "^8.5.15"
-  },
-  "license": "MIT"
+  }
 }

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -2762,7 +2762,7 @@ fn update_package_dependency(root: &Path) -> Result<Value> {
             "package.json dependencies must be a JSON object".to_owned(),
         ));
     };
-    deps.insert("@canary-obs/sdk".to_owned(), json!("^0.1.0"));
+    deps.insert("@canary-obs/sdk".to_owned(), json!("^1.0.0"));
     write_json_file(&path, &package)?;
     Ok(json!({"path": path.display().to_string(), "status": "updated"}))
 }

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -33,8 +33,16 @@ require explicit migration steps and are documented here.
 
 ## TypeScript SDK (`clients/typescript/`)
 
-- The SDK is not yet published to npm (tracked in #051).
-- Until npm publish ships, install from source via `file:` linking
+- Publish pipeline: `.github/workflows/sdk-publish.yml` runs the same
+  typecheck/test/build gate as CI, then publishes with npm provenance
+  (`npm publish --provenance --access public`) on every `sdk-v*` tag.
+- The first publish is held pending an operator step: the `@canary-obs` scope
+  has no npm org yet (`npm view @canary-obs/sdk` 404s). Creating an
+  organization for public-only packages is free on npm; once it exists, mint
+  an automation token with publish rights and add it as the `NPM_TOKEN` repo
+  secret, then push an `sdk-v*` tag (or re-run the workflow via
+  `workflow_dispatch`) to fire the first release.
+- Until that first publish lands, install from source via `file:` linking
   (see `clients/typescript/INTEGRATION.md`).
 - The package exports `@canary-obs/sdk` (main) and
   `@canary-obs/sdk/nextjs` (Next.js integration); these entry points


### PR DESCRIPTION
## Summary

Closes the release-pipeline gap tracked in `backlog.d/051-typescript-sdk-npm-publish.md`. `INTEGRATION.md` has always told external consumers to `npm install @canary-obs/sdk`, but the package was never published (`npm view @canary-obs/sdk` 404s) and no workflow ran `npm publish`.

- `clients/typescript/package.json`: adds `repository`/`homepage`/`bugs`/`keywords`/`author`/`engines`/`publishConfig.access:"public"`, bumps the `0.1.0` placeholder to `1.0.0` (first real release).
- `clients/typescript/README.md`: new — renders on the npm package page (previously absent).
- `.github/workflows/sdk-publish.yml`: new — on `sdk-v*` tags (or `workflow_dispatch`), runs the same typecheck/test:ci/build gate as CI, verifies the tag matches `package.json` version, `npm pack --dry-run`s the contents, then publishes with `npm publish --provenance --access public` using an `NPM_TOKEN` secret. **If `NPM_TOKEN` is absent, the job builds/tests/packs and skips publish with a loud `::warning::` annotation** rather than failing or silently no-oping.
- `crates/canary-cli/src/lib.rs`: `bin/canary integrate patch` was writing `^0.1.0` as the SDK dependency spec into consumer `package.json` files — bumped to `^1.0.0` so a freshly patched app gets a range that resolves once the SDK is actually published.
- `docs/compatibility-policy.md` / `clients/typescript/INTEGRATION.md`: updated to describe the real state — pipeline exists and is ready, first publish is held on an operator step, not "already published."

## Org-scope finding

`@canary-obs` has no npm org yet. Per current npm docs, **creating an organization for public-only packages is free** (no paid Teams plan required unless you need private packages) — see [Creating and publishing an organization scoped package](https://docs.npmjs.com/creating-and-publishing-an-organization-scoped-package/) and [Organizations | npm Docs](https://docs.npmjs.com/organizations/). Recommendation: keep the `@canary-obs` scope (it's already baked into published docs, the CLI's auto-patch dependency spec, and existing tests) rather than renaming to a personal-user scope.

## Operator steps to fire the first publish

1. On npmjs.com: create the `canary-obs` organization (free, public packages only — do not add paid seats).
2. Mint an npm **automation token** scoped to publish rights for that org (Account → Access Tokens → Generate New Token → Automation).
3. Add it as the `NPM_TOKEN` secret on `misty-step/canary` (repo or org secret).
4. Push a `sdk-v1.0.0` tag (matching `clients/typescript/package.json`'s current version) — or re-run `sdk-publish.yml` via `workflow_dispatch` if the tag already exists.
5. Confirm with `npm view @canary-obs/sdk` and `npm view @canary-obs/sdk/nextjs` (subpath export resolves through the package's `exports` map, not a separate registry entry — no extra step needed there).

## Evidence

- `npm run typecheck`, `npm run test:ci` (48/48 tests, coverage report), `npm run build` (tsup ESM+CJS+DTS for both entry points) all green locally with the updated `package.json`.
- `npm pack --dry-run` tarball: 10 files — `dist/{index,nextjs}.{js,cjs,d.ts,d.cts}`, `package.json`, `README.md`. 5.2 kB packed / 33.6 kB unpacked.
- `npm publish --dry-run` confirms "Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)" — `publishConfig.access` honored.
- `actionlint .github/workflows/sdk-publish.yml` — clean, exit 0.
- `cargo check -p canary-cli --locked` and `cargo test -p canary-cli --locked integration_` (14/14 tests) — clean after the `^0.1.0` → `^1.0.0` dependency-spec fix.
- Repo's own pre-commit/pre-push hooks ran the Dagger `fast` and `strict` gates (both green) on this branch automatically.

## Test plan

- [ ] CI green on this PR (`.github/workflows/ci.yml` Dagger `strict` gate)
- [ ] After merge + operator steps above: push `sdk-v1.0.0` tag, confirm `sdk-publish.yml` publishes successfully with provenance
- [ ] `npm view @canary-obs/sdk` resolves; `npm install @canary-obs/sdk` works from a clean external Next.js project per `INTEGRATION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)