### PR TITLE
docs(readme): load env in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ coordination philosophy live in
 ```bash
 git clone https://github.com/misty-step/canary && cd canary
 cp .env.example .env
+set -a; . ./.env; set +a
 ./bin/bootstrap    # installs deps for the core service and SDK packages
 cargo run -p canary-server
 ```
@@ -36,6 +37,7 @@ On first boot, Canary seeds a one-time bootstrap admin key and prints it to
 **stderr**. Capture it immediately — it is not shown again:
 
 ```bash
+set -a; . ./.env; set +a
 cargo run -p canary-server 2>&1 | grep "Bootstrap API key:"
 ```
 


### PR DESCRIPTION
## Summary
- Export `.env` in the Quick Start before launching `canary-server`, matching the checked-in local `CANARY_DB_PATH`.
- Apply the same env export to the bootstrap-key capture command.

## Verification
- Cold-start path from clean checkout/worktree: `cp .env.example .env`; `set -a; . ./.env; set +a`; `./bin/bootstrap --ci`; `cargo run -p canary-server`; `/healthz` returned `{"status":"ok"}`. The disposable bootstrap-key log and SQLite DB were deleted.
- `./bin/validate --fast`
- push pre-push hook: `dagger call strict` passed in 19m39s

Agent: codex
Agent-Surface: Codex CLI
Agent-Model: OpenAI GPT-5
Agent-Task: misty-step-909