### PR TITLE
fix(readiness): expose overdue monitor details

### DIFF
--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -3396,8 +3396,10 @@ fn alert_plane_detail(worker: &Value) -> Value {
         "due_count": worker.get("due_count").and_then(Value::as_u64).unwrap_or(0),
         "in_flight_count": worker.get("in_flight_count").and_then(Value::as_u64).unwrap_or(0),
         "oldest_due_age_ms": worker.get("oldest_due_age_ms").cloned().unwrap_or(Value::Null),
+        "oldest_due_item": worker.get("oldest_due_item").cloned().unwrap_or(Value::Null),
         "backoff_or_circuit_open": worker.get("backoff_or_circuit_open").and_then(Value::as_bool).unwrap_or(false),
-        "reason": alert_worker_reason(worker)
+        "reason": alert_worker_reason(worker),
+        "detail": alert_worker_detail(worker)
     })
 }
 
@@ -3454,6 +3456,76 @@ fn alert_worker_reason(worker: &Value) -> String {
     format!("{name} impaired")
 }
 
+fn alert_worker_detail(worker: &Value) -> String {
+    oldest_due_item_reason(worker).unwrap_or_else(|| alert_worker_reason(worker))
+}
+
+fn oldest_due_item_reason(worker: &Value) -> Option<String> {
+    let item = worker.get("oldest_due_item")?;
+    if item.is_null() {
+        return None;
+    }
+    let worker_name = string_field(worker, "name");
+    let subject_type = string_field(item, "subject_type");
+    let subject_id = string_field(item, "subject_id");
+    let item_name = string_field(item, "name");
+    let expected = item
+        .get("expected_every_ms")
+        .and_then(Value::as_u64)
+        .map(format_duration_ms)
+        .unwrap_or_else(|| "unknown cadence".to_owned());
+    let grace = item
+        .get("grace_ms")
+        .and_then(Value::as_u64)
+        .map(format_duration_ms)
+        .unwrap_or_else(|| "unknown grace".to_owned());
+    let age = item
+        .get("age_ms")
+        .or_else(|| worker.get("oldest_due_age_ms"))
+        .and_then(Value::as_u64)
+        .map(format_duration_ms)
+        .unwrap_or_else(|| "unknown age".to_owned());
+
+    Some(format!(
+        "{worker_name} pressured: {subject_type} {item_name} ({subject_id}) expected every {expected} + {grace} grace; overdue {age}"
+    ))
+}
+
+fn format_duration_ms(ms: u64) -> String {
+    if ms < 1_000 {
+        return format!("{ms}ms");
+    }
+    let seconds = ms / 1_000;
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        let remainder = seconds % 60;
+        return if remainder == 0 {
+            format!("{minutes}m")
+        } else {
+            format!("{minutes}m {remainder}s")
+        };
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        let remainder = minutes % 60;
+        return if remainder == 0 {
+            format!("{hours}h")
+        } else {
+            format!("{hours}h {remainder}m")
+        };
+    }
+    let days = hours / 24;
+    let remainder = hours % 24;
+    if remainder == 0 {
+        format!("{days}d")
+    } else {
+        format!("{days}d {remainder}h")
+    }
+}
+
 fn alert_plane_reason(worker: &Value) -> String {
     worker
         .get("reason")
@@ -3462,6 +3534,20 @@ fn alert_plane_reason(worker: &Value) -> String {
 }
 
 fn alert_plane_reason_summary(alert_plane: &Value) -> String {
+    let details = alert_plane
+        .get("workers")
+        .and_then(Value::as_array)
+        .map(|workers| {
+            workers
+                .iter()
+                .filter_map(|worker| worker.get("detail").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !details.is_empty() {
+        return details.join(", ");
+    }
+
     let reasons = alert_plane
         .get("reasons")
         .and_then(Value::as_array)
@@ -3507,6 +3593,7 @@ fn worker_pressure_detail(worker: &Value) -> Value {
         "due_count": worker.get("due_count").and_then(Value::as_u64).unwrap_or(0),
         "in_flight_count": worker.get("in_flight_count").and_then(Value::as_u64).unwrap_or(0),
         "oldest_due_age_ms": worker.get("oldest_due_age_ms").cloned().unwrap_or(Value::Null),
+        "oldest_due_item": worker.get("oldest_due_item").cloned().unwrap_or(Value::Null),
         "backoff_or_circuit_open": worker.get("backoff_or_circuit_open").and_then(Value::as_bool).unwrap_or(false)
     })
 }
@@ -5117,7 +5204,27 @@ mod tests {
             "failing_workers": 0,
             "pressured_workers": 1,
             "workers": [
-                {"name": "monitor_overdue", "state": "started", "health": "pressured", "failure_count": 0, "consecutive_failures": 0, "due_count": 1, "oldest_due_age_ms": 7200000, "backoff_or_circuit_open": false},
+                {
+                    "name": "monitor_overdue",
+                    "state": "started",
+                    "health": "pressured",
+                    "failure_count": 0,
+                    "consecutive_failures": 0,
+                    "due_count": 1,
+                    "oldest_due_age_ms": 7200000,
+                    "oldest_due_item": {
+                        "subject_type": "monitor",
+                        "subject_id": "MON-4uhhh40u445u",
+                        "name": "powder",
+                        "service": "powder",
+                        "expected_every_ms": 300000,
+                        "grace_ms": 60000,
+                        "last_observed_at": "2026-07-03T22:00:00Z",
+                        "deadline_at": "2026-07-03T22:06:00Z",
+                        "age_ms": 7200000
+                    },
+                    "backoff_or_circuit_open": false
+                },
                 {"name": "target_probe", "state": "started", "health": "ok", "failure_count": 0, "consecutive_failures": 0, "due_count": 0, "oldest_due_age_ms": null, "backoff_or_circuit_open": false}
             ]
         });
@@ -5140,15 +5247,21 @@ mod tests {
         );
 
         assert_eq!(alert_plane["status"], "impaired");
+        assert_eq!(alert_plane["reasons"], json!(["monitor_overdue pressured"]));
+        assert_eq!(
+            alert_plane["workers"][0]["detail"],
+            "monitor_overdue pressured: monitor powder (MON-4uhhh40u445u) expected every 5m + 1m grace; overdue 2h"
+        );
         assert_eq!(verdict["overall"], "degraded");
         assert_eq!(verdict["alert_plane"]["status"], "impaired");
         assert!(
             verdict["blocking_signals"]
                 .as_array()
-                .is_some_and(|signals| signals.iter().any(|signal| signal
-                    .as_str()
-                    .unwrap_or_default()
-                    .contains("alert-plane impaired: monitor_overdue pressured")))
+                .is_some_and(|signals| signals
+                    .iter()
+                    .any(|signal| signal.as_str().unwrap_or_default().contains(
+                        "alert-plane impaired: monitor_overdue pressured: monitor powder"
+                    )))
         );
         assert!(
             verdict["next_operator_action"]

--- a/crates/canary-http/src/public.rs
+++ b/crates/canary-http/src/public.rs
@@ -139,8 +139,34 @@ pub struct WorkerReadyzCheck {
     pub in_flight_count: u64,
     /// Milliseconds by which the oldest due work item is overdue, when known.
     pub oldest_due_age_ms: Option<u64>,
+    /// Identifying metadata for the oldest due work item, when the worker can expose it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oldest_due_item: Option<WorkerDueItem>,
     /// Whether the last observed pass saw backoff, circuit-open, or interruption pressure.
     pub backoff_or_circuit_open: bool,
+}
+
+/// Readiness-safe metadata for one due background-worker subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerDueItem {
+    /// Durable subject type, such as monitor.
+    pub subject_type: String,
+    /// Durable subject id.
+    pub subject_id: String,
+    /// Human-readable subject name.
+    pub name: String,
+    /// Owning service name.
+    pub service: String,
+    /// Expected cadence in milliseconds, when applicable.
+    pub expected_every_ms: Option<u64>,
+    /// Grace period in milliseconds, when applicable.
+    pub grace_ms: Option<u64>,
+    /// Last observed timestamp for the subject, when applicable.
+    pub last_observed_at: Option<String>,
+    /// Current due deadline timestamp, when applicable.
+    pub deadline_at: Option<String>,
+    /// Milliseconds since the subject became due, when known.
+    pub age_ms: Option<u64>,
 }
 
 /// Background worker lifecycle state.
@@ -297,6 +323,7 @@ mod tests {
                     due_count: 0,
                     in_flight_count: 0,
                     oldest_due_age_ms: None,
+                    oldest_due_item: None,
                     backoff_or_circuit_open: false,
                 },
                 WorkerReadyzCheck {
@@ -311,6 +338,7 @@ mod tests {
                     due_count: 0,
                     in_flight_count: 0,
                     oldest_due_age_ms: None,
+                    oldest_due_item: None,
                     backoff_or_circuit_open: false,
                 },
             ],
@@ -345,6 +373,7 @@ mod tests {
                     due_count: 12,
                     in_flight_count: 0,
                     oldest_due_age_ms: Some(90_000),
+                    oldest_due_item: None,
                     backoff_or_circuit_open: true,
                 }],
             );
