### PR TITLE
fix(readiness): make retention_prune due_count self-describing over the wire

### DIFF
--- a/crates/canary-http/src/public.rs
+++ b/crates/canary-http/src/public.rs
@@ -133,17 +133,40 @@ pub struct WorkerReadyzCheck {
     pub consecutive_failures: u64,
     /// Last non-secret failure class observed by the worker loop.
     pub last_error_class: Option<String>,
-    /// Work items due at the last observed lifecycle pass.
+    /// How to interpret `due_count`/`oldest_due_age_ms` for this worker.
+    pub pressure_shape: WorkerPressureShape,
+    /// Meaning of this count depends on `pressure_shape`: for `queue` workers, items
+    /// currently due and waiting; for `sweep_result` workers, items processed in the
+    /// last completed pass (not a live backlog — do not alert on its magnitude alone).
     pub due_count: u64,
     /// Work items still in flight at the last observed lifecycle pass.
     pub in_flight_count: u64,
-    /// Milliseconds by which the oldest due work item is overdue, when known.
+    /// Milliseconds by which the oldest due work item is overdue, when known. Only
+    /// meaningful for `queue`-shaped workers; `sweep_result` workers never populate this.
     pub oldest_due_age_ms: Option<u64>,
     /// Identifying metadata for the oldest due work item, when the worker can expose it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oldest_due_item: Option<WorkerDueItem>,
     /// Whether the last observed pass saw backoff, circuit-open, or interruption pressure.
     pub backoff_or_circuit_open: bool,
+}
+
+/// How a worker's `due_count`/`oldest_due_age_ms` fields should be read.
+///
+/// Queue-backed workers (webhook delivery, target probe, monitor overdue) track a
+/// live backlog: `due_count` is items waiting right now, and staleness of the oldest
+/// item is a real pressure signal. Sweep-based workers (retention prune, TLS expiry
+/// scan) have no queue — they delete or scan everything past a cutoff in one pass —
+/// so `due_count` is only a report of the last completed pass's volume. Treating a
+/// sweep worker's `due_count` as a live backlog, or its cadence gap as staleness
+/// before its own `stale_after` threshold, produces a false pressure reading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerPressureShape {
+    /// `due_count` is a live queue depth; `oldest_due_age_ms` is real overdue time.
+    Queue,
+    /// `due_count` is the last completed pass's processed-row count, not a backlog.
+    SweepResult,
 }
 
 /// Readiness-safe metadata for one due background-worker subject.
