### PR TITLE
feat(responders): gate incident context reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ curl -fsS -X POST http://localhost:4000/api/v1/keys \
 
 See [`docs/api-key-rotation.md`](docs/api-key-rotation.md) for the full scope
 matrix and rotation procedure.
+Responder incident context uses a redacted envelope, service-bound
+`responder-write` read authority, and durable read-audit events; see
+[`docs/responder-context-safety.md`](docs/responder-context-safety.md).
 
 For Fly deployment (including key recovery if the first boot log was missed),
 see [`docs/self-host-fly.md`](docs/self-host-fly.md).

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -4840,7 +4840,7 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "canary_incident_get",
-            description: "Read one incident detail by id, including bounded signals, annotations, remediation claims, and recent timeline events.",
+            description: "Read one redacted incident context envelope by id, including bounded signals, annotations, remediation claims, recent timeline events, and responder read-audit metadata.",
             input_schema: json!({"type":"object","required":["incident_id"],"properties":{"incident_id":{"type":"string"}}}),
         },
         ToolSpec {

--- a/crates/canary-core/src/lib.rs
+++ b/crates/canary-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ids;
 pub mod ingest;
 pub mod metrics;
 pub mod query;
+pub mod redaction;
 pub mod secrets;
 pub mod slo;
 pub mod webhook_events;

--- a/crates/canary-core/src/redaction.rs
+++ b/crates/canary-core/src/redaction.rs
@@ -1,0 +1,127 @@
+//! Shared redaction vocabulary for Canary-controlled payloads.
+//!
+//! This is a deliberately small pattern floor. It catches common credentials
+//! and PII-shaped values before Canary repeats context to agent consumers; it
+//! is not a full DLP engine.
+
+use std::{borrow::Cow, sync::LazyLock};
+
+use regex::Regex;
+use serde_json::Value;
+
+/// Replacement used when a value is sensitive by field name.
+pub const REDACTED: &str = "[REDACTED]";
+
+static REDACTION_RULES: LazyLock<std::result::Result<Vec<(Regex, &'static str)>, regex::Error>> =
+    LazyLock::new(|| {
+        Ok(vec![
+            (
+                Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")?,
+                "Bearer [REDACTED]",
+            ),
+            (
+                Regex::new(r"\bsk_(?:live|test)_[A-Za-z0-9_=-]+")?,
+                "[CANARY_API_KEY]",
+            ),
+            (
+                Regex::new(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")?,
+                "[EMAIL]",
+            ),
+            (
+                Regex::new(
+                    r#"(?i)\b(password|secret|token|api[_-]?key)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'&,;]+)"#,
+                )?,
+                "$1=[REDACTED]",
+            ),
+        ])
+    });
+
+/// Scrub common credential and PII-shaped strings.
+pub fn scrub_string(value: &str) -> String {
+    let Ok(rules) = REDACTION_RULES.as_ref() else {
+        return REDACTED.to_owned();
+    };
+    let mut scrubbed = Cow::Borrowed(value);
+    for (pattern, replacement) in rules {
+        if pattern.is_match(&scrubbed) {
+            scrubbed = Cow::Owned(pattern.replace_all(&scrubbed, *replacement).into_owned());
+        }
+    }
+    scrubbed.into_owned()
+}
+
+/// Scrub all strings in a JSON value and replace sensitive-key values.
+pub fn scrub_value(value: &Value) -> Value {
+    match value {
+        Value::String(value) => Value::String(scrub_string(value)),
+        Value::Array(values) => Value::Array(values.iter().map(scrub_value).collect()),
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| {
+                    let value = if sensitive_key(key) {
+                        Value::String(REDACTED.to_owned())
+                    } else {
+                        scrub_value(value)
+                    };
+                    (key.clone(), value)
+                })
+                .collect(),
+        ),
+        value => value.clone(),
+    }
+}
+
+/// Return true when a JSON/object key conventionally carries secret material.
+pub fn sensitive_key(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().replace(['-', ' '], "_").as_str(),
+        "authorization"
+            | "cookie"
+            | "set_cookie"
+            | "password"
+            | "passwd"
+            | "secret"
+            | "token"
+            | "api_key"
+            | "apikey"
+            | "access_token"
+            | "refresh_token"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn scrub_string_redacts_common_credential_shapes() {
+        let input = "alice@example.com Authorization: Bearer abc.def token=sk_live_secret";
+
+        let scrubbed = scrub_string(input);
+
+        assert_eq!(
+            scrubbed,
+            "[EMAIL] Authorization: Bearer [REDACTED] token=[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn scrub_value_redacts_sensitive_keys_recursively() {
+        let value = json!({
+            "authorization": "Bearer context-secret",
+            "nested": {
+                "email": "bob@example.com",
+                "api_key": "sk_live_nested_secret"
+            }
+        });
+
+        let scrubbed = scrub_value(&value);
+
+        assert_eq!(scrubbed["authorization"], REDACTED);
+        assert_eq!(scrubbed["nested"]["email"], "[EMAIL]");
+        assert_eq!(scrubbed["nested"]["api_key"], REDACTED);
+    }
+}

--- a/crates/canary-ingest/src/lib.rs
+++ b/crates/canary-ingest/src/lib.rs
@@ -4,7 +4,7 @@
 //! truncation, grouping, classification, and the single call into
 //! `canary-store`.
 
-use std::{borrow::Cow, collections::BTreeMap, sync::LazyLock};
+use std::collections::BTreeMap;
 
 use canary_core::{
     ids::{ErrorId, EventId},
@@ -12,12 +12,12 @@ use canary_core::{
         classification::classify,
         grouping::{GroupingInput, compute},
     },
+    redaction::{scrub_string, scrub_value},
 };
 use canary_store::{
     BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, ErrorIngest, ErrorIngestCommit, ErrorIngestIds,
     ErrorIngestPayload, Store, StoreError,
 };
-use regex::Regex;
 use serde_json::{Map, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
@@ -26,44 +26,6 @@ const MAX_FINGERPRINT_ELEMENTS: usize = 5;
 const MAX_FINGERPRINT_ELEMENT_LEN: usize = 256;
 const MAX_MESSAGE_LEN: usize = 4_096;
 const MAX_STACK_TRACE_LEN: usize = 32_768;
-const REDACTED: &str = "[REDACTED]";
-
-static REDACTION_RULES: LazyLock<std::result::Result<Vec<(Regex, &'static str)>, regex::Error>> =
-    LazyLock::new(|| {
-        Ok(vec![
-            (
-                Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")?,
-                "Bearer [REDACTED]",
-            ),
-            (
-                Regex::new(r"\bsk_(?:live|test)_[A-Za-z0-9_=-]+")?,
-                "[CANARY_API_KEY]",
-            ),
-            (
-                Regex::new(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")?,
-                "[EMAIL]",
-            ),
-            (
-                Regex::new(
-                    r#"(?i)\b(password|secret|token|api[_-]?key)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'&,;]+)"#,
-                )?,
-                "$1=[REDACTED]",
-            ),
-        ])
-    });
-
-fn scrub_string(value: &str) -> String {
-    let Ok(rules) = REDACTION_RULES.as_ref() else {
-        return REDACTED.to_owned();
-    };
-    let mut scrubbed = Cow::Borrowed(value);
-    for (pattern, replacement) in rules {
-        if pattern.is_match(&scrubbed) {
-            scrubbed = Cow::Owned(pattern.replace_all(&scrubbed, *replacement).into_owned());
-        }
-    }
-    scrubbed.into_owned()
-}
 
 /// Result type returned by the ingest boundary.
 pub type Result<T> = std::result::Result<T, IngestError>;
@@ -363,44 +325,6 @@ fn context_json(attrs: &Map<String, Value>) -> Option<String> {
     }
 }
 
-fn scrub_value(value: &Value) -> Value {
-    match value {
-        Value::String(value) => Value::String(scrub_string(value)),
-        Value::Array(values) => Value::Array(values.iter().map(scrub_value).collect()),
-        Value::Object(object) => Value::Object(
-            object
-                .iter()
-                .map(|(key, value)| {
-                    let value = if sensitive_key(key) {
-                        Value::String(REDACTED.to_owned())
-                    } else {
-                        scrub_value(value)
-                    };
-                    (key.clone(), value)
-                })
-                .collect(),
-        ),
-        value => value.clone(),
-    }
-}
-
-fn sensitive_key(key: &str) -> bool {
-    matches!(
-        key.to_ascii_lowercase().replace(['-', ' '], "_").as_str(),
-        "authorization"
-            | "cookie"
-            | "set_cookie"
-            | "password"
-            | "passwd"
-            | "secret"
-            | "token"
-            | "api_key"
-            | "apikey"
-            | "access_token"
-            | "refresh_token"
-    )
-}
-
 fn fingerprint_json(fingerprint: Option<&[String]>) -> Option<String> {
     fingerprint.and_then(|fingerprint| serde_json::to_string(fingerprint).ok())
 }
@@ -414,6 +338,7 @@ mod tests {
     use std::str::FromStr;
 
     use canary_core::ids::{ErrorId, EventId};
+    use canary_core::redaction::REDACTED;
     use canary_store::{BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, Store};
     use serde_json::json;
 

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -38,6 +38,7 @@ mod query_routes;
 mod rate_limit;
 mod read_audit;
 mod report_routes;
+mod responder_context;
 mod retention_prune;
 mod route_state;
 mod runtime;
@@ -8023,6 +8024,249 @@ mod tests {
 
         assert_eq!(status, StatusCode::FORBIDDEN);
         assert_eq!(body["code"], "insufficient_scope");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn responder_incident_detail_returns_redacted_context_and_audit_event()
+    -> Result<(), Box<dyn Error>> {
+        let state = test_ingest_state()?;
+        let incident_id = open_test_incident(&state).await?;
+        let router = ingest_router(state);
+
+        let claim = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/claims",
+                RESPONDER_KEY,
+                &format!(
+                    r#"{{
+                        "subject_type":"incident",
+                        "subject_id":"{incident_id}",
+                        "owner":"alice@example.com",
+                        "purpose":"follow token=sk_live_claim_secret before paging",
+                        "ttl_ms":900000,
+                        "idempotency_key":"responder-context-redaction",
+                        "evidence_links":["https://ops.example/run?token=sk_live_evidence_secret&user=alice@example.com"]
+                    }}"#
+                ),
+            )?)
+            .await?;
+        assert_eq!(claim.status(), StatusCode::CREATED);
+
+        let annotation = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                &format!("/api/v1/incidents/{incident_id}/annotations"),
+                RESPONDER_KEY,
+                r#"{
+                    "agent":"alice@example.com",
+                    "action":"triaged",
+                    "metadata":{
+                        "authorization":"Bearer abc.def.ghi",
+                        "api_key":"sk_live_nested_secret",
+                        "nested":{"email":"bob@example.com","note":"password=\"hunter2\""}
+                    }
+                }"#,
+            )?)
+            .await?;
+        assert_eq!(annotation.status(), StatusCode::CREATED);
+
+        let detail = router
+            .clone()
+            .oneshot(read_request(
+                RESPONDER_KEY,
+                &format!("/api/v1/incidents/{incident_id}"),
+            )?)
+            .await?;
+        let detail_status = detail.status();
+        let detail_body = json_body(detail).await?;
+        assert_eq!(detail_status, StatusCode::OK, "{detail_body}");
+
+        assert_eq!(
+            detail_body["context_envelope"]["schema"],
+            "canary.responder_context.incident.v1"
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["tenant_id"],
+            canary_store::BOOTSTRAP_TENANT_ID
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["project_id"],
+            canary_store::BOOTSTRAP_PROJECT_ID
+        );
+        assert_eq!(detail_body["context_envelope"]["service"], "test-svc");
+        assert_eq!(
+            detail_body["context_envelope"]["subject"]["type"],
+            "incident"
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["subject"]["id"],
+            incident_id
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["retention"]["class"],
+            "audit"
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["privacy_policy"]["classification"],
+            "redacted"
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["bounds"]["signals"]["max"],
+            25
+        );
+        assert_eq!(
+            detail_body["context_envelope"]["bounds"]["annotations"]["max"],
+            20
+        );
+        assert!(
+            detail_body["context_envelope"]["audit_event_id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("EVT-"))
+        );
+
+        let rendered = serde_json::to_string(&detail_body)?;
+        for leaked in [
+            "sk_live_claim_secret",
+            "sk_live_evidence_secret",
+            "sk_live_nested_secret",
+            "alice@example.com",
+            "bob@example.com",
+            "abc.def.ghi",
+            "hunter2",
+        ] {
+            assert!(!rendered.contains(leaked), "{leaked} leaked in {rendered}");
+        }
+        assert_eq!(
+            detail_body["annotations"][0]["metadata"]["authorization"],
+            "[REDACTED]"
+        );
+        assert_eq!(
+            detail_body["annotations"][0]["metadata"]["api_key"],
+            "[REDACTED]"
+        );
+        assert_eq!(
+            detail_body["annotations"][0]["metadata"]["nested"]["email"],
+            "[EMAIL]"
+        );
+        assert_eq!(detail_body["claims"][0]["owner"], "[EMAIL]");
+        assert_eq!(
+            detail_body["claims"][0]["evidence_links"][0],
+            "https://ops.example/run?token=[REDACTED]&user=[EMAIL]"
+        );
+
+        let audit = router
+            .oneshot(read_request(
+                READ_KEY,
+                "/api/v1/timeline?service=test-svc&event_type=telemetry.event&limit=5",
+            )?)
+            .await?;
+        let audit_status = audit.status();
+        let audit_body = json_body(audit).await?;
+        assert_eq!(audit_status, StatusCode::OK, "{audit_body}");
+        assert_eq!(audit_body["returned_count"], 1);
+        let event = &audit_body["events"][0];
+        assert_eq!(event["signal_name"], "responder.context_read");
+        assert_eq!(event["retention_class"], "audit");
+        assert_eq!(event["privacy_policy"], "redacted");
+        assert_eq!(event["attributes"]["reader"]["key_id"], "KEY-responder");
+        assert_eq!(event["attributes"]["reader"]["scope"], "responder-write");
+        assert_eq!(event["attributes"]["reader"]["service"], "test-svc");
+        assert_eq!(event["attributes"]["subject"]["type"], "incident");
+        assert_eq!(event["attributes"]["subject"]["id"], incident_id);
+        assert_eq!(
+            event["attributes"]["context_envelope"]["schema"],
+            "canary.responder_context.incident.v1"
+        );
+        assert!(event["attributes"].get("response_body").is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn responder_incident_detail_rejects_cross_service_reads_with_scope_problem()
+    -> Result<(), Box<dyn Error>> {
+        const API_RESPONDER_KEY: &str = "sk_live_incident_api_responder_secret";
+        let state = test_ingest_state()?;
+        let incident_id = {
+            let mut store = state.lock_store().map_err(|_| "store lock poisoned")?;
+            seed_responder_api_key_for_service(
+                &mut store,
+                "KEY-incident-api-responder",
+                API_RESPONDER_KEY,
+                "api",
+            )?;
+            let error_id = canary_core::ids::ErrorId::generate().into_string();
+            let event_id = canary_core::ids::EventId::generate().into_string();
+            store.commit_error_ingest(owned_error_ingest(
+                canary_store::BOOTSTRAP_TENANT_ID,
+                canary_store::BOOTSTRAP_PROJECT_ID,
+                &error_id,
+                &event_id,
+                "group-web-read-deny",
+                "web",
+                "web incident",
+            )?)?;
+            let incident_id = canary_core::ids::IncidentId::generate().into_string();
+            store.correlate_incident(IncidentCorrelation {
+                tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
+                project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
+                signal_type: "error_group".to_owned(),
+                signal_ref: "group-web-read-deny".to_owned(),
+                service: "web".to_owned(),
+                incident_id: incident_id.parse()?,
+                event_id: canary_core::ids::EventId::generate(),
+                now: server_time::current_rfc3339(),
+            })?;
+            incident_id
+        };
+
+        let response = ingest_router(state)
+            .oneshot(read_request(
+                API_RESPONDER_KEY,
+                &format!("/api/v1/incidents/{incident_id}"),
+            )?)
+            .await?;
+        let status = response.status();
+        let body = json_body(response).await?;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], "insufficient_scope");
+        assert_eq!(body["bound_service"], "api");
+        assert_eq!(body["requested_service"], "web");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read_routes_reject_unbound_responder_write_keys() -> Result<(), Box<dyn Error>> {
+        const UNBOUND_RESPONDER_KEY: &str = "sk_live_unbound_responder_secret";
+        let state = test_ingest_state()?;
+        {
+            let mut store = state.lock_store().map_err(|_| "store lock poisoned")?;
+            seed_api_key(
+                &mut store,
+                "KEY-unbound-responder",
+                UNBOUND_RESPONDER_KEY,
+                "responder-write",
+                None,
+            )?;
+        }
+
+        let response = ingest_router(state)
+            .oneshot(read_request(UNBOUND_RESPONDER_KEY, "/api/v1/incidents")?)
+            .await?;
+        let status = response.status();
+        let body = json_body(response).await?;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["code"], "insufficient_scope");
+        assert_eq!(body["scope"], "responder-write");
+        assert_eq!(body["required_service_binding"], true);
 
         Ok(())
     }

