### PR TITLE
feat(agent-ops): add cold-agent readiness proof entrypoint (#050)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,10 @@ User-ratified composition: **`/settle → /refactor → /code-review → merge`.
 
 Canary reports its own errors through the Rust runtime direct-ingest path, no HTTP loopback. Query Canary itself (`GET /api/v1/query?service=canary&window=1h`) for post-deploy signal.
 
+## Cold-agent readiness proof
+
+`bin/canary-readiness-proof --json` is the one discoverable entrypoint proving a cold agent can inspect and operate this instance: doctor, mcp-manifest/mcp-server, dogfood discovery, and `bin/validate --fast`, ending in a redacted receipt. See `docs/agent-inspection-cli.md#cold-agent-readiness-proof`.
+
 ## Deploy (operational crib)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ authority, or admin for break-glass operator use. The server returns MCP
 `inputSchema` fields at the wire boundary while the checked CLI manifest remains gated in
 `priv/mcp/canary-cli-tools.json`.
 
+### Cold-Agent Readiness Proof
+
+```bash
+bin/canary-readiness-proof --json
+```
+
+One discoverable entrypoint proving a cold agent can inspect and operate this
+instance: `doctor`, `mcp-manifest`/`mcp-server`, dogfood discovery, and
+`bin/validate --fast`, ending in a redacted receipt. Missing credentials or an
+unconfigured dogfood registry report as concrete blocked fields rather than
+failing the proof; see `docs/agent-inspection-cli.md#cold-agent-readiness-proof`.
+
 ## API
 
 The machine-readable contract lives at `GET /api/v1/openapi.json`. That

--- a/backlog.d/050-cold-agent-readiness-proof.md
+++ b/backlog.d/050-cold-agent-readiness-proof.md
@@ -32,3 +32,34 @@ the repo's own agent operating proof discoverable and repeatable.
 3. Add fixture tests for missing credentials and stale manifest/tool names.
 4. Integrate the MCP wrapper smoke after #049 lands it.
 5. Link the proof from `AGENTS.md`, `README.md`, and `docs/agent-inspection-cli.md`.
+
+## Implementation
+
+The entrypoint is `bin/canary-readiness-proof` (child 1: script, not a
+`bin/canary` subcommand, so it stays composable with `bin/validate --fast`
+rather than becoming a Rust CLI surface). It chains `bin/canary doctor --json`,
+`bin/canary mcp-manifest --json` (cross-checked against the checked-in
+`priv/mcp/canary-cli-tools.json` snapshot for drift), a `bin/canary mcp-server`
+stdio smoke against #052's already-shipped MCP server (initialize → tools/list
+→ one `tools/call` on a read-only tool, default `canary_summary`), `bin/dogfood-inventory --json`
+as the integration/status discovery smoke, and `bin/validate --fast`
+(skippable via `--skip-validate` for composability/CI recursion).
+
+Missing `CANARY_ENDPOINT`/`CANARY_API_KEY` and an unconfigured dogfood
+registry surface as `blocked_fields` (field, reason, replacement command) in
+the redacted JSON receipt and exit `0` — the documented state for a
+not-yet-configured instance. The proof exits nonzero only on a real defect: a
+generated MCP manifest that drifts from the checked-in snapshot or from the
+live `tools/list` count, an MCP `tools/call` that errors for a reason other
+than missing credentials, an unexpected `dogfood-inventory` failure, or a
+failing `bin/validate --fast`. No secret values are ever interpolated into the
+receipt, only presence booleans.
+
+`test/bin/canary_readiness_proof_test.sh` (wired into Dagger's
+`scriptsQualityContainer`, alongside a `bash -n` syntax check) covers all of
+child 3 offline with a stubbed `canary`/`dogfood-inventory`/`validate`: missing
+credentials, healthy run, blocked discovery, unexpected discovery error, stale
+manifest, and an unexpected MCP tool defect — 30 assertions, all passing.
+Verified live against a local `cargo run -p canary-server` instance (blocked
+path with no credentials, and the full happy path with a bootstrap admin key)
+before the fixture test was written.