@@ -320,6 +343,7 @@ mod tests {
                     failure_count: 0,
                     consecutive_failures: 0,
                     last_error_class: None,
+                    pressure_shape: WorkerPressureShape::Queue,
                     due_count: 0,
                     in_flight_count: 0,
                     oldest_due_age_ms: None,
@@ -335,6 +359,7 @@ mod tests {
                     failure_count: 2,
                     consecutive_failures: 2,
                     last_error_class: Some("panic".to_owned()),
+                    pressure_shape: WorkerPressureShape::Queue,
                     due_count: 0,
                     in_flight_count: 0,
                     oldest_due_age_ms: None,
@@ -370,6 +395,7 @@ mod tests {
                     failure_count: 3,
                     consecutive_failures: 3,
                     last_error_class: Some("runtime_error".to_owned()),
+                    pressure_shape: WorkerPressureShape::Queue,
                     due_count: 12,
                     in_flight_count: 0,
                     oldest_due_age_ms: Some(90_000),
@@ -398,6 +424,7 @@ mod tests {
                 failure_count: 0,
                 consecutive_failures: 0,
                 last_error_class: None,
+                pressure_shape: WorkerPressureShape::Queue,
                 due_count: 1,
                 in_flight_count: 0,
                 oldest_due_age_ms: Some(690_853),
@@ -474,6 +501,7 @@ mod tests {
                 "failure_count",
                 "consecutive_failures",
                 "last_error_class",
+                "pressure_shape",
                 "due_count",
                 "in_flight_count",
                 "oldest_due_age_ms",

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -241,7 +241,7 @@ mod tests {
     use canary_http::{
         public::{
             APPLICATION_JSON, DependencyStatus, OPENAPI_JSON, WorkerHealthStatus,
-            WorkerLifecycleState, WorkerReadyzCheck,
+            WorkerLifecycleState, WorkerPressureShape, WorkerReadyzCheck,
         },
         request::MAX_JSON_BODY_BYTES,
     };
@@ -608,6 +608,7 @@ mod tests {
                         failure_count: 0,
                         consecutive_failures: 0,
                         last_error_class: None,
+                        pressure_shape: WorkerPressureShape::Queue,
                         due_count: 0,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,
@@ -623,6 +624,7 @@ mod tests {
                         failure_count: 1,
                         consecutive_failures: 1,
                         last_error_class: Some("panic".to_owned()),
+                        pressure_shape: WorkerPressureShape::Queue,
                         due_count: 0,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,

--- a/crates/canary-server/src/worker_health.rs
+++ b/crates/canary-server/src/worker_health.rs
@@ -10,7 +10,7 @@ use std::sync::{
 };
 
 use canary_http::public::{
-    WorkerDueItem, WorkerHealthStatus, WorkerLifecycleState, WorkerReadyzCheck,
+    WorkerDueItem, WorkerHealthStatus, WorkerLifecycleState, WorkerPressureShape, WorkerReadyzCheck,
 };
 
 /// Stable names for lifecycle workers exposed through readiness.
@@ -51,6 +51,22 @@ impl WorkerName {
         match self {
             Self::WebhookDelivery | Self::TargetProbe | Self::MonitorOverdue => 120_000,
             Self::RetentionPrune | Self::TlsExpiryScan => 25 * 60 * 60 * 1_000,
+        }
+    }
+
+    /// How this worker's `due_count`/`oldest_due_age_ms` fields should be read.
+    ///
+    /// Root-caused by canary-911: retention_prune and tls_scan sweep everything past
+    /// a cutoff in one pass rather than draining a queue, so their `due_count` is a
+    /// last-pass volume report, not a live backlog. Callers must branch on this shape
+    /// before treating a large `due_count` or a sub-`stale_after_ms` cadence gap as
+    /// pressure.
+    pub const fn pressure_shape(self) -> WorkerPressureShape {
+        match self {
+            Self::WebhookDelivery | Self::TargetProbe | Self::MonitorOverdue => {
+                WorkerPressureShape::Queue
+            }
+            Self::RetentionPrune | Self::TlsExpiryScan => WorkerPressureShape::SweepResult,
         }
     }
 }
@@ -257,6 +273,7 @@ impl WorkerHealthHandle {
             failure_count,
             consecutive_failures,
             last_error_class: details.last_error_class,
+            pressure_shape: self.inner.name.pressure_shape(),
             due_count: details.pressure.due_count,
             in_flight_count: details.pressure.in_flight_count,
             oldest_due_age_ms: details.pressure.oldest_due_age_ms,
@@ -322,6 +339,80 @@ fn health_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pressure_shape_marks_sweep_workers_distinctly_from_queue_workers() {
+        assert_eq!(
+            WorkerName::WebhookDelivery.pressure_shape(),
+            WorkerPressureShape::Queue
+        );
+        assert_eq!(
+            WorkerName::TargetProbe.pressure_shape(),
+            WorkerPressureShape::Queue
+        );
+        assert_eq!(
+            WorkerName::MonitorOverdue.pressure_shape(),
+            WorkerPressureShape::Queue
+        );
+        assert_eq!(
+            WorkerName::RetentionPrune.pressure_shape(),
+            WorkerPressureShape::SweepResult
+        );
+        assert_eq!(
+            WorkerName::TlsExpiryScan.pressure_shape(),
+            WorkerPressureShape::SweepResult
+        );
+    }
+
+    /// Regression for canary-911: a live audit read `retention_prune`'s
+    /// `due_count: 518` and a ~19.5h success gap as a stuck 518-item backlog.
+    /// The worker was healthy the whole time — `due_count` for a sweep worker is
+    /// last-pass volume, not a backlog, and its cadence is 24h (stale_after is 25h).
+    /// This pins both halves: a large due_count from a completed pass never taints
+    /// health, and the wire snapshot is now self-describing via `pressure_shape` so
+    /// a consumer cannot repeat that misread.
+    #[test]
+    fn retention_prune_large_due_count_from_completed_pass_is_not_pressure() {
+        let worker = WorkerHealthHandle::new(WorkerName::RetentionPrune);
+        worker.record_success_with_pressure(
+            "2026-07-04T23:29:18Z".to_owned(),
+            0,
+            WorkerPressureSnapshot {
+                due_count: 518,
+                in_flight_count: 0,
+                oldest_due_age_ms: None,
+                oldest_due_item: None,
+                backoff_or_circuit_open: false,
+            },
+        );
+
+        // ~19.5h later: well inside the 24h tick cadence and the 25h stale threshold.
+        let snapshot = worker.snapshot_at(19 * 3_600_000 + 1_800_000);
+
+        assert_eq!(snapshot.health, WorkerHealthStatus::Ok);
+        assert_eq!(snapshot.due_count, 518);
+        assert_eq!(snapshot.pressure_shape, WorkerPressureShape::SweepResult);
+    }
+
+    /// A genuinely wedged retention_prune (no successful pass past its own 25h
+    /// stale threshold) must still surface as unhealthy — the sweep-vs-queue
+    /// distinction changes how `due_count` is read, not whether staleness fires.
+    #[test]
+    fn retention_prune_genuine_staleness_past_25h_still_surfaces_as_stale() {
+        let worker = WorkerHealthHandle::new(WorkerName::RetentionPrune);
+        worker.record_success_with_pressure(
+            "2026-07-03T23:29:18Z".to_owned(),
+            0,
+            WorkerPressureSnapshot {
+                due_count: 518,
+                ..WorkerPressureSnapshot::default()
+            },
+        );
+
+        let snapshot = worker.snapshot_at(25 * 3_600_000 + 1);
+
+        assert_eq!(snapshot.health, WorkerHealthStatus::Stale);
+    }
 
     #[test]
     fn registry_returns_all_lifecycle_workers_in_stable_order() {

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -2875,6 +2875,7 @@
           "failure_count",
           "consecutive_failures",
           "last_error_class",
+          "pressure_shape",
           "due_count",
           "in_flight_count",
           "oldest_due_age_ms",
@@ -2936,6 +2937,14 @@
               "null"
             ],
             "description": "Sanitized failure class such as runtime_error or panic; never a raw error message."
+          },
+          "pressure_shape": {
+            "type": "string",
+            "enum": [
+              "queue",
+              "sweep_result"
+            ],
+            "description": "How to read due_count/oldest_due_age_ms for this worker. queue: due_count is a live backlog depth and oldest_due_age_ms is real overdue time. sweep_result: due_count is the last completed pass's processed-row count, not a backlog; oldest_due_age_ms is never populated."
           },
           "due_count": {
             "type": "integer",


### PR DESCRIPTION
## Summary

Root-cause for canary-911 (retention_prune backlog: 518 pending, no successful
run in 12h+): the worker was never wedged. Confirmed live against
`https://canary-obs.fly.dev/readyz` — `retention_prune` health `ok`,
`last_success_age_ms` ~4.4h, `due_count: 475`. `due_count` for retention_prune
(a pure sweep-delete, no queue table) is the last completed pass's processed-row
count, not a live backlog — the card's 20:45Z observation captured the worker
mid-cycle (~19.5h into its 24h tick, well inside the 25h stale threshold) and a
consumer read it the same way it would read `monitor_overdue`'s genuine queue
depth, because the wire shape gave no way to tell the two apart.

canary-908 (`9ae2558`) added `oldest_due_item` for queue workers but left
`due_count`/`oldest_due_age_ms` overloaded across worker types.

## Fix

- Add `WorkerPressureShape` (`queue` | `sweep_result`) to `WorkerReadyzCheck` so
  the readyz contract states which meaning applies for each worker.
- `WorkerName::pressure_shape()` maps the three queue-backed workers
  (`webhook_delivery`, `target_probe`, `monitor_overdue`) to `Queue` and the two
  sweep workers (`retention_prune`, `tls_scan`) to `SweepResult`.
- Update `priv/openapi/openapi.json` to document the new field.
- Regression tests pin both halves of the incident: a large `due_count` from a
  completed sweep never taints health, and genuine staleness past the 25h
  threshold still surfaces as non-`Ok`.

No live production mutation was needed — the instance was healthy the whole
time; only read-only `/readyz` and `fly status` calls were made against it.

## Test plan
- [x] `cargo test --workspace` — full pass (243 in canary-server alone, plus all other crates)
- [x] `cargo clippy --workspace --all-targets` — 0 warnings
- [x] `cargo fmt --check` — clean
- [x] Live `/readyz` read against canary-obs confirming current healthy state
- [ ] Deploy to canary-obs so the live instance serves `pressure_shape` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)