### PR TITLE
docs(ops): add Docker self-host quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ cargo run -p canary-server
 
 No Docker is required for local development outside the Dagger gate. The repo
 includes the Rust service workspace and the TypeScript SDK package.
+For a Docker-only self-hosted first boot, use
+[`docs/self-host-docker.md`](docs/self-host-docker.md).
 
 ### First run: capturing the bootstrap API key
 
@@ -43,6 +45,16 @@ Store the key as an environment variable for API calls:
 
 ```bash
 export CANARY_ADMIN_KEY="sk_live_..."
+```
+
+Immediately run the agent-facing doctor against the new instance. Treat
+non-clean doctor output as a failed production setup until the reported field
+is fixed or explicitly waived:
+
+```bash
+CANARY_ENDPOINT="http://localhost:4000" \
+CANARY_API_KEY="$CANARY_ADMIN_KEY" \
+bin/canary doctor --json
 ```
 
 All authenticated endpoints require a scoped API key. The bootstrap key has
@@ -61,8 +73,11 @@ Responder incident context uses a redacted envelope, service-bound
 `responder-write` read authority, and durable read-audit events; see
 [`docs/responder-context-safety.md`](docs/responder-context-safety.md).
 
-For Fly deployment (including key recovery if the first boot log was missed),
-see [`docs/self-host-fly.md`](docs/self-host-fly.md).
+For non-Fly Docker deployment, including Compose, local volume persistence,
+doctor, and an ingest/query smoke, see
+[`docs/self-host-docker.md`](docs/self-host-docker.md). For Fly deployment,
+including Tigris backups and key recovery if the first boot log was missed, see
+[`docs/self-host-fly.md`](docs/self-host-fly.md).
 
 Canary has no human dashboard by design — agents are the UI. Operators who
 need to look at current state use the query API directly (`GET
@@ -587,9 +602,14 @@ All webhooks are HMAC-SHA256 signed. Secret returned on subscription creation.
 
 ## Deployment
 
-Deploy to Fly.io with SQLite persistence and a Fly Tigris-backed Litestream
-restore path. A full cold-operator runbook lives in
-[docs/self-host-fly.md](docs/self-host-fly.md).
+Deploy with either a generic Docker host or Fly.io. The Fly path uses SQLite
+persistence and a Fly Tigris-backed Litestream restore path; the Docker path
+uses the same image with a local volume and no Fly-specific variables.
+
+- Generic Docker or Compose:
+  [docs/self-host-docker.md](docs/self-host-docker.md)
+- Fly.io:
+  [docs/self-host-fly.md](docs/self-host-fly.md)
 
 ```bash
 export CANARY_FLY_APP="<your-fly-app>"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  canary:
+    build: .
+    image: canary:local
+    ports:
+      - "4000:4000"
+    environment:
+      CANARY_DB_PATH: /data/canary.db
+      CANARY_REQUIRE_LITESTREAM: "0"
+    volumes:
+      - canary-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:4000/readyz"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+
+  canary-doctor:
+    image: rust:1.94.0-bookworm@sha256:365468470075493dc4583f47387001854321c5a8583ea9604b297e67f01c5a4f
+    profiles:
+      - tools
+    working_dir: /workspace
+    environment:
+      CARGO_TARGET_DIR: /cargo-target
+      PATH: /usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    volumes:
+      - .:/workspace:ro
+      - canary-cargo-git:/usr/local/cargo/git
+      - canary-cargo-registry:/usr/local/cargo/registry
+      - canary-cargo-target:/cargo-target
+    entrypoint: ["/bin/bash", "-lc"]
+    command:
+      - |
+        test -n "$${CANARY_API_KEY:-}" ||
+        { echo "set CANARY_API_KEY to an admin or read-only key" >&2; exit 2; }
+        /usr/local/cargo/bin/cargo run -q -p canary-cli -- --endpoint http://canary:4000 --api-key "$$CANARY_API_KEY" --json doctor
+
+volumes:
+  canary-data:
+  canary-cargo-git:
+  canary-cargo-registry:
+  canary-cargo-target:

--- a/docs/self-host-docker.md
+++ b/docs/self-host-docker.md
@@ -1,0 +1,199 @@
+# Self-Host Canary With Docker
+
+This is the Fly-independent path for a fresh Canary instance. It uses the same
+checked-in Docker image as production, a local Docker volume for SQLite, and no
+Fly account, Fly app name, Tigris bucket, or Fly-specific environment variables.
+
+Use the Fly runbook only when you are deploying to Fly:
+[`docs/self-host-fly.md`](self-host-fly.md).
+
+## Prerequisites
+
+- Docker with Compose v2
+- `curl` and `jq` on the host for the copy-paste smoke commands
+- This repository checkout
+
+## Start Canary
+
+Build and start the service:
+
+```bash
+docker compose up --build -d canary
+```
+
+The service listens on `http://localhost:4000` and stores its SQLite database in
+the named Docker volume `canary_canary-data`.
+
+If you prefer raw Docker without Compose:
+
+```bash
+docker build -t canary:local .
+docker volume create canary-data
+docker run -d --name canary \
+  -p 4000:4000 \
+  -v canary-data:/data \
+  -e CANARY_DB_PATH=/data/canary.db \
+  -e CANARY_REQUIRE_LITESTREAM=0 \
+  canary:local
+```
+
+## Capture The Bootstrap Admin Key
+
+On first boot, Canary prints a one-time bootstrap admin key to container logs.
+Capture it immediately and store it in your secret manager; it is not shown
+again after the database has been seeded.
+
+```bash
+docker compose logs canary | grep "Bootstrap API key:"
+export CANARY_ADMIN_KEY="<store-the-bootstrap-key-securely>"
+```
+
+If you missed the first boot log, mint a replacement admin key against the
+existing container database. This prints a raw key once:
+
+```bash
+docker compose exec canary \
+  /app/bin/canary-server mint-key --scope admin --name operator-recovery
+```
+
+## First-Boot Smoke
+
+Set the local endpoint and prove the process and writable store are live:
+
+```bash
+export CANARY_ENDPOINT="http://localhost:4000"
+curl -fsS "$CANARY_ENDPOINT/healthz"
+curl -fsS "$CANARY_ENDPOINT/readyz"
+```
+
+Run the agent-facing doctor immediately after first boot. From a workstation
+with the Rust toolchain available:
+
+```bash
+CANARY_ENDPOINT="$CANARY_ENDPOINT" \
+CANARY_API_KEY="$CANARY_ADMIN_KEY" \
+bin/canary doctor --json
+```
+
+For a Docker-only machine, run the Compose doctor profile instead. It uses a
+Rust container and named Cargo cache volumes, so no Rust installation is needed
+on the host:
+
+```bash
+docker compose run --rm \
+  -e CANARY_API_KEY="$CANARY_ADMIN_KEY" \
+  canary-doctor
+```
+
+Treat any non-clean doctor output as a failed production setup until the
+reported field is understood and either fixed or explicitly waived. A local
+smoke with no external witness may report `canary-watchman monitor is missing`;
+that proves the container is reachable, but the instance is not production-ready
+until self-watch is configured.
+
+## Ingest And Query Roundtrip
+
+Create scoped caller keys instead of sharing the bootstrap admin key:
+
+```bash
+CANARY_INGEST_KEY="$(
+  curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/keys" \
+    -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"docker-smoke-ingest","scope":"ingest-only"}' \
+    | jq -r '.key'
+)"
+
+CANARY_READ_KEY="$(
+  curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/keys" \
+    -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"docker-smoke-read","scope":"read-only"}' \
+    | jq -r '.key'
+)"
+```
+
+Ingest one synthetic error and read it back:
+
+```bash
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/errors" \
+  -H "Authorization: Bearer $CANARY_INGEST_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"service":"docker-smoke","error_class":"DockerSmoke","message":"docker self-host smoke"}'
+
+curl -fsS "$CANARY_ENDPOINT/api/v1/query?service=docker-smoke&window=1h" \
+  -H "Authorization: Bearer $CANARY_READ_KEY" \
+  | jq '.groups | length'
+```
+
+The final command should print a number greater than zero.
+
+## Optional Backups
+
+The default Docker path runs without Litestream backups. That is intentional for
+the smallest local self-host path: `CANARY_REQUIRE_LITESTREAM=0` and no
+`BUCKET_NAME` means the entrypoint starts Canary directly with a local volume.
+
+The entrypoint treats these backup variables as the portable S3-compatible
+contract:
+
+- `BUCKET_NAME`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `CANARY_REQUIRE_LITESTREAM=1` to fail closed when backup configuration is
+  incomplete
+
+The checked-in `litestream.yml` is currently pinned to the Fly Tigris endpoint
+for the Fly production runbook. For MinIO, plain AWS S3, or another
+S3-compatible endpoint, mount an endpoint-specific Litestream config at
+`/etc/litestream.yml` and pass the same credential variables to the container.
+
+Plain AWS S3 example config:
+
+```yaml
+dbs:
+  - path: /data/canary.db
+    replicas:
+      - type: s3
+        bucket: ${BUCKET_NAME}
+        path: canary.db
+        region: us-east-1
+```
+
+MinIO example config:
+
+```yaml
+dbs:
+  - path: /data/canary.db
+    replicas:
+      - type: s3
+        bucket: ${BUCKET_NAME}
+        path: canary.db
+        endpoint: http://minio:9000
+        region: us-east-1
+        force-path-style: true
+```
+
+When backups are required, start only after proving restore status from the
+mounted configuration:
+
+```bash
+docker compose exec canary litestream status -config /etc/litestream.yml
+```
+
+## Stop Or Reset The Local Instance
+
+Stop the service while keeping data:
+
+```bash
+docker compose down
+```
+
+Delete the local database volume and force a fresh bootstrap:
+
+```bash
+docker compose down -v
+```
+
+Do not delete `/data/canary.db*` while the container is running. SQLite WAL file
+handles stay open; stop the container before destructive maintenance.


### PR DESCRIPTION
## Summary

- add `docs/self-host-docker.md` for a Fly-independent Docker/Compose self-host path
- add `docker-compose.yml` with a persistent local SQLite volume and Docker-only `canary-doctor` profile
- update README Quick Start and Deployment links so `bin/canary doctor --json` is part of first boot

## Evidence

- `test -f docs/self-host-docker.md` failed before the patch and passes after.
- `docker compose config` and `docker compose --profile tools config` pass; config output does not render host API key values.
- Fresh non-Fly Docker smoke:
  - `docker compose up --build -d canary`
  - `/healthz` returned `{"status":"ok"}`
  - `/readyz` returned `{"status":"ready", ...}`
  - bootstrap admin key captured from logs and redacted
  - `POST /api/v1/errors` returned `ERR-i7ng2mbkyids`
  - `GET /api/v1/query?service=docker-smoke&window=1h` returned `query_groups=1`
- Docker-only doctor profile:
  - `docker compose run --rm -e CANARY_API_KEY=redacted canary-doctor`
  - returned `overall=degraded`, `worker_readiness=ready`, `blocking_signals=["canary-watchman monitor is missing"]`
  - docs now describe this as local smoke success but not production-ready until self-watch is configured
- Canonical local gate: `./bin/validate`
  - `ci:deterministic` OK
  - `ci:secrets-history` OK
- Pre-push hook: `dagger call strict` OK in 9m34s.
- Fresh-context critic over diff + oracle: `NO BLOCKERS`.

Plan artifact: https://bastion.tail5f5eb4.ts.net/artifacts/a/canary-909/

## Residual Risk

- The checked-in `litestream.yml` remains Fly Tigris-pinned by design; the Docker guide documents mounting an endpoint-specific Litestream config for MinIO/plain AWS S3 instead of changing runtime backup semantics in this docs card.
- A local-only Docker instance reports `canary-watchman monitor is missing` until external self-watch is configured.

Agent: codex-canary-909
Agent-Surface: Codex CLI
Agent-Model: GPT-5.5
Agent-Task: canary-909