--- a/crates/canary-server/src/query_routes.rs
+++ b/crates/canary-server/src/query_routes.rs
@@ -287,20 +287,37 @@ pub(crate) async fn show_incident(
         Err(_) => return problem_response(internal_problem()),
     };
 
-    let response = match store.incident_detail_scoped(&id, &key.tenant_id, &key.project_id) {
+    match store.incident_detail_scoped(&id, &key.tenant_id, &key.project_id) {
         Ok(Some(result)) => {
             if let Some(bound_service) = key.service.as_deref()
                 && result.incident.service != bound_service
             {
-                return problem_response(not_found_problem(format!("Incident {id} not found.")));
+                return problem_response(crate::service_authority_problem(
+                    bound_service,
+                    &result.incident.service,
+                ));
             }
-            json_status_response(StatusCode::OK.as_u16(), result)
+            let audit_event_id = match crate::read_audit::record_context_read_audit(
+                &mut store,
+                &key,
+                crate::read_audit::ReadAuditContext {
+                    route: "GET /api/v1/incidents/{id}",
+                    subject_type: "incident",
+                    subject_id: &result.incident.id,
+                    subject_service: &result.incident.service,
+                    context_schema: crate::responder_context::INCIDENT_CONTEXT_SCHEMA,
+                },
+            ) {
+                Ok(audit_event_id) => audit_event_id,
+                Err(_) => return problem_response(internal_problem()),
+            };
+            json_status_response(
+                StatusCode::OK.as_u16(),
+                crate::responder_context::incident_context_response(result, &key, audit_event_id),
+            )
         }
         Ok(None) => problem_response(not_found_problem(format!("Incident {id} not found."))),
         Err(QueryError::InvalidWindow) => problem_response(invalid_window_problem()),
         Err(QueryError::Sqlite(_)) => problem_response(internal_problem()),
-    };
-
-    crate::read_audit::record_read_audit(&mut store, &key, "GET /api/v1/incidents/{id}");
-    response
+    }
 }