@@ -372,6 +401,17 @@ mod tests {
                 due_count: 1,
                 in_flight_count: 0,
                 oldest_due_age_ms: Some(690_853),
+                oldest_due_item: Some(WorkerDueItem {
+                    subject_type: "monitor".to_owned(),
+                    subject_id: "MON-powder".to_owned(),
+                    name: "powder".to_owned(),
+                    service: "powder".to_owned(),
+                    expected_every_ms: Some(300_000),
+                    grace_ms: Some(60_000),
+                    last_observed_at: Some("2026-06-12T19:54:29Z".to_owned()),
+                    deadline_at: Some("2026-06-12T20:00:00Z".to_owned()),
+                    age_ms: Some(690_853),
+                }),
                 backoff_or_circuit_open: false,
             }],
         );
@@ -384,6 +424,20 @@ mod tests {
         assert_eq!(body["checks"]["workers"][0]["health"], "pressured");
         assert_eq!(body["checks"]["workers"][0]["due_count"], 1);
         assert_eq!(body["checks"]["workers"][0]["oldest_due_age_ms"], 690_853);
+        assert_eq!(
+            body["checks"]["workers"][0]["oldest_due_item"],
+            json!({
+                "subject_type": "monitor",
+                "subject_id": "MON-powder",
+                "name": "powder",
+                "service": "powder",
+                "expected_every_ms": 300000,
+                "grace_ms": 60000,
+                "last_observed_at": "2026-06-12T19:54:29Z",
+                "deadline_at": "2026-06-12T20:00:00Z",
+                "age_ms": 690853
+            })
+        );
     }
 
     #[test]