--- a/bin/canary-readiness-proof
+++ b/bin/canary-readiness-proof
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ENDPOINT="${CANARY_ENDPOINT:-}"
+API_KEY="${CANARY_API_KEY:-${CANARY_READ_API_KEY:-}}"
+CANARY_BIN="${CANARY_READINESS_CANARY_BIN:-$ROOT/bin/canary}"
+DOGFOOD_INVENTORY_BIN="${CANARY_READINESS_DOGFOOD_INVENTORY_BIN:-$ROOT/bin/dogfood-inventory}"
+VALIDATE_BIN="${CANARY_READINESS_VALIDATE_BIN:-$ROOT/bin/validate}"
+STATIC_MANIFEST="${CANARY_READINESS_STATIC_MANIFEST:-$ROOT/priv/mcp/canary-cli-tools.json}"
+RECEIPT="${CANARY_READINESS_RECEIPT:-canary-readiness-receipt.json}"
+MCP_PROBE_TOOL="${CANARY_READINESS_MCP_TOOL:-canary_summary}"
+MCP_TIMEOUT_SECONDS="${CANARY_READINESS_MCP_TIMEOUT_SECONDS:-10}"
+RUN_VALIDATE=1
+JSON_OUTPUT=0
+
+usage() {
+  cat <<'EOF'
+Usage: bin/canary-readiness-proof [--endpoint <url>] [--api-key <key>] [--receipt <path>] [--mcp-tool <name>] [--skip-validate] [--json] [-h|--help]
+
+One discoverable, repeatable proof that a cold agent can inspect, operate, and
+hand off evidence for this Canary instance without re-deriving the runbook
+from scattered docs.
+
+Runs, in order:
+  1. Credential discovery      - CANARY_ENDPOINT / CANARY_API_KEY (or
+                                  CANARY_READ_API_KEY), reported present/absent
+                                  only, never the values.
+  2. `bin/canary doctor --json`            - live health/coverage diagnostic.
+  3. `bin/canary mcp-manifest --json`      - generated MCP tool surface,
+                                  cross-checked against the checked-in static
+                                  snapshot for drift.
+  4. `bin/canary mcp-server` stdio smoke   - initialize, tools/list, and one
+                                  tools/call against a read-only tool
+                                  (default: canary_summary).
+  5. `bin/dogfood-inventory --json`        - integration/coverage discovery
+                                  smoke.
+  6. `bin/validate --fast`                 - repo gate (skip with
+                                  --skip-validate for composability/CI).
+
+Missing credentials or an unconfigured dogfood registry are reported as
+concrete blocked fields with a replacement command, and the proof still exits
+0 - that is the documented, expected state for a not-yet-configured instance.
+The proof exits nonzero only on unexpected defects: a stale generated MCP
+manifest, a broken MCP tool call, an unreadable dogfood registry error, or a
+failing repo gate.
+
+A redacted JSON receipt is written to --receipt (default:
+./canary-readiness-receipt.json) and, with --json, also printed to stdout.
+EOF
+}
+
+fail() {
+  printf 'canary-readiness-proof: %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+now_utc() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+while (($#)); do
+  case "$1" in
+    --endpoint)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      ENDPOINT="$2"
+      shift 2
+      ;;
+    --api-key)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      API_KEY="$2"
+      shift 2
+      ;;
+    --receipt)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      RECEIPT="$2"
+      shift 2
+      ;;
+    --mcp-tool)
+      (($# >= 2)) || { usage >&2; exit 1; }
+      MCP_PROBE_TOOL="$2"
+      shift 2
+      ;;
+    --skip-validate)
+      RUN_VALIDATE=0
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_command jq
+require_command date
+
+[[ -x "$CANARY_BIN" || -f "$CANARY_BIN" ]] || fail "missing canary CLI entrypoint: $CANARY_BIN"
+[[ -x "$DOGFOOD_INVENTORY_BIN" || -f "$DOGFOOD_INVENTORY_BIN" ]] || fail "missing dogfood-inventory entrypoint: $DOGFOOD_INVENTORY_BIN"
+
+STARTED_AT="$(now_utc)"
+UNEXPECTED_FAILURE=0
+BLOCKED_FIELDS_FILE="$(mktemp)"
+MCP_REQUEST_FILE="$(mktemp)"
+MCP_RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$BLOCKED_FIELDS_FILE" "$MCP_REQUEST_FILE" "$MCP_RESPONSE_FILE"' EXIT
+: > "$BLOCKED_FIELDS_FILE"
+
+add_blocked_field() {
+  local field="$1" reason="$2" replacement="$3"
+  jq -cn --arg field "$field" --arg reason "$reason" --arg replacement "$replacement" \
+    '{field: $field, reason: $reason, replacement_command: $replacement}' \
+    >> "$BLOCKED_FIELDS_FILE"
+}
+
+# --- Step 1: credential discovery -------------------------------------------
+
+endpoint_present=false
+api_key_present=false
+[[ -n "$ENDPOINT" ]] && endpoint_present=true
+[[ -n "$API_KEY" ]] && api_key_present=true
+
+if [[ "$endpoint_present" == false ]]; then
+  add_blocked_field "endpoint" "CANARY_ENDPOINT is not set and --endpoint was not passed" \
+    "set CANARY_ENDPOINT or pass --endpoint <url>"
+fi
+if [[ "$api_key_present" == false ]]; then
+  add_blocked_field "read_api_key" "no CANARY_API_KEY or CANARY_READ_API_KEY is set" \
+    "set CANARY_API_KEY (or CANARY_READ_API_KEY) or pass --api-key <key>"
+fi
+
+canary_cmd() {
+  local endpoint_args=()
+  [[ -n "$ENDPOINT" ]] && endpoint_args+=(--endpoint "$ENDPOINT")
+  [[ -n "$API_KEY" ]] && endpoint_args+=(--api-key "$API_KEY")
+  "$CANARY_BIN" "${endpoint_args[@]}" "$@"
+}
+
+# --- Step 2: doctor ----------------------------------------------------------
+
+set +e
+doctor_output="$(canary_cmd doctor --json 2>&1)"
+doctor_exit=$?
+set -e
+
+if ((doctor_exit == 0)) && jq -e . >/dev/null 2>&1 <<<"$doctor_output"; then
+  doctor_status="ok"
+  doctor_verdict="$(jq -c '.response.verdict // null' <<<"$doctor_output")"
+else
+  doctor_status="blocked"
+  doctor_verdict=null
+  if [[ "$endpoint_present" == true && "$api_key_present" == true ]]; then
+    # Credentials were supplied but doctor still failed: an unexpected defect,
+    # not a documented blocked state.
+    UNEXPECTED_FAILURE=1
+    printf 'canary-readiness-proof: doctor failed with credentials present: %s\n' "$doctor_output" >&2
+  fi
+fi
+
+# --- Step 3: mcp-manifest + static snapshot parity ---------------------------
+
+manifest_output="$("$CANARY_BIN" mcp-manifest --json)"
+manifest_tool_count="$(jq '.tools | length' <<<"$manifest_output")"
+manifest_tool_names="$(jq -c '[.tools[].name] | sort' <<<"$manifest_output")"
+
+manifest_stale=false
+if [[ -f "$STATIC_MANIFEST" ]]; then
+  static_tool_names="$(jq -c '[.tools[].name] | sort' "$STATIC_MANIFEST")"
+  if [[ "$manifest_tool_names" != "$static_tool_names" ]]; then
+    manifest_stale=true
+    UNEXPECTED_FAILURE=1
+    printf 'canary-readiness-proof: generated MCP manifest tool names differ from checked-in %s\n' "$STATIC_MANIFEST" >&2
+  fi
+else
+  static_tool_names=null
+fi
+
+# --- Step 4: MCP wrapper stdio smoke -----------------------------------------
+
+{
+  jq -nc '{jsonrpc: "2.0", id: 1, method: "initialize", params: {protocolVersion: "2025-11-25", capabilities: {}, clientInfo: {name: "canary-readiness-proof", version: "1"}}}'
+  jq -nc '{jsonrpc: "2.0", method: "notifications/initialized"}'
+  jq -nc '{jsonrpc: "2.0", id: 2, method: "tools/list"}'
+  jq -nc --arg tool "$MCP_PROBE_TOOL" '{jsonrpc: "2.0", id: 3, method: "tools/call", params: {name: $tool, arguments: {}}}'
+} > "$MCP_REQUEST_FILE"
+
+set +e
+timeout "$MCP_TIMEOUT_SECONDS" "$CANARY_BIN" mcp-server < "$MCP_REQUEST_FILE" > "$MCP_RESPONSE_FILE" 2>/dev/null
+mcp_exit=$?
+set -e
+
+mcp_tools_listed=0
+mcp_probe_status="error"
+mcp_probe_message=""
+
+if ((mcp_exit == 0)) && [[ -s "$MCP_RESPONSE_FILE" ]]; then
+  mcp_tools_listed="$(jq -r 'select(.id == 2) | .result.tools | length' "$MCP_RESPONSE_FILE" 2>/dev/null | head -1)"
+  [[ -n "$mcp_tools_listed" ]] || mcp_tools_listed=0
+
+  call_is_error="$(jq -r 'select(.id == 3) | .result.isError' "$MCP_RESPONSE_FILE" 2>/dev/null | head -1)"
+  mcp_probe_message="$(jq -r 'select(.id == 3) | .result.content[0].text // ""' "$MCP_RESPONSE_FILE" 2>/dev/null | head -1)"
+
+  if [[ "$call_is_error" == "false" || "$call_is_error" == "null" ]]; then
+    mcp_probe_status="ok"
+  elif [[ "$call_is_error" == "true" && "$mcp_probe_message" == *"missing Canary endpoint"* ]]; then
+    mcp_probe_status="blocked"
+  else
+    mcp_probe_status="error"
+    UNEXPECTED_FAILURE=1
+    printf 'canary-readiness-proof: MCP tool call to %s returned an unexpected error: %s\n' "$MCP_PROBE_TOOL" "$mcp_probe_message" >&2
+  fi
+else
+  UNEXPECTED_FAILURE=1
+  printf 'canary-readiness-proof: mcp-server stdio session failed (exit %s)\n' "$mcp_exit" >&2
+fi
+
+if [[ "$mcp_tools_listed" != "$manifest_tool_count" ]]; then
+  manifest_stale=true
+  UNEXPECTED_FAILURE=1
+  printf 'canary-readiness-proof: MCP tools/list count (%s) does not match mcp-manifest tool count (%s)\n' "$mcp_tools_listed" "$manifest_tool_count" >&2
+fi
+
+# --- Step 5: integration/status discovery smoke ------------------------------
+
+set +e
+discovery_output="$("$DOGFOOD_INVENTORY_BIN" --json 2>&1)"
+discovery_exit=$?
+set -e
+
+if ((discovery_exit == 0)) && jq -e . >/dev/null 2>&1 <<<"$discovery_output"; then
+  discovery_status="ok"
+  discovery_summary="$(jq -c '.summary // null' <<<"$discovery_output")"
+elif ((discovery_exit == 2)); then
+  discovery_status="blocked"
+  discovery_summary=null
+  add_blocked_field "dogfood_registry" "$discovery_output" \
+    "configure .canary/dogfood/owned_services.json (see priv/dogfood/owned_services.example.json) or set CANARY_DOGFOOD_MANIFEST"
+else
+  discovery_status="error"
+  discovery_summary=null
+  UNEXPECTED_FAILURE=1
+  printf 'canary-readiness-proof: dogfood-inventory discovery smoke failed unexpectedly (exit %s): %s\n' "$discovery_exit" "$discovery_output" >&2
+fi
+
+# --- Step 6: repo gate --------------------------------------------------------
+
+if ((RUN_VALIDATE == 1)); then
+  set +e
+  validate_output="$("$VALIDATE_BIN" --fast 2>&1)"
+  validate_exit=$?
+  set -e
+  if ((validate_exit == 0)); then
+    validate_status="ok"
+  else
+    validate_status="failed"
+    UNEXPECTED_FAILURE=1
+    printf 'canary-readiness-proof: bin/validate --fast failed:\n%s\n' "$validate_output" >&2
+  fi
+else
+  validate_status="skipped"
+fi
+
+# --- Receipt -------------------------------------------------------------------
+
+FINISHED_AT="$(now_utc)"
+blocked_fields_json="$(jq -s '.' "$BLOCKED_FIELDS_FILE")"
+
+if [[ -z "${doctor_verdict:-}" ]]; then
+  doctor_verdict=null
+fi
+
+overall_status="ok"
+if ((UNEXPECTED_FAILURE == 1)); then
+  overall_status="error"
+elif [[ "$(jq 'length' <<<"$blocked_fields_json")" != "0" ]]; then
+  overall_status="blocked"
+fi
+
+receipt="$(jq -n \
+  --argjson schema_version 1 \
+  --arg status "$overall_status" \
+  --arg started_at "$STARTED_AT" \
+  --arg finished_at "$FINISHED_AT" \
+  --argjson endpoint_present "$endpoint_present" \
+  --argjson api_key_present "$api_key_present" \
+  --arg doctor_status "$doctor_status" \
+  --argjson doctor_verdict "$doctor_verdict" \
+  --argjson manifest_tool_count "$manifest_tool_count" \
+  --argjson manifest_stale "$manifest_stale" \
+  --argjson mcp_tools_listed "$mcp_tools_listed" \
+  --arg mcp_probe_tool "$MCP_PROBE_TOOL" \
+  --arg mcp_probe_status "$mcp_probe_status" \
+  --arg discovery_status "$discovery_status" \
+  --argjson discovery_summary "$discovery_summary" \
+  --arg validate_status "$validate_status" \
+  --argjson blocked_fields "$blocked_fields_json" \
+  '{
+    schema_version: $schema_version,
+    status: $status,
+    started_at: $started_at,
+    finished_at: $finished_at,
+    credentials: {
+      endpoint_present: $endpoint_present,
+      api_key_present: $api_key_present
+    },
+    doctor: {
+      status: $doctor_status,
+      verdict: $doctor_verdict
+    },
+    mcp: {
+      manifest_tool_count: $manifest_tool_count,
+      manifest_stale: $manifest_stale,
+      tools_list_count: $mcp_tools_listed,
+      probe_tool: $mcp_probe_tool,
+      probe_status: $mcp_probe_status
+    },
+    discovery: {
+      status: $discovery_status,
+      summary: $discovery_summary
+    },
+    validate: {
+      status: $validate_status
+    },
+    blocked_fields: $blocked_fields
+  }')"
+
+printf '%s\n' "$receipt" > "$RECEIPT"
+
+if ((JSON_OUTPUT == 1)); then
+  jq -c . <<<"$receipt"
+else
+  printf 'Canary cold-agent readiness proof: %s\n' "$overall_status"
+  printf 'receipt: %s\n' "$RECEIPT"
+  printf 'doctor: %s\n' "$doctor_status"
+  printf 'mcp manifest tools: %s (stale: %s)\n' "$manifest_tool_count" "$manifest_stale"
+  printf 'mcp probe (%s): %s\n' "$MCP_PROBE_TOOL" "$mcp_probe_status"
+  printf 'discovery: %s\n' "$discovery_status"
+  printf 'validate: %s\n' "$validate_status"
+  if [[ "$(jq 'length' <<<"$blocked_fields_json")" != "0" ]]; then
+    printf 'blocked fields:\n'
+    jq -r '.[] | "  - \(.field): \(.reason) -> \(.replacement_command)"' <<<"$blocked_fields_json"
+  fi
+fi
+
+if ((UNEXPECTED_FAILURE == 1)); then
+  exit 1
+fi
+exit 0

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -207,9 +207,11 @@ export class Ci {
       .withExec(["bash", "test/bin/dogfood_inventory_test.sh"])
       .withExec(["bash", "test/bin/canary_witness_test.sh"])
       .withExec(["bash", "test/bin/canary_write_path_rehearsal_test.sh"])
+      .withExec(["bash", "test/bin/canary_readiness_proof_test.sh"])
       .withExec(["bash", "-n", "bin/canary"])
       .withExec(["bash", "-n", "bin/canary-witness"])
       .withExec(["bash", "-n", "bin/canary-write-path-rehearsal"])
+      .withExec(["bash", "-n", "bin/canary-readiness-proof"])
       .withExec(["bash", "bin/check-aesthetic-currency"])
   }
 

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -221,6 +221,32 @@ If the GitHub CLI or auth is unavailable, the verdict still returns the
 replacement command plus the receipt artifact convention
 `canary-witness-<run_id>`.
 