--- a/crates/canary-server/src/read_audit.rs
+++ b/crates/canary-server/src/read_audit.rs
@@ -1,21 +1,26 @@
 //! Durable read-audit events for responder context fetches.
 //!
-//! When a non-admin API key reads rich context (`/api/v1/report`,
-//! `/api/v1/incidents/{id}`, `/api/v1/errors/{id}`), Canary records a
-//! durable audit event in `service_events` with
-//! `retention_class = 'audit'`. The audit record captures *who* read
-//! *what route* and *when* — never the response payload itself.
-//!
-//! This gives the future context-minimization pass (#048) a real read
-//! trail to design against without requiring the scope-model decision tonight.
+//! When a non-admin API key reads rich context, Canary records a durable audit
+//! event in `service_events` with `retention_class = 'audit'`. Incident context
+//! reads also capture the subject and context envelope schema. The audit record
+//! captures *who* read *what route* and *when* — never the response payload
+//! itself.
 
 use canary_core::ids::EventId;
-use canary_store::{Store, TelemetryEventInsert, VerifiedApiKey};
+use canary_store::{Store, TelemetryEventError, TelemetryEventInsert, VerifiedApiKey};
 use serde_json::json;
 
 use crate::server_time::current_rfc3339;
 
-/// Record a read-audit event for a responder-scoped context fetch.
+pub(crate) struct ReadAuditContext<'a> {
+    pub(crate) route: &'a str,
+    pub(crate) subject_type: &'a str,
+    pub(crate) subject_id: &'a str,
+    pub(crate) subject_service: &'a str,
+    pub(crate) context_schema: &'a str,
+}
+
+/// Record a legacy route-level read-audit event.
 ///
 /// Skips silently for admin keys (admin already has full visibility; the
 /// goal is a responder-specific trail). The audit record never contains the
@@ -50,6 +55,65 @@ pub(crate) fn record_read_audit(store: &mut Store, key: &VerifiedApiKey, route: 
     };
 
     let _ = store.insert_telemetry_event(event);