@@ -424,6 +478,25 @@ mod tests {
                 "in_flight_count",
                 "oldest_due_age_ms",
                 "backoff_or_circuit_open"
+            ])
+        );
+        assert_eq!(
+            document["components"]["schemas"]["WorkerReadyzCheck"]["properties"]["oldest_due_item"]
+                ["anyOf"][0]["$ref"],
+            "#/components/schemas/WorkerDueItem"
+        );
+        assert_eq!(
+            document["components"]["schemas"]["WorkerDueItem"]["required"],
+            json!([
+                "subject_type",
+                "subject_id",
+                "name",
+                "service",
+                "expected_every_ms",
+                "grace_ms",
+                "last_observed_at",
+                "deadline_at",
+                "age_ms"
             ])
         );
     }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -611,6 +611,7 @@ mod tests {
                         due_count: 0,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,
+                        oldest_due_item: None,
                         backoff_or_circuit_open: false,
                     },
                     WorkerReadyzCheck {
@@ -625,6 +626,7 @@ mod tests {
                         due_count: 0,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,
+                        oldest_due_item: None,
                         backoff_or_circuit_open: false,
                     },
                 ],

--- a/crates/canary-server/src/monitor_overdue.rs
+++ b/crates/canary-server/src/monitor_overdue.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use canary_core::health::state_machine::HealthState;
+use canary_http::public::WorkerDueItem;
 use canary_store::{MonitorOverdueCandidate, Store};
 use canary_workers::health::{
     HealthPlanError, MonitorMode, MonitorOverdueSnapshot, ObservationContext, plan_monitor_overdue,
@@ -107,6 +108,8 @@ pub struct MonitorOverdueLifecycleReport {
     pub loaded: usize,
     /// Age in milliseconds of the oldest loaded overdue deadline.
     pub oldest_due_age_ms: Option<u64>,
+    /// Identifying metadata for the oldest loaded overdue deadline.
+    pub oldest_due_item: Option<WorkerDueItem>,
     /// Candidates that produced no transition.
     pub noop: usize,
     /// Candidates that committed an overdue transition.
@@ -150,6 +153,7 @@ impl MonitorOverdueLifecycle {
         let mut report = MonitorOverdueLifecycleReport {
             loaded: candidates.len(),
             oldest_due_age_ms: oldest_monitor_due_age_ms(now_millis, &candidates),
+            oldest_due_item: oldest_monitor_due_item(now_millis, &candidates),
             ..MonitorOverdueLifecycleReport::default()
         };
 
@@ -408,6 +412,7 @@ fn run_lifecycle_worker(
                         due_count: report.loaded as u64,
                         in_flight_count: 0,
                         oldest_due_age_ms: report.oldest_due_age_ms,
+                        oldest_due_item: report.oldest_due_item,
                         backoff_or_circuit_open: report.failed > 0
                             || report.event_fanout_failed > 0
                             || report.interrupted,
@@ -452,17 +457,43 @@ fn oldest_monitor_due_age_ms(
 ) -> Option<u64> {
     candidates
         .iter()
-        .filter_map(|candidate| candidate.deadline_at.as_deref())
-        .filter_map(|deadline| OffsetDateTime::parse(deadline, &Rfc3339).ok())
-        .map(|deadline| {
-            let deadline_millis = deadline
-                .unix_timestamp()
-                .saturating_mul(1_000)
-                .saturating_add(i64::from(deadline.millisecond()));
-            now_millis.saturating_sub(deadline_millis)
-        })
+        .filter_map(|candidate| monitor_due_age_ms(now_millis, candidate.deadline_at.as_deref()))
         .map(|age| age.max(0) as u64)
         .max()
+}
+
+fn oldest_monitor_due_item(
+    now_millis: i64,
+    candidates: &[MonitorOverdueCandidate],
+) -> Option<WorkerDueItem> {
+    candidates
+        .iter()
+        .filter_map(|candidate| {
+            let age_ms =
+                monitor_due_age_ms(now_millis, candidate.deadline_at.as_deref())?.max(0) as u64;
+            Some((age_ms, candidate))
+        })
+        .max_by_key(|(age_ms, _)| *age_ms)
+        .map(|(age_ms, candidate)| WorkerDueItem {
+            subject_type: "monitor".to_owned(),
+            subject_id: candidate.id.clone(),
+            name: candidate.name.clone(),
+            service: candidate.service.clone(),
+            expected_every_ms: u64::try_from(candidate.expected_every_ms).ok(),
+            grace_ms: u64::try_from(candidate.grace_ms).ok(),
+            last_observed_at: candidate.last_check_in_at.clone(),
+            deadline_at: candidate.deadline_at.clone(),
+            age_ms: Some(age_ms),
+        })
+}
+
+fn monitor_due_age_ms(now_millis: i64, deadline_at: Option<&str>) -> Option<i64> {
+    let deadline = OffsetDateTime::parse(deadline_at?, &Rfc3339).ok()?;
+    let deadline_millis = deadline
+        .unix_timestamp()
+        .saturating_mul(1_000)
+        .saturating_add(i64::from(deadline.millisecond()));
+    Some(now_millis.saturating_sub(deadline_millis))
 }
 
 fn monitor_mode(value: &str) -> Option<MonitorMode> {
@@ -560,6 +591,7 @@ mod tests {
             MonitorOverdueLifecycleReport {
                 loaded: 1,
                 oldest_due_age_ms: Some(0),
+                oldest_due_item: overdue_item("MON-overdue", "Overdue worker"),
                 noop: 0,
                 transitioned: 1,
                 failed: 0,
@@ -573,6 +605,7 @@ mod tests {
             MonitorOverdueLifecycleReport {
                 loaded: 1,
                 oldest_due_age_ms: Some(0),
+                oldest_due_item: overdue_item("MON-overdue", "Overdue worker"),
                 noop: 1,
                 transitioned: 0,
                 failed: 0,
@@ -684,6 +717,7 @@ mod tests {
             MonitorOverdueLifecycleReport {
                 loaded: 2,
                 oldest_due_age_ms: Some(0),
+                oldest_due_item: overdue_item("MON-overdue-b", "Overdue worker MON-overdue-b"),
                 noop: 0,
                 transitioned: 1,
                 failed: 0,
@@ -792,5 +826,19 @@ mod tests {
             transition: None,
         })?;
         Ok(())
+    }
+
+    fn overdue_item(id: &str, name: &str) -> Option<WorkerDueItem> {
+        Some(WorkerDueItem {
+            subject_type: "monitor".to_owned(),
+            subject_id: id.to_owned(),
+            name: name.to_owned(),
+            service: "worker".to_owned(),
+            expected_every_ms: Some(60_000),
+            grace_ms: Some(5_000),
+            last_observed_at: Some("2026-05-28T20:00:00Z".to_owned()),
+            deadline_at: Some("2026-05-28T20:00:05Z".to_owned()),
+            age_ms: Some(0),
+        })
     }
 }

--- a/crates/canary-server/src/retention_prune.rs
+++ b/crates/canary-server/src/retention_prune.rs
@@ -330,6 +330,7 @@ fn run_lifecycle_worker(
                             + report.target_checks_deleted,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,
+                        oldest_due_item: None,
                         backoff_or_circuit_open: report.interrupted,
                     },
                 ),

--- a/crates/canary-server/src/target_probes.rs
+++ b/crates/canary-server/src/target_probes.rs
@@ -870,6 +870,7 @@ fn run_lifecycle_worker(
                         due_count: report.due as u64,
                         in_flight_count: report.in_flight as u64,
                         oldest_due_age_ms: report.oldest_due_age_ms,
+                        oldest_due_item: None,
                         backoff_or_circuit_open: report.failed > 0
                             || report.event_fanout_failed > 0,
                     },

--- a/crates/canary-server/src/tls_scan.rs
+++ b/crates/canary-server/src/tls_scan.rs
@@ -368,6 +368,7 @@ fn run_lifecycle_worker(
                         due_count: report.loaded as u64,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,
+                        oldest_due_item: None,
                         backoff_or_circuit_open: report.failed > 0
                             || report.event_fanout_failed > 0
                             || report.interrupted,

--- a/crates/canary-server/src/webhook_delivery.rs
+++ b/crates/canary-server/src/webhook_delivery.rs
@@ -573,6 +573,7 @@ fn run_drain_worker(
                     due_count: u64::from(report.due_count),
                     in_flight_count: u64::from(report.in_flight_count),
                     oldest_due_age_ms: report.oldest_due_age_ms,
+                    oldest_due_item: None,
                     backoff_or_circuit_open: report.retried > 0
                         || report.discarded > 0
                         || report.circuit_open_suppressed > 0

--- a/crates/canary-server/src/worker_health.rs
+++ b/crates/canary-server/src/worker_health.rs
@@ -9,7 +9,9 @@ use std::sync::{
     atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
 };
 
-use canary_http::public::{WorkerHealthStatus, WorkerLifecycleState, WorkerReadyzCheck};
+use canary_http::public::{
+    WorkerDueItem, WorkerHealthStatus, WorkerLifecycleState, WorkerReadyzCheck,
+};
 
 /// Stable names for lifecycle workers exposed through readiness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,7 +143,7 @@ pub struct WorkerHealthHandle {
 }
 
 /// Last-observed work pressure for a lifecycle pass.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WorkerPressureSnapshot {
     /// Work items due at the last observed lifecycle pass.
     pub due_count: u64,
@@ -149,6 +151,8 @@ pub struct WorkerPressureSnapshot {
     pub in_flight_count: u64,
     /// Milliseconds by which the oldest due work item is overdue, when known.
     pub oldest_due_age_ms: Option<u64>,
+    /// Identifying metadata for the oldest due work item, when known.
+    pub oldest_due_item: Option<WorkerDueItem>,
     /// Whether the pass saw backoff, circuit-open, or interruption pressure.
     pub backoff_or_circuit_open: bool,
 }
@@ -241,7 +245,7 @@ impl WorkerHealthHandle {
             state,
             last_success_age_ms,
             consecutive_failures,
-            details.pressure,
+            &details.pressure,
         );
 
         WorkerReadyzCheck {
@@ -256,6 +260,7 @@ impl WorkerHealthHandle {
             due_count: details.pressure.due_count,
             in_flight_count: details.pressure.in_flight_count,
             oldest_due_age_ms: details.pressure.oldest_due_age_ms,
+            oldest_due_item: details.pressure.oldest_due_item,
             backoff_or_circuit_open: details.pressure.backoff_or_circuit_open,
         }
     }
@@ -291,7 +296,7 @@ fn health_status(
     state: WorkerLifecycleState,
     last_success_age_ms: Option<u64>,
     consecutive_failures: u64,
-    pressure: WorkerPressureSnapshot,
+    pressure: &WorkerPressureSnapshot,
 ) -> WorkerHealthStatus {
     if !matches!(state, WorkerLifecycleState::Started) {
         return WorkerHealthStatus::Stopped;
@@ -354,6 +359,7 @@ mod tests {
                 due_count: 2,
                 in_flight_count: 1,
                 oldest_due_age_ms: Some(250),
+                oldest_due_item: None,
                 backoff_or_circuit_open: false,
             },
         );

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -508,11 +508,14 @@ for attempt in $(seq 1 30); do
     and .response.worker_readiness.status == "ready"
     and .response.worker_readiness.pressured_workers >= 1
     and .response.alert_plane.status == "impaired"
-    and (.response.alert_plane.reasons | index("monitor_overdue pressured") != null)
+    and any(.response.alert_plane.reasons[]?; startswith("monitor_overdue pressured"))
     and any(.response.alert_plane.workers[]?;
       .name == "monitor_overdue"
       and .health == "pressured"
-      and ((.oldest_due_age_ms // 0) > 120000))
+      and ((.oldest_due_age_ms // 0) > 120000)
+      and .oldest_due_item.subject_type == "monitor"
+      and (.oldest_due_item.subject_id | startswith("MON-"))
+      and (.oldest_due_item.name | startswith("canary-alert-plane-")))
     and any(.response.verdict.blocking_signals[]?;
       startswith("alert-plane impaired:"))
   ' /tmp/canary-alert-plane-doctor.json >/dev/null; then
@@ -530,7 +533,7 @@ for attempt in $(seq 1 30); do
     jq -e '
       .status == "degraded"
       and .alert_plane.status == "impaired"
-      and (.alert_plane.reasons | index("monitor_overdue pressured") != null)
+      and any(.alert_plane.reasons[]?; startswith("monitor_overdue pressured"))
       and .check_in.skipped == true
     ' /tmp/canary-alert-plane-witness.json >/dev/null
     jq '{

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -2952,8 +2952,87 @@
             ],
             "minimum": 0
           },
+          "oldest_due_item": {
+            "description": "Identifying metadata for the oldest due work item, when the worker can expose it.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkerDueItem"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "backoff_or_circuit_open": {
             "type": "boolean"
+          }
+        }
+      },
+      "WorkerDueItem": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "subject_type",
+          "subject_id",
+          "name",
+          "service",
+          "expected_every_ms",
+          "grace_ms",
+          "last_observed_at",
+          "deadline_at",
+          "age_ms"
+        ],
+        "properties": {
+          "subject_type": {
+            "type": "string",
+            "description": "Durable subject type, such as monitor."
+          },
+          "subject_id": {
+            "type": "string",
+            "description": "Durable subject id."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable subject name."
+          },
+          "service": {
+            "type": "string",
+            "description": "Owning service name."
+          },
+          "expected_every_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "grace_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "last_observed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "deadline_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "age_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
           }
         }
       },


### PR DESCRIPTION
## Summary

- adds optional `/readyz` `oldest_due_item` metadata for worker pressure when `monitor_overdue` can identify the oldest due monitor
- carries that metadata into the CLI alert-plane detail and human summary so agents see monitor name, id, cadence, grace, and overdue age
- updates the Dagger alert-plane rehearsal to require the new monitor-shaped detail while accepting the more specific reason text

## Live operator evidence

- `bin/dr-status --app canary-obs`: live DB status ok, local txid `00000000000d985c`, WAL 11 MB
- `bin/dr-restore-check --app canary-obs --db-path /data/canary.db`: non-destructive restore produced `/tmp/canary-restore.eLVlzj` on the Fly machine
- minted read-only key `KEY-2u0mys3ojq6b` and stored the raw value at `~/.factory-lanes/.canary-read-key` with mode `600`
- read-key round trip: `GET /api/v1/status` 200, `GET /api/v1/report?window=1h` 200, `GET /api/v1/keys` 403
- Powder monitor safety check: `MON-4uhhh40u445u` is `ttl`/`service=powder` but live readback showed `state=up` with `last_check_in_at=2026-07-04T20:07:06.469676632Z`; not deleted because the card required verifying the last check-in predates cutover before deletion
- bridge follow-up card created: `weave-907`

## Verification

- `cargo test -p canary-http readyz --locked`
- `cargo test -p canary-server monitor_overdue --locked`
- `cargo test -p canary-server worker_health --locked`
- `cargo test -p canary-cli doctor_verdict_degrades_for_alert_plane_pressure_even_when_readyz_is_ready --locked`
- `./bin/validate`
- pre-push `dagger call strict`

Agent: codex-canary-908
Agent-Surface: Codex CLI
Agent-Task: powder/canary-908