+## Cold-Agent Readiness Proof
+
+A cold agent dropped into this repo with only credentials (or only a repo
+checkout) should not have to re-derive which of the commands above prove the
+CLI, MCP, and coverage surfaces actually work. `bin/canary-readiness-proof`
+is the one discoverable entrypoint that runs them in sequence and writes a
+redacted receipt:
+
+```bash
+bin/canary-readiness-proof --json
+```
+
+It runs `bin/canary doctor --json`, `bin/canary mcp-manifest --json` (checked
+against the checked-in `priv/mcp/canary-cli-tools.json` snapshot for drift), a
+`bin/canary mcp-server` stdio smoke (`initialize` → `tools/list` → one
+`tools/call` against a read-only tool), `bin/dogfood-inventory --json`, and
+`bin/validate --fast`. Missing `CANARY_ENDPOINT`/`CANARY_API_KEY` or an
+unconfigured dogfood registry are reported as concrete `blocked_fields` with a
+replacement command — the proof still exits `0`, because that is the expected
+state for a not-yet-configured instance. It exits nonzero only on a real
+defect: a stale generated MCP manifest, a broken MCP tool call, an unreadable
+dogfood registry, or a failing `bin/validate --fast`. See
+`bin/canary-readiness-proof --help` for flags, and
+`test/bin/canary_readiness_proof_test.sh` for the fixture coverage gating this
+script in CI.
+
 ## Integration Agent
 
 `integrate` is the agent-native setup loop for deployed applications. It is