+}
+
+pub(crate) fn record_context_read_audit(
+    store: &mut Store,
+    key: &VerifiedApiKey,
+    context: ReadAuditContext<'_>,
+) -> Result<Option<String>, TelemetryEventError> {
+    if key.scope == "admin" {
+        return Ok(None);
+    }
+
+    let now = current_rfc3339();
+    let event_id = EventId::generate();
+    let event_id_string = event_id.as_str().to_owned();
+    let attributes = json!({
+        "reader": {
+            "key_id": key.id,
+            "key_name": key.name,
+            "scope": key.scope,
+            "service": key.service,
+        },
+        "route": context.route,
+        "subject": {
+            "type": context.subject_type,
+            "id": context.subject_id,
+            "service": context.subject_service,
+        },
+        "context_envelope": {
+            "schema": context.context_schema,
+            "privacy_policy": "redacted",
+            "retention_class": "audit",
+        },
+        "read_at": now,
+    });
+
+    let event = TelemetryEventInsert {
+        id: event_id,
+        tenant_id: key.tenant_id.clone(),
+        project_id: key.project_id.clone(),
+        service: context.subject_service.to_owned(),
+        name: "responder.context_read".to_owned(),
+        severity: "info".to_owned(),
+        summary: format!(
+            "{}: {} {} read by key {} via {}",
+            context.subject_service,
+            context.subject_type,
+            context.subject_id,
+            key.id,
+            context.route
+        ),
+        attributes_json: attributes.to_string(),
+        retention_class: "audit".to_owned(),
+        privacy_policy: "redacted".to_owned(),
+        sampling_policy: "unsampled".to_owned(),
+        created_at: now,
+    };
+
+    store.insert_telemetry_event(event)?;
+    Ok(Some(event_id_string))
 }
 
 #[cfg(test)]
@@ -182,5 +246,50 @@ mod tests {
             attrs.get("response_body").is_none(),
             "audit event must not contain the response payload"
         );
+    }
+
+    #[test]
+    fn context_read_audit_records_reader_subject_and_envelope() {
+        let mut store = make_migrated_store();
+        let key = test_key("responder-write", Some("svc-a"));
+
+        let audit_id = record_context_read_audit(
+            &mut store,
+            &key,
+            ReadAuditContext {
+                route: "GET /api/v1/incidents/{id}",
+                subject_type: "incident",
+                subject_id: "INC-test",
+                subject_service: "svc-a",
+                context_schema: "canary.responder_context.incident.v1",
+            },
+        )
+        .unwrap();
+
+        let response = store
+            .timeline(
+                "1h",
+                TimelineQueryOptions {
+                    tenant_id: Some(BOOTSTRAP_TENANT_ID.to_owned()),
+                    project_id: Some(BOOTSTRAP_PROJECT_ID.to_owned()),
+                    service: Some("svc-a".to_owned()),
+                    limit: Some("10".to_owned()),
+                    cursor: None,
+                    event_type: Some("telemetry.event".to_owned()),
+                },
+            )
+            .unwrap();
+
+        assert!(audit_id.is_some());
+        assert_eq!(response.events.len(), 1);
+        let attrs = &response.events[0].attributes;
+        assert_eq!(attrs["reader"]["key_id"], "KEY-test");
+        assert_eq!(attrs["subject"]["type"], "incident");
+        assert_eq!(attrs["subject"]["id"], "INC-test");
+        assert_eq!(
+            attrs["context_envelope"]["schema"],
+            "canary.responder_context.incident.v1"
+        );
+        assert!(attrs.get("response_body").is_none());
     }
 }

--- a/crates/canary-server/src/responder_context.rs
+++ b/crates/canary-server/src/responder_context.rs
@@ -1,0 +1,264 @@
+//! Server-side responder context adapters.
+//!
+//! Store read models intentionally preserve raw durable rows. This module owns
+//! the HTTP boundary that narrows those rows into redacted envelopes before an
+//! external responder receives them.
+
+use canary_core::{
+    query::IncidentDetail,
+    redaction::{REDACTED, scrub_string, sensitive_key},
+};
+use canary_store::VerifiedApiKey;
+use serde_json::{Value, json};
+
+pub(crate) const INCIDENT_CONTEXT_SCHEMA: &str = "canary.responder_context.incident.v1";
+const MAX_CONTEXT_STRING_CHARS: usize = 1_024;
+const MAX_METADATA_BYTES: usize = 4_096;
+const MAX_EVIDENCE_LINK_CHARS: usize = 512;
+const MAX_INCIDENT_SIGNALS: usize = 25;
+const MAX_INCIDENT_ANNOTATIONS: usize = 20;
+const MAX_INCIDENT_CLAIMS: usize = 20;
+const MAX_INCIDENT_TIMELINE_EVENTS: usize = 5;
+
+pub(crate) fn incident_context_response(
+    detail: IncidentDetail,
+    authority: &VerifiedApiKey,
+    audit_event_id: Option<String>,
+) -> Value {
+    let service = detail.incident.service.clone();
+    let incident_id = detail.incident.id.clone();
+    let signals_returned = detail.signals.len();
+    let annotations_returned = detail.annotations.len();
+    let claims_returned = detail.claims.len();
+    let timeline_returned = detail.recent_timeline_events.len();
+    let signals_truncated = detail.signals_truncated;
+    let annotations_truncated = detail.annotations_truncated;
+
+    let mut body = serde_json::to_value(detail).unwrap_or_else(|_| {
+        json!({
+            "summary": "Incident context serialization failed.",
+            "incident": {"id": incident_id, "service": service}
+        })
+    });
+    redact_context_value(&mut body);
+    if let Some(object) = body.as_object_mut() {
+        object.insert(
+            "context_envelope".to_owned(),
+            json!({
+                "schema": INCIDENT_CONTEXT_SCHEMA,
+                "tenant_id": authority.tenant_id,
+                "project_id": authority.project_id,
+                "service": service,
+                "subject": {
+                    "type": "incident",
+                    "id": incident_id
+                },
+                "retention": {
+                    "class": "audit",
+                    "audit_event": "responder.context_read"
+                },
+                "privacy_policy": {
+                    "classification": "redacted",
+                    "redaction_rules": [
+                        "bearer_token",
+                        "canary_api_key",
+                        "email",
+                        "sensitive_key_value"
+                    ],
+                    "max_string_chars": MAX_CONTEXT_STRING_CHARS,
+                    "max_metadata_bytes": MAX_METADATA_BYTES,
+                    "max_evidence_link_chars": MAX_EVIDENCE_LINK_CHARS
+                },
+                "bounds": {
+                    "signals": {
+                        "returned": signals_returned,
+                        "max": MAX_INCIDENT_SIGNALS,
+                        "truncated": signals_truncated
+                    },
+                    "annotations": {
+                        "returned": annotations_returned,
+                        "max": MAX_INCIDENT_ANNOTATIONS,
+                        "truncated": annotations_truncated
+                    },
+                    "claims": {
+                        "returned": claims_returned,
+                        "max": MAX_INCIDENT_CLAIMS
+                    },
+                    "recent_timeline_events": {
+                        "returned": timeline_returned,
+                        "max": MAX_INCIDENT_TIMELINE_EVENTS
+                    }
+                },
+                "audit_event_id": audit_event_id
+            }),
+        );
+    }
+    body
+}
+
+fn redact_context_value(value: &mut Value) {
+    match value {
+        Value::String(value) => {
+            *value = bounded_string(scrub_string(value), MAX_CONTEXT_STRING_CHARS);
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_context_value(value);
+            }
+        }
+        Value::Object(object) => {
+            for (key, value) in object.iter_mut() {
+                if sensitive_key(key) {
+                    *value = Value::String(REDACTED.to_owned());
+                } else {
+                    redact_context_value(value);
+                    if key == "metadata" {
+                        bound_json_value(value, MAX_METADATA_BYTES);
+                    } else if key == "evidence_links" {
+                        bound_evidence_links(value);
+                    }
+                }
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn bound_json_value(value: &mut Value, max_bytes: usize) {
+    let Ok(serialized) = serde_json::to_vec(value) else {
+        *value = truncated_json_value(0, max_bytes);
+        return;
+    };
+    if serialized.len() > max_bytes {
+        *value = truncated_json_value(serialized.len(), max_bytes);
+    }
+}
+
+fn bound_evidence_links(value: &mut Value) {
+    let Value::Array(values) = value else {
+        return;
+    };
+    for value in values {
+        let Value::String(link) = value else {
+            continue;
+        };
+        *link = bounded_string(link.clone(), MAX_EVIDENCE_LINK_CHARS);
+    }
+}
+
+fn truncated_json_value(original_size_bytes: usize, limit_bytes: usize) -> Value {
+    json!({
+        "redacted": "[TRUNCATED]",
+        "original_size_bytes": original_size_bytes,
+        "limit_bytes": limit_bytes
+    })
+}
+
+fn bounded_string(value: String, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value;
+    }
+    let mut truncated = value.chars().take(max_chars).collect::<String>();
+    truncated.push_str(" [TRUNCATED]");
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use canary_core::query::{
+        IncidentActionBrief, IncidentActionRecommendation, IncidentActionSignalCounts,
+        IncidentAnnotation, IncidentDetailIncident, RemediationClaim,
+    };
+    use serde_json::json;
+
+    fn authority() -> VerifiedApiKey {
+        VerifiedApiKey {
+            id: "KEY-test".to_owned(),
+            name: "test".to_owned(),
+            scope: "responder-write".to_owned(),
+            tenant_id: "TENANT-test".to_owned(),
+            project_id: "PROJECT-test".to_owned(),
+            service: Some("svc".to_owned()),
+        }
+    }
+
+    #[test]
+    fn incident_context_response_redacts_metadata_and_claim_evidence() {
+        let detail = IncidentDetail {
+            summary: "svc incident for alice@example.com".to_owned(),
+            incident: IncidentDetailIncident {
+                id: "INC-test".to_owned(),
+                service: "svc".to_owned(),
+                state: "investigating".to_owned(),
+                severity: "medium".to_owned(),
+                title: Some("Bearer abc.def".to_owned()),
+                opened_at: "2026-05-28T20:00:00Z".to_owned(),
+                resolved_at: None,
+                signal_count: 0,
+            },
+            signals: Vec::new(),
+            signals_truncated: false,
+            annotations: vec![IncidentAnnotation {
+                id: "ANN-test".to_owned(),
+                subject_type: Some("incident".to_owned()),
+                subject_id: Some("INC-test".to_owned()),
+                incident_id: Some("INC-test".to_owned()),
+                group_hash: None,
+                agent: "bob@example.com".to_owned(),
+                action: "triaged".to_owned(),
+                metadata: Some(json!({"api_key": "sk_live_secret"})),
+                created_at: "2026-05-28T20:01:00Z".to_owned(),
+            }],
+            claims: vec![RemediationClaim {
+                id: "CLM-test".to_owned(),
+                tenant_id: "TENANT-test".to_owned(),
+                project_id: "PROJECT-test".to_owned(),
+                service: Some("svc".to_owned()),
+                subject_type: "incident".to_owned(),
+                subject_id: "INC-test".to_owned(),
+                owner: "alice@example.com".to_owned(),
+                purpose: "token=sk_live_secret".to_owned(),
+                state: "claimed".to_owned(),
+                idempotency_key: "idem".to_owned(),
+                evidence_links: vec!["https://example.test?token=sk_live_secret".to_owned()],
+                created_at: "2026-05-28T20:01:00Z".to_owned(),
+                updated_at: "2026-05-28T20:01:00Z".to_owned(),
+                expires_at: "2026-05-28T20:10:00Z".to_owned(),
+                released_at: None,
+                completed_at: None,
+            }],
+            annotations_truncated: false,
+            recent_timeline_events: Vec::new(),
+            action_brief: IncidentActionBrief {
+                summary: "brief".to_owned(),
+                recommendation: IncidentActionRecommendation {
+                    action: "watch".to_owned(),
+                    reason: "no-op".to_owned(),
+                },
+                signal_counts: IncidentActionSignalCounts {
+                    active: 0,
+                    resolved: 0,
+                    visible: 0,
+                    total: 0,
+                },
+                signals_truncated: false,
+                latest_annotation: None,
+                current_claim: None,
+            },
+        };
+
+        let value = incident_context_response(detail, &authority(), Some("EVT-test".to_owned()));
+        let rendered = serde_json::to_string(&value).unwrap_or_default();
+
+        assert!(!rendered.contains("sk_live_secret"));
+        assert!(!rendered.contains("alice@example.com"));
+        assert!(!rendered.contains("bob@example.com"));
+        assert_eq!(value["annotations"][0]["metadata"]["api_key"], REDACTED);
+        assert_eq!(
+            value["claims"][0]["evidence_links"][0],
+            "https://example.test?token=[REDACTED]"
+        );
+        assert_eq!(value["context_envelope"]["schema"], INCIDENT_CONTEXT_SCHEMA);
+    }
+}

--- a/crates/canary-server/src/server_auth.rs
+++ b/crates/canary-server/src/server_auth.rs
@@ -37,6 +37,11 @@ pub(crate) fn require_read_scope(
     headers: &HeaderMap,
 ) -> Result<VerifiedApiKey, Box<ProblemDetails>> {
     let key = require_scope(state, headers, Permission::Read)?;
+    if ApiKeyScope::parse(&key.scope) == Some(ApiKeyScope::ResponderWrite)
+        && key.service.as_deref().is_none()
+    {
+        return Err(Box::new(responder_service_binding_problem()));
+    }
     enforce_rate_limit(state, RateLimitKind::Query, &key.id)?;
     Ok(key)
 }

--- a/crates/canary-store/src/query.rs
+++ b/crates/canary-store/src/query.rs
@@ -21,6 +21,7 @@ use crate::scope::owner_clause;
 
 const MAX_INCIDENT_SIGNALS: usize = 25;
 const MAX_INCIDENT_ANNOTATIONS: usize = 20;
+const MAX_INCIDENT_CLAIMS: usize = 20;
 const MAX_INCIDENT_TIMELINE_EVENTS: usize = 5;
 
 /// Optional filters for service error queries.
@@ -983,7 +984,7 @@ fn incident_detail_for_owner(
             project_id,
             "incident",
             incident_id,
-            MAX_INCIDENT_ANNOTATIONS,
+            MAX_INCIDENT_CLAIMS,
         )?
     } else {
         Vec::new()

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -84,6 +84,15 @@ with `--subject-type incident --subject-id <id>`. Claim, annotation, transition,
 and release writes are replayable from the incident detail timeline and the
 service timeline.
 
+Incident detail reads are the responder context boundary. A service-bound
+`responder-write` key may read `incidents get <id>` only for its bound service;
+cross-service and unbound responder reads fail with `insufficient_scope`. The
+JSON response includes `context_envelope.schema =
+canary.responder_context.incident.v1`, redacts sensitive-looking annotation
+metadata and claim evidence, and records a durable `responder.context_read`
+audit event for non-admin reads. See
+[`docs/responder-context-safety.md`](responder-context-safety.md).
+
 `dogfood audit --strict --json` still prints the JSON report before exiting
 nonzero when coverage gaps remain, so agents can inspect the failure details.
 

--- a/docs/architecture/responder-context-safety-plan-2026-07-04.html
+++ b/docs/architecture/responder-context-safety-plan-2026-07-04.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Canary 048 Responder Context Safety Plan</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f7f7f4; color: #191a17; }
+    main { max-width: 1040px; margin: 0 auto; padding: 40px 24px 64px; }
+    h1 { font-size: 36px; line-height: 1.05; margin: 0 0 16px; }
+    h2 { font-size: 18px; margin: 28px 0 10px; text-transform: uppercase; letter-spacing: 0; }
+    p, li, td, th { font-size: 15px; line-height: 1.45; }
+    .hero { border-top: 4px solid #191a17; border-bottom: 1px solid #b8b8ae; padding: 24px 0 28px; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+    .panel { border: 1px solid #b8b8ae; border-radius: 6px; padding: 16px; background: #fff; }
+    table { width: 100%; border-collapse: collapse; background: #fff; }
+    th, td { border: 1px solid #b8b8ae; padding: 10px; text-align: left; vertical-align: top; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92em; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #171815; color: #f0efe7; }
+      .hero { border-color: #f0efe7 #55584f; }
+      .panel, table { background: #20211d; }
+      .panel, th, td { border-color: #55584f; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <h1>Gate incident responder context behind service-bound authority, redaction, and read audit.</h1>
+    <p><strong>Chosen design:</strong> keep the store read model raw and reusable; adapt <code>GET /api/v1/incidents/{id}</code> at the server boundary into a redacted incident context envelope with tenant/project/service/subject metadata, bounded arrays, sanitized annotation metadata and claim evidence, and a durable <code>responder.context_read</code> audit row.</p>
+    <p><strong>Stop rules:</strong> stop if the slice requires a new key class, changes source-signal correlation semantics, weakens route gates, or exposes unredacted secret/PII-shaped data in responder context.</p>
+  </section>
+
+  <div class="grid">
+    <article class="panel">
+      <h2>Outcome</h2>
+      <p>A service-bound responder can read its incident context, claim and annotate through existing authority, and replay an audit trail. Cross-service incident reads fail. The context includes only the incident detail allowlist and redacted bounded metadata.</p>
+    </article>
+    <article class="panel">
+      <h2>Standards</h2>
+      <p>Rust-only code, no new DB table unless required, no LLM request path, RFC 9457 failures, service-bound responder authority, no raw response body in audit events, OpenAPI and docs match runtime behavior.</p>
+    </article>
+  </div>
+
+  <h2>Verification System</h2>
+  <table>
+    <tr><th>Claim</th><td>External incident responders receive authorized, minimized, redacted, auditable context.</td></tr>
+    <tr><th>Falsifier</th><td>Responder reads another service, context contains <code>sk_live_</code>, bearer tokens, emails, or sensitive-key values, or no durable audit row exists.</td></tr>
+    <tr><th>Driver</th><td>Focused Rust route tests, redaction unit tests, OpenAPI contract assertions, local live request replay, <code>./bin/validate</code>.</td></tr>
+    <tr><th>Grader</th><td>403 Problem Details for cross-service read; response has <code>context_envelope</code>; audit timeline has reader/subject/envelope metadata; negative string checks pass.</td></tr>
+    <tr><th>Evidence</th><td><code>/tmp/lane-canary-048-receipt.md</code> plus test/gate transcript and PR diff.</td></tr>
+    <tr><th>Cadence</th><td>Tests before code, focused tests after each milestone, full gate before PR, fresh diff-only critic before closeout.</td></tr>
+  </table>
+
+  <h2>Acceptance Slice</h2>
+  <ul>
+    <li>Incident detail response carries tenant, project, service, subject, retention, privacy policy, bounds, and audit metadata.</li>
+    <li>Responder-write reads require a service binding and cannot read sibling-service incidents.</li>
+    <li>Annotation metadata and claim evidence are scrubbed for credential and PII-shaped strings, with response size bounds.</li>
+    <li>Successful rich incident reads record durable audit events without copying the response payload.</li>
+    <li>Docs/OpenAPI name the redaction vocabulary and residual target/monitor/browser/receiver-fixture work.</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/docs/responder-context-safety.md
+++ b/docs/responder-context-safety.md
@@ -1,0 +1,149 @@
+# Responder Context Safety
+
+This document is the contract for rich context that Canary returns to external
+responders. The current shipped slice covers incident detail reads through
+`GET /api/v1/incidents/{id}`.
+
+The goal is least privilege, minimization, and replayability: a responder wakes
+from a webhook, claims or annotates with a service-bound `responder-write` key,
+reads one bounded incident context envelope for the same service, acts outside
+Canary, and leaves durable audit evidence.
+
+## Authority
+
+| Credential | Incident context read behavior |
+| --- | --- |
+| `responder-write` with `service=<name>` | May read incident context for the bound service. |
+| `responder-write` without a service binding | Rejected with RFC 9457 `insufficient_scope`. |
+| `responder-write` bound to a different service | Rejected with RFC 9457 `insufficient_scope`; response includes `bound_service` and `requested_service`. |
+| `read-only` | May read incident detail across the key owner scope. |
+| `admin` | Break-glass read; context response is still redacted, but no responder read-audit event is written. |
+
+Responder keys are not tenant-wide read keys. They are service-bound automation
+credentials for claim, annotation, transition, and incident-context loops.
+
+## Incident Context Envelope
+
+Every incident detail response includes `context_envelope`:
+
+```json
+{
+  "schema": "canary.responder_context.incident.v1",
+  "tenant_id": "TENANT-...",
+  "project_id": "PROJECT-...",
+  "service": "service-name",
+  "subject": {
+    "type": "incident",
+    "id": "INC-..."
+  },
+  "retention": {
+    "class": "audit",
+    "audit_event": "responder.context_read"
+  },
+  "privacy_policy": {
+    "classification": "redacted",
+    "redaction_rules": [
+      "bearer_token",
+      "canary_api_key",
+      "email",
+      "sensitive_key_value"
+    ],
+    "max_string_chars": 1024,
+    "max_metadata_bytes": 4096,
+    "max_evidence_link_chars": 512
+  },
+  "bounds": {
+    "signals": {
+      "returned": 1,
+      "max": 25,
+      "truncated": false
+    },
+    "annotations": {
+      "returned": 1,
+      "max": 20,
+      "truncated": false
+    },
+    "claims": {
+      "returned": 1,
+      "max": 20
+    },
+    "recent_timeline_events": {
+      "returned": 5,
+      "max": 5
+    }
+  },
+  "audit_event_id": "EVT-..."
+}
+```
+
+The incident context schema is an allowlist over the existing incident detail
+read model: `summary`, `incident`, `signals`, `signals_truncated`,
+`annotations`, `annotations_truncated`, `claims`, `recent_timeline_events`,
+`action_brief`, and `context_envelope`.
+
+## Redaction Policy
+
+| Rule | Input shape | Output |
+| --- | --- | --- |
+| `bearer_token` | `Bearer <token-like-value>` | `Bearer [REDACTED]` |
+| `canary_api_key` | `sk_live_*` or `sk_test_*` | `[CANARY_API_KEY]` |
+| `email` | Email-shaped strings | `[EMAIL]` |
+| `sensitive_key_value` | Object keys or assignment names such as `authorization`, `cookie`, `password`, `secret`, `token`, `api_key`, `access_token`, or `refresh_token` | `[REDACTED]` or `name=[REDACTED]` |
+| `max_string_chars` | Any string longer than 1024 characters | First 1024 characters plus ` [TRUNCATED]` |
+| `max_metadata_bytes` | Annotation metadata JSON larger than 4096 serialized bytes | Truncation marker with original and limit byte counts |
+| `max_evidence_link_chars` | Claim evidence link longer than 512 characters | First 512 characters plus ` [TRUNCATED]` |
+
+The durable store may preserve raw submitted annotations, telemetry attributes,
+and claim evidence. Redaction happens at the responder HTTP boundary before the
+payload is serialized.
+
+## Read Audit
+
+Successful non-admin incident context reads insert one telemetry event:
+
+```json
+{
+  "event_type": "telemetry.event",
+  "signal_name": "responder.context_read",
+  "retention_class": "audit",
+  "privacy_policy": "redacted",
+  "attributes": {
+    "reader": {
+      "key_id": "KEY-...",
+      "key_name": "responder-name",
+      "scope": "responder-write",
+      "service": "service-name"
+    },
+    "route": "GET /api/v1/incidents/{id}",
+    "subject": {
+      "type": "incident",
+      "id": "INC-...",
+      "service": "service-name"
+    },
+    "context_envelope": {
+      "schema": "canary.responder_context.incident.v1",
+      "privacy_policy": "redacted",
+      "retention_class": "audit"
+    },
+    "read_at": "2026-07-04T00:00:00Z"
+  }
+}
+```
+
+The audit event records who read which context and when. It does not include
+the response payload.
+
+## Residuals
+
+This slice does not claim the full backlog.d/048 surface:
+
+- Target and monitor responder context envelopes still need equivalent
+  minimization and read audit.
+- Browser/public-ingest credential semantics remain a separate safety gate
+  before client-side capture is promoted.
+- Webhook receiver fixtures exist for timestamp validation, delivery-id dedupe,
+  and timeline replay, but this slice does not expand them.
+- `GET /api/v1/errors/{id}` remains a raw drill-down route for broader read
+  authority. Responder agents should start with incident context and only fall
+  through when the envelope reports truncation or the workflow explicitly needs
+  raw stack traces.

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -87,7 +87,7 @@
       "name": "canary_incidents"
     },
     {
-      "description": "Read one incident detail by id, including bounded signals, annotations, remediation claims, and recent timeline events.",
+      "description": "Read one redacted incident context envelope by id, including bounded signals, annotations, remediation claims, recent timeline events, and responder read-audit metadata.",
       "input_schema": {
         "properties": {
           "incident_id": {

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -18,8 +18,14 @@
       "webhook_contract": "Verify x-canary-signature with the secret selected by x-webhook-id over `x-timestamp.x-delivery-id.body`, reject stale x-timestamp values in the receiver, and deduplicate deliveries by x-delivery-id. Canary also sends legacy x-signature over the body for older consumers. For disputed or failed deliveries, read `GET /api/v1/webhook-deliveries/{delivery_id}` for diagnostics, then replay durable state through `GET /api/v1/timeline` before acting. Webhooks are non-authoritative wake-up hints; the timeline is the durable event log and must be replayed for correctness.",
       "crash_recovery": "After a crash or restart, resume from the last persisted cursor, replay missed timeline events, and continue polling until the API returns no further cursor.",
       "cursor_precedence": "When both `after` and `cursor` are provided on timeline-style pagination endpoints, Canary resolves `after` first and ignores `cursor` for that request.",
-      "incident_entrypoint": "On an `incident.opened` webhook, call `GET /api/v1/incidents/{id}` once — the response carries summary, the full incident metadata, a deterministic action brief, up to 25 correlated signals with per-type context, up to 20 newest annotations, and up to 5 most recent timeline events. Only fall through to /query, /timeline, or /errors/{id} when `signals_truncated` or `annotations_truncated` is true, or the agent needs raw stack traces.",
+      "incident_entrypoint": "On an `incident.opened` webhook, call `GET /api/v1/incidents/{id}` once — the response carries a redacted context envelope, summary, bounded incident metadata, a deterministic action brief, up to 25 correlated signals with per-type context, up to 20 newest annotations, and up to 5 most recent timeline events. Only fall through to /query, /timeline, or /errors/{id} when `signals_truncated` or `annotations_truncated` is true, or the agent needs raw stack traces under a broader read authority.",
       "scope_semantics": "`x-canary-required-scope` names the least-privilege key scope to provision for the operation. Admin keys may also satisfy read-only, ingest-only, and responder-write route permissions at runtime, but agents should request the narrow scope unless they are managing Canary configuration.",
+      "responder_context_safety": {
+        "incident_schema": "canary.responder_context.incident.v1",
+        "authority": "Service-bound responder-write keys may read responder incident context only for their bound service; cross-service reads return RFC 9457 insufficient_scope and unbound responder-write keys are rejected.",
+        "redaction": "Incident context applies bearer_token, canary_api_key, email, and sensitive_key_value redaction plus field allowlists and size bounds before serialization.",
+        "audit": "Successful non-admin incident context reads emit telemetry.event signal responder.context_read with retention_class audit, privacy_policy redacted, and reader/subject/context envelope metadata only."
+      },
       "cold_start": {
         "entrypoint": "When an agent has no saved cursor, call GET /api/v1/report?window=1h first. The report is the bounded current-state snapshot for targets, monitors, active incidents, and active error groups.",
         "pagination": "If report.truncated is true or report.cursor is non-null, keep calling /api/v1/report with that report cursor until the response is no longer truncated. Report cursors are only for report pagination and are not timeline cursors.",
@@ -979,7 +985,7 @@
           "Incidents"
         ],
         "summary": "Get incident detail with bounded signals, annotations, and timeline",
-        "description": "One-call payload for responder agents: deterministic summary, incident metadata, a read-only action brief derived from existing state, up to 25 correlated signals, up to 20 newest annotations, and up to 5 most recent timeline events. Truncation is signalled by `signals_truncated` and `annotations_truncated`.",
+        "description": "One-call payload for responder agents: redacted context envelope, deterministic summary, incident metadata, a read-only action brief derived from existing state, up to 25 correlated signals, up to 20 newest annotations, and up to 5 most recent timeline events. Truncation is signalled by `signals_truncated` and `annotations_truncated`; successful non-admin reads emit a responder.context_read audit event.",
         "parameters": [
           {
             "name": "id",
@@ -1015,9 +1021,15 @@
           }
         },
         "x-canary-required-scope": "read-only",
+        "x-canary-accepted-scopes": [
+          "read-only",
+          "responder-write",
+          "admin"
+        ],
+        "x-canary-responder-scope": "Service-bound responder-write keys are accepted for same-service incident context reads. Unbound responder-write keys and cross-service incident reads return RFC 9457 insufficient_scope.",
         "x-agent-guidance": {
           "when_to_call": "Use as the first detail call after an incident.opened or incident.updated event references an incident id.",
-          "trust": "The response summary, action_brief, signals, annotations, and recent timeline are deterministic and bounded; truncation booleans identify when to fetch more.",
+          "trust": "The response context_envelope, summary, action_brief, signals, annotations, and recent timeline are deterministic, redacted, audited, and bounded; truncation booleans identify when to fetch more.",
           "next": "If signals_truncated or annotations_truncated is true, fetch timeline, query, or annotations pages before acting; otherwise write back an annotation when follow-up completes."
         }
       }
@@ -4173,6 +4185,7 @@
         "additionalProperties": false,
         "required": [
           "summary",
+          "context_envelope",
           "incident",
           "signals",
           "signals_truncated",
@@ -4185,6 +4198,9 @@
         "properties": {
           "summary": {
             "type": "string"
+          },
+          "context_envelope": {
+            "$ref": "#/components/schemas/ResponderContextEnvelope"
           },
           "incident": {
             "$ref": "#/components/schemas/IncidentDetailIncident"
@@ -4221,6 +4237,169 @@
             "items": {
               "$ref": "#/components/schemas/RemediationClaim"
             }
+          }
+        }
+      },
+      "ResponderContextEnvelope": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "tenant_id",
+          "project_id",
+          "service",
+          "subject",
+          "retention",
+          "privacy_policy",
+          "bounds",
+          "audit_event_id"
+        ],
+        "properties": {
+          "schema": {
+            "type": "string",
+            "enum": [
+              "canary.responder_context.incident.v1"
+            ]
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "id"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "incident"
+                ]
+              },
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "retention": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "class",
+              "audit_event"
+            ],
+            "properties": {
+              "class": {
+                "type": "string",
+                "enum": [
+                  "audit"
+                ]
+              },
+              "audit_event": {
+                "type": "string",
+                "enum": [
+                  "responder.context_read"
+                ]
+              }
+            }
+          },
+          "privacy_policy": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "classification",
+              "redaction_rules",
+              "max_string_chars",
+              "max_metadata_bytes",
+              "max_evidence_link_chars"
+            ],
+            "properties": {
+              "classification": {
+                "type": "string",
+                "enum": [
+                  "redacted"
+                ]
+              },
+              "redaction_rules": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "bearer_token",
+                    "canary_api_key",
+                    "email",
+                    "sensitive_key_value"
+                  ]
+                }
+              },
+              "max_string_chars": {
+                "type": "integer"
+              },
+              "max_metadata_bytes": {
+                "type": "integer"
+              },
+              "max_evidence_link_chars": {
+                "type": "integer"
+              }
+            }
+          },
+          "bounds": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "signals",
+              "annotations",
+              "claims",
+              "recent_timeline_events"
+            ],
+            "properties": {
+              "signals": {
+                "$ref": "#/components/schemas/ResponderContextBound"
+              },
+              "annotations": {
+                "$ref": "#/components/schemas/ResponderContextBound"
+              },
+              "claims": {
+                "$ref": "#/components/schemas/ResponderContextBound"
+              },
+              "recent_timeline_events": {
+                "$ref": "#/components/schemas/ResponderContextBound"
+              }
+            }
+          },
+          "audit_event_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Event id of the durable responder.context_read audit event. Null only for admin reads."
+          }
+        }
+      },
+      "ResponderContextBound": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "returned",
+          "max"
+        ],
+        "properties": {
+          "returned": {
+            "type": "integer"
+          },
+          "max": {
+            "type": "integer"
+          },
+          "truncated": {
+            "type": "boolean"
           }
         }
       },