--- a/test/bin/canary_readiness_proof_test.sh
+++ b/test/bin/canary_readiness_proof_test.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PROOF="$ROOT/bin/canary-readiness-proof"
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+assert_exit_code() {
+  local actual="$1" expected="$2" test_name="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected exit code: $expected"
+    echo "    Got: $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_json_equals() {
+  local json="$1" filter="$2" expected="$3" test_name="$4"
+  local actual
+  actual="$(jq -r "$filter" <<<"$json")"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Filter: $filter"
+    echo "    Expected: $expected"
+    echo "    Got: $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" test_name="$3"
+  if grep -qF -- "$needle" <<<"$haystack"; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected to contain: $needle"
+    echo "    Got: $haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# A stub `canary` CLI covering doctor/mcp-manifest/mcp-server so this test
+# runs offline without a live server or a compiled binary. Behavior is
+# switched by the FIXTURE_* env vars each test case sets below.
+write_stub_canary() {
+  local path="$1"
+  cat > "$path" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+has_endpoint=0
+has_key=0
+subcommand=""
+skip_next=0
+for arg in "$@"; do
+  if [[ $skip_next -eq 1 ]]; then
+    skip_next=0
+    continue
+  fi
+  case "$arg" in
+    --endpoint) has_endpoint=1; skip_next=1 ;;
+    --api-key) has_key=1; skip_next=1 ;;
+    --json) ;;
+    --*) skip_next=1 ;;
+    *)
+      if [[ -z "$subcommand" ]]; then
+        subcommand="$arg"
+      fi
+      ;;
+  esac
+done
+
+TOOL_NAMES='["canary_summary","canary_errors"]'
+if [[ "${FIXTURE_MANIFEST_TOOLS:-}" != "" ]]; then
+  TOOL_NAMES="$FIXTURE_MANIFEST_TOOLS"
+fi
+
+case "$subcommand" in
+  doctor)
+    if [[ $has_endpoint -eq 1 && $has_key -eq 1 ]]; then
+      echo '{"command":"doctor","endpoint":"http://stub","response":{"verdict":{"overall":"healthy"}}}'
+      exit 0
+    fi
+    echo "canary: missing Canary endpoint; set --endpoint, CANARY_ENDPOINT, or config endpoint" >&2
+    exit 1
+    ;;
+  mcp-manifest)
+    jq -cn --argjson names "$TOOL_NAMES" '{schema_version: 1, tools: ($names | map({name: ., description: "", input_schema: {}}))}'
+    exit 0
+    ;;
+  mcp-server)
+    while IFS= read -r line; do
+      id="$(jq -r '.id // empty' <<<"$line")"
+      method="$(jq -r '.method // empty' <<<"$line")"
+      case "$method" in
+        initialize)
+          jq -cn --argjson id "$id" '{jsonrpc: "2.0", id: $id, result: {protocolVersion: "2025-11-25", capabilities: {tools: {listChanged: false}}}}'
+          ;;
+        tools/list)
+          jq -cn --argjson id "$id" --argjson names "$TOOL_NAMES" \
+            '{jsonrpc: "2.0", id: $id, result: {tools: ($names | map({name: ., inputSchema: {type: "object"}}))}}'
+          ;;
+        tools/call)
+          case "${FIXTURE_MCP_CALL:-ok}" in
+            ok)
+              jq -cn --argjson id "$id" '{jsonrpc: "2.0", id: $id, result: {content: [{type: "text", text: "{}"}], structuredContent: {}}}'
+              ;;
+            blocked)
+              jq -cn --argjson id "$id" '{jsonrpc: "2.0", id: $id, result: {isError: true, content: [{type: "text", text: "missing Canary endpoint; set --endpoint, CANARY_ENDPOINT, or config endpoint"}]}}'
+              ;;
+            error)
+              jq -cn --argjson id "$id" '{jsonrpc: "2.0", id: $id, result: {isError: true, content: [{type: "text", text: "boom: unexpected tool failure"}]}}'
+              ;;
+          esac
+          ;;
+      esac
+    done
+    ;;
+  *)
+    echo "stub canary: unsupported subcommand ${args[0]:-}" >&2
+    exit 2
+    ;;
+esac
+STUB
+  chmod +x "$path"
+}
+
+write_stub_dogfood_inventory() {
+  local path="$1"
+  cat > "$path" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${FIXTURE_DISCOVERY:-blocked}" in
+  ok)
+    echo '{"summary":{"covered":1,"partial":0,"blocked":0,"ignored":0,"strict_failures":0}}'
+    exit 0
+    ;;
+  blocked)
+    echo "dogfood-inventory: manifest not found: /fixture/owned_services.json" >&2
+    exit 2
+    ;;
+  error)
+    echo "dogfood-inventory: unexpected internal error" >&2
+    exit 3
+    ;;
+esac
+STUB
+  chmod +x "$path"
+}
+
+write_stub_validate() {
+  local path="$1"
+  cat > "$path" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${FIXTURE_VALIDATE:-ok}" == "ok" ]]; then
+  echo "fixture validate ok"
+  exit 0
+fi
+echo "fixture validate failed" >&2
+exit 1
+STUB
+  chmod +x "$path"
+}
+
+STUB_CANARY="$TMPDIR_TEST/canary"
+STUB_DOGFOOD="$TMPDIR_TEST/dogfood-inventory"
+STUB_VALIDATE="$TMPDIR_TEST/validate"
+write_stub_canary "$STUB_CANARY"
+write_stub_dogfood_inventory "$STUB_DOGFOOD"
+write_stub_validate "$STUB_VALIDATE"
+
+run_proof() {
+  local receipt="$TMPDIR_TEST/receipt-$RANDOM.json"
+  local rc=0
+  local out
+  out="$(
+    CANARY_READINESS_CANARY_BIN="$STUB_CANARY" \
+    CANARY_READINESS_DOGFOOD_INVENTORY_BIN="$STUB_DOGFOOD" \
+    CANARY_READINESS_VALIDATE_BIN="$STUB_VALIDATE" \
+    CANARY_READINESS_STATIC_MANIFEST="${CANARY_READINESS_STATIC_MANIFEST:-$TMPDIR_TEST/nonexistent-static-manifest.json}" \
+    CANARY_READINESS_RECEIPT="$receipt" \
+    "$@" bash "$PROOF" --skip-validate --json 2>"$TMPDIR_TEST/stderr.log"
+  )" && rc=0 || rc=$?
+  printf '%s\n%s\n%s' "$rc" "$out" "$receipt"
+}
+
+echo "Test 1: missing credentials reports blocked fields without failing"
+result="$(unset CANARY_ENDPOINT CANARY_API_KEY CANARY_READ_API_KEY; run_proof)"
+rc="$(sed -n '1p' <<<"$result")"
+body="$(sed -n '2p' <<<"$result")"
+assert_exit_code "$rc" "0" "missing credentials exits 0"
+assert_json_equals "$body" ".status" "blocked" "status is blocked"
+assert_json_equals "$body" ".credentials.endpoint_present" "false" "endpoint reported absent"
+assert_json_equals "$body" ".credentials.api_key_present" "false" "api key reported absent"
+assert_json_equals "$body" '.blocked_fields | map(.field) | index("endpoint") != null' "true" "endpoint listed as blocked field"
+assert_json_equals "$body" '.blocked_fields | map(.field) | index("read_api_key") != null' "true" "read_api_key listed as blocked field"
+assert_json_equals "$body" '.blocked_fields[] | select(.field == "read_api_key") | .replacement_command | contains("CANARY_API_KEY")' "true" "read_api_key blocked field names a replacement command"
+
+echo "Test 2: a real API key value never appears in the receipt, only presence"
+result="$(CANARY_ENDPOINT=http://stub CANARY_API_KEY="sk_live_should_never_appear_in_receipt" FIXTURE_DISCOVERY=ok FIXTURE_MCP_CALL=ok run_proof)"
+body="$(sed -n '2p' <<<"$result")"
+if grep -qF "sk_live_should_never_appear_in_receipt" <<<"$body"; then
+  echo "  FAIL: receipt leaks the literal key value"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: receipt does not leak the literal key value"
+  PASS=$((PASS + 1))
+fi
+assert_json_equals "$body" ".credentials.api_key_present" "true" "receipt still records that a key was present"
+
+echo "Test 3: full credentials with healthy CLI/MCP/discovery reports ok"
+result="$(CANARY_ENDPOINT=http://stub CANARY_API_KEY=sk_live_test_fixture_key FIXTURE_DISCOVERY=ok FIXTURE_MCP_CALL=ok run_proof)"
+rc="$(sed -n '1p' <<<"$result")"
+body="$(sed -n '2p' <<<"$result")"
+assert_exit_code "$rc" "0" "healthy run exits 0"
+assert_json_equals "$body" ".status" "ok" "status is ok"
+assert_json_equals "$body" ".doctor.status" "ok" "doctor reports ok"
+assert_json_equals "$body" ".mcp.probe_status" "ok" "mcp probe reports ok"
+assert_json_equals "$body" ".discovery.status" "ok" "discovery reports ok"
+assert_json_equals "$body" ".mcp.manifest_stale" "false" "manifest is not stale when tools/list matches mcp-manifest"
+
+echo "Test 4: unconfigured dogfood registry is blocked, not a failure"
+result="$(CANARY_ENDPOINT=http://stub CANARY_API_KEY=sk_live_test_fixture_key FIXTURE_DISCOVERY=blocked FIXTURE_MCP_CALL=ok run_proof)"
+rc="$(sed -n '1p' <<<"$result")"
+body="$(sed -n '2p' <<<"$result")"
+assert_exit_code "$rc" "0" "blocked discovery still exits 0"
+assert_json_equals "$body" ".status" "blocked" "status is blocked"
+assert_json_equals "$body" ".discovery.status" "blocked" "discovery reports blocked"
+assert_json_equals "$body" '.blocked_fields[] | select(.field == "dogfood_registry") | .replacement_command | contains("owned_services.json")' "true" "dogfood_registry blocked field names the registry file"
+
+echo "Test 5: an unexpected discovery error fails the proof"
+result="$(CANARY_ENDPOINT=http://stub CANARY_API_KEY=sk_live_test_fixture_key FIXTURE_DISCOVERY=error FIXTURE_MCP_CALL=ok run_proof)"
+rc="$(sed -n '1p' <<<"$result")"
+body="$(sed -n '2p' <<<"$result")"
+assert_exit_code "$rc" "1" "unexpected discovery error exits nonzero"
+assert_json_equals "$body" ".status" "error" "status is error"
+
+echo "Test 6: a stale generated MCP manifest fails the proof"
+cat > "$TMPDIR_TEST/stale-static-manifest.json" <<'JSON'
+{"schema_version":1,"tools":[{"name":"canary_summary"},{"name":"canary_errors"}]}
+JSON
+result="$(CANARY_ENDPOINT=http://stub CANARY_API_KEY=sk_live_test_fixture_key FIXTURE_DISCOVERY=ok FIXTURE_MCP_CALL=ok FIXTURE_MANIFEST_TOOLS='["canary_summary","canary_new_tool_not_in_snapshot"]' CANARY_READINESS_STATIC_MANIFEST="$TMPDIR_TEST/stale-static-manifest.json" run_proof)"
+rc="$(sed -n '1p' <<<"$result")"
+body="$(sed -n '2p' <<<"$result")"
+assert_exit_code "$rc" "1" "stale manifest exits nonzero"
+assert_json_equals "$body" ".mcp.manifest_stale" "true" "manifest_stale is true"
+assert_json_equals "$body" ".status" "error" "status is error"
+
+echo "Test 7: an unexpected MCP tool-call defect fails the proof"
+result="$(CANARY_ENDPOINT=http://stub CANARY_API_KEY=sk_live_test_fixture_key FIXTURE_DISCOVERY=ok FIXTURE_MCP_CALL=error run_proof)"
+rc="$(sed -n '1p' <<<"$result")"
+body="$(sed -n '2p' <<<"$result")"
+assert_exit_code "$rc" "1" "unexpected mcp tool defect exits nonzero"
+assert_json_equals "$body" ".mcp.probe_status" "error" "mcp probe reports error"
+assert_json_equals "$body" ".status" "error" "status is error"
+
+echo "Test 8: --help documents the proof without requiring credentials"
+help_output="$(bash "$PROOF" --help)"
+assert_contains "$help_output" "Usage: bin/canary-readiness-proof" "usage line present"
+assert_contains "$help_output" "bin/canary doctor" "help mentions doctor step"
+assert_contains "$help_output" "bin/validate --fast" "help mentions the repo gate step"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Adds `bin/canary-readiness-proof`, one discoverable, repeatable entrypoint proving a cold agent can inspect and operate this Canary instance: `doctor`, `mcp-manifest`/`mcp-server` (against #052's shipped MCP server, cross-checked for manifest drift), `dogfood-inventory` discovery, and `bin/validate --fast`, ending in a redacted receipt.
- Missing `CANARY_ENDPOINT`/`CANARY_API_KEY` or an unconfigured dogfood registry report as concrete `blocked_fields` (field, reason, replacement command) and the proof still exits `0` — that's the documented state for a not-yet-configured instance. It exits nonzero only on a real defect: a stale generated MCP manifest, an unexpected MCP tool-call error, an unreadable dogfood registry, or a failing repo gate. No secret values are ever interpolated into the receipt.
- Links the proof from `AGENTS.md`, `README.md`, and `docs/agent-inspection-cli.md` per the ticket's children.

## Test plan
- [x] `test/bin/canary_readiness_proof_test.sh` — 30 fixture assertions (missing credentials, healthy run, blocked discovery, unexpected discovery error, stale manifest, unexpected MCP tool defect, `--help`), wired into Dagger's `scriptsQualityContainer` alongside a `bash -n` syntax check.
- [x] Verified live against a local `cargo run -p canary-server` instance: blocked path with no credentials, and the full happy path with a bootstrap admin key.
- [x] `./bin/validate --fast` green.
- [x] `./bin/validate --strict` green (ran via the pre-push hook).

Closes the P1 half of `backlog.d/050-cold-agent-readiness-proof.md`; see that file's new `## Implementation` section for detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)