@@ -4293,7 +4472,7 @@
                 "type": "null"
               }
             ],
-            "description": "Opaque metadata preserved by Canary. Expected keys are optional coordination hints, not Canary behavior switches.",
+            "description": "Opaque metadata preserved by Canary. Expected keys are optional coordination hints, not Canary behavior switches. Incident responder context redacts sensitive-looking keys and bounds metadata before serialization.",
             "x-canary-expected-keys": [
               "external_url",
               "external_id",


### PR DESCRIPTION
## Summary

- Add a shared redaction vocabulary and use it for responder incident context plus ingest-side persistence redaction.
- Gate incident detail reads for `responder-write` keys behind service binding, returning `insufficient_scope` for unbound or cross-service responder reads.
- Wrap `GET /api/v1/incidents/{id}` responses in `canary.responder_context.incident.v1` with tenant/project/service/subject, retention, privacy policy, bounds, and audit id metadata.
- Record durable `responder.context_read` telemetry events for successful non-admin incident context reads without storing the response payload.
- Update OpenAPI, MCP manifest text, CLI docs, README, and responder context safety docs.

## Redaction Policy

| Rule | Input shape | Output |
| --- | --- | --- |
| `bearer_token` | `Bearer <token-like-value>` | `Bearer [REDACTED]` |
| `canary_api_key` | `sk_live_*` or `sk_test_*` | `[CANARY_API_KEY]` |
| `email` | Email-shaped strings | `[EMAIL]` |
| `sensitive_key_value` | Sensitive object keys or `password/secret/token/api_key=...` assignments | `[REDACTED]` or `name=[REDACTED]` |
| `max_string_chars` | Any string longer than 1024 chars | First 1024 chars plus ` [TRUNCATED]` |
| `max_metadata_bytes` | Annotation metadata JSON larger than 4096 serialized bytes | Truncation marker with original and limit byte counts |
| `max_evidence_link_chars` | Claim evidence link longer than 512 chars | First 512 chars plus ` [TRUNCATED]` |

## Audited Read Transcript

Sanitized local temp-DB HTTP replay:

```text
POST /api/v1/errors -> 201
GET /api/v1/incidents -> 200
POST /api/v1/claims -> 201 claimed incident INC-3kpz7n6p72xz
POST /api/v1/incidents/{id}/annotations -> 201 triaged
GET /api/v1/incidents/{id} -> 200 schema canary.responder_context.incident.v1
subject: {id: INC-3kpz7n6p72xz, type: incident}
privacy_policy: redacted; rules bearer_token, canary_api_key, email, sensitive_key_value
bounds: signals max 25 returned 1; annotations max 20 returned 1; claims max 20 returned 1; timeline max 5 returned 3
audit_event_id: EVT-9moit2338ec3
redaction_leak_check: pass
annotation_metadata: authorization/api_key [REDACTED], email [EMAIL], password=[REDACTED]
claim_owner: [EMAIL]
claim_evidence_link: token=[REDACTED]&user=[EMAIL]
GET /api/v1/timeline?service=test-svc&event_type=telemetry.event&limit=5 -> 200 returned_count 1
matching_audit_events: 1
audit_event: responder.context_read, retention_class audit, privacy_policy redacted, reader scope responder-write service test-svc, has_response_body false
```

## Verification

- `cargo test -p canary-core redaction --locked`
- `cargo test -p canary-ingest server_side_redaction_runs_before_persistence --locked`
- `cargo test -p canary-server responder_incident_detail --locked`
- `cargo test -p canary-server read_routes_reject_unbound_responder_write_keys --locked`
- `cargo test -p canary-server read_audit --locked`
- `cargo test -p canary-store incident_detail --locked`
- `cargo test -p canary-server openapi --locked`
- `cargo test -p canary-cli mcp_manifest --locked`
- `python3 -m json.tool priv/openapi/openapi.json >/dev/null`
- `python3 -m json.tool priv/mcp/canary-cli-tools.json >/dev/null`
- `cargo fmt --check`
- `git diff --check`
- Local temp-DB HTTP replay above
- `./bin/validate` -> `ci:deterministic` OK and `ci:secrets-history` OK
- Pre-push `./bin/validate --strict` hook -> `.strict` OK

## Residuals

- Target and monitor context envelopes still need equivalent redaction/read-audit treatment.
- Browser/public-ingest credential semantics remain a separate safety gate before client-side capture promotion.
- Webhook receiver conformance fixtures already exist for timestamp validation, delivery-id dedupe, and timeline replay; this slice does not expand them.
- `GET /api/v1/errors/{id}` remains a raw drill-down route for broader read authority. Responder agents should start with incident context and only fall through when truncation or explicit raw stack needs justify it.

Agent: Codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: backlog.d/048
