### PR TITLE
fix(ops): stop leaking CANARY_API_KEY into doctor container argv

### DIFF
--- a/bin/canary-doctor-entrypoint.sh
+++ b/bin/canary-doctor-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Entrypoint for the docker-compose.yml `canary-doctor` service. Never pass
+# CANARY_API_KEY as a literal argv value to cargo/canary-cli — canary-cli
+# already reads it from its inherited process environment
+# (crates/canary-cli/src/lib.rs Config::resolve_with_mode). Passing it via
+# --api-key instead would put the raw key in this container's process
+# argv, visible via `docker top`/`ps`/`/proc/<pid>/cmdline`.
+if [ -z "${CANARY_API_KEY:-}" ]; then
+  echo "set CANARY_API_KEY to an admin or read-only key" >&2
+  exit 2
+fi
+
+exec cargo run -q -p canary-cli -- \
+  --endpoint "${CANARY_DOCTOR_ENDPOINT:-http://canary:4000}" \
+  --json doctor

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -208,10 +208,12 @@ export class Ci {
       .withExec(["bash", "test/bin/canary_witness_test.sh"])
       .withExec(["bash", "test/bin/canary_write_path_rehearsal_test.sh"])
       .withExec(["bash", "test/bin/canary_readiness_proof_test.sh"])
+      .withExec(["bash", "test/bin/canary_doctor_entrypoint_test.sh"])
       .withExec(["bash", "-n", "bin/canary"])
       .withExec(["bash", "-n", "bin/canary-witness"])
       .withExec(["bash", "-n", "bin/canary-write-path-rehearsal"])
       .withExec(["bash", "-n", "bin/canary-readiness-proof"])
+      .withExec(["bash", "-n", "bin/canary-doctor-entrypoint.sh"])
       .withExec(["bash", "bin/check-aesthetic-currency"])
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,17 +24,17 @@ services:
     environment:
       CARGO_TARGET_DIR: /cargo-target
       PATH: /usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      # No inline value: Compose passes this through from the invoking
+      # shell's own environment, so the key never appears as a literal
+      # `-e CANARY_API_KEY=<value>` argument on the `docker compose run`
+      # command line. See docs/self-host-docker.md.
+      CANARY_API_KEY:
     volumes:
       - .:/workspace:ro
       - canary-cargo-git:/usr/local/cargo/git
       - canary-cargo-registry:/usr/local/cargo/registry
       - canary-cargo-target:/cargo-target
-    entrypoint: ["/bin/bash", "-lc"]
-    command:
-      - |
-        test -n "$${CANARY_API_KEY:-}" ||
-        { echo "set CANARY_API_KEY to an admin or read-only key" >&2; exit 2; }
-        /usr/local/cargo/bin/cargo run -q -p canary-cli -- --endpoint http://canary:4000 --api-key "$$CANARY_API_KEY" --json doctor
+    entrypoint: ["/bin/bash", "/workspace/bin/canary-doctor-entrypoint.sh"]
 
 volumes:
   canary-data:

--- a/docs/self-host-docker.md
+++ b/docs/self-host-docker.md
@@ -80,10 +80,15 @@ Rust container and named Cargo cache volumes, so no Rust installation is needed
 on the host:
 
 ```bash
-docker compose run --rm \
-  -e CANARY_API_KEY="$CANARY_ADMIN_KEY" \
-  canary-doctor
+export CANARY_API_KEY="$CANARY_ADMIN_KEY"
+docker compose run --rm canary-doctor
 ```
+
+Do not pass the key with `-e CANARY_API_KEY=<value>` on the `docker compose
+run` command line — that puts the raw key in the host's process list for
+every process running `docker compose run` while it executes. `docker-compose.yml`
+declares `CANARY_API_KEY` with no inline value, so Compose passes it through
+from your shell's own exported environment instead.
 
 Treat any non-clean doctor output as a failed production setup until the
 reported field is understood and either fixed or explicitly waived. A local

--- a/test/bin/canary_doctor_entrypoint_test.sh
+++ b/test/bin/canary_doctor_entrypoint_test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Regression test for bin/canary-doctor-entrypoint.sh (canary-913).
+# Proves CANARY_API_KEY never reaches cargo/canary-cli as a literal argv
+# value — it must be picked up from the inherited process environment only.
+set -e
+
+ENTRYPOINT="$(cd "$(dirname "$0")/../.." && pwd)/bin/canary-doctor-entrypoint.sh"
+ORIGINAL_PATH="$PATH"
+PASS=0
+FAIL=0
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+SECRET_VALUE="sk_test_do_not_leak_9f3a7c2e"
+
+reset_env() {
+  unset CANARY_API_KEY
+  unset CANARY_DOCTOR_ENDPOINT
+}
+
+setup_stubs() {
+  export PATH="$TMPDIR_TEST/bin:$ORIGINAL_PATH"
+  mkdir -p "$TMPDIR_TEST/bin"
+  export CARGO_LOG="$TMPDIR_TEST/cargo.log"
+  : > "$CARGO_LOG"
+  cat > "$TMPDIR_TEST/bin/cargo" << 'STUB'
+#!/bin/bash
+# Log full argv exactly as this process received it (not the parent
+# shell's unexpanded script text) — this is what `ps`/`docker top` would
+# show for the real cargo/canary-cli process.
+printf '%s\n' "$*" >> "${CARGO_LOG:?}"
+exit 0
+STUB
+  chmod +x "$TMPDIR_TEST/bin/cargo"
+}
+
+run_entrypoint() {
+  bash "$ENTRYPOINT" 2>&1
+}
+
+run_entrypoint_failure() {
+  local output
+  set +e
+  output=$(run_entrypoint)
+  local rc=$?
+  set -e
+  printf '%s\n%s' "$rc" "$output"
+}
+
+assert_contains() {
+  local output="$1" expected="$2" test_name="$3"
+  if grep -qF -- "$expected" <<<"$output"; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected to contain: $expected"
+    echo "    Got: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local output="$1" unexpected="$2" test_name="$3"
+  if grep -qF -- "$unexpected" <<<"$output"; then
+    echo "  FAIL: $test_name"
+    echo "    Expected NOT to contain: $unexpected"
+    echo "    Got: $output"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_exit_code() {
+  local actual="$1" expected="$2" test_name="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "    Expected exit code: $expected"
+    echo "    Got: $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test 1: missing key fails closed before ever invoking cargo ---
+echo "Test 1: CANARY_API_KEY unset fails closed"
+reset_env
+setup_stubs
+OUTPUT=$(run_entrypoint_failure)
+STATUS=$(printf '%s' "$OUTPUT" | head -n 1)
+BODY=$(printf '%s' "$OUTPUT" | tail -n +2)
+assert_exit_code "$STATUS" "2" \
+  "exits non-zero when CANARY_API_KEY is unset"
+assert_contains "$BODY" "set CANARY_API_KEY to an admin or read-only key" \
+  "reports the missing-key message"
+if [ -s "$CARGO_LOG" ]; then
+  echo "  FAIL: does not invoke cargo when the key is missing"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: does not invoke cargo when the key is missing"
+  PASS=$((PASS + 1))
+fi
+
+# --- Test 2: key present -> the raw value never appears in cargo's argv ---
+echo "Test 2: CANARY_API_KEY set is never passed as a literal argv value"
+reset_env
+setup_stubs
+export CANARY_API_KEY="$SECRET_VALUE"
+run_entrypoint > /dev/null
+CARGO_ARGV="$(cat "$CARGO_LOG")"
+assert_not_contains "$CARGO_ARGV" "$SECRET_VALUE" \
+  "cargo/canary-cli argv does not contain the raw key value"
+assert_not_contains "$CARGO_ARGV" "--api-key" \
+  "cargo/canary-cli is never invoked with an --api-key flag"
+
+# --- Test 3: doctor still runs against the resolved endpoint ---
+echo "Test 3: doctor still targets the expected endpoint and subcommand"
+reset_env
+setup_stubs
+export CANARY_API_KEY="$SECRET_VALUE"
+run_entrypoint > /dev/null
+CARGO_ARGV="$(cat "$CARGO_LOG")"
+assert_contains "$CARGO_ARGV" "run -q -p canary-cli -- --endpoint http://canary:4000 --json doctor" \
+  "invokes the doctor subcommand against the default compose endpoint"
+
+# --- Test 4: endpoint override is honored ---
+echo "Test 4: CANARY_DOCTOR_ENDPOINT override is honored"
+reset_env
+setup_stubs
+export CANARY_API_KEY="$SECRET_VALUE"
+export CANARY_DOCTOR_ENDPOINT="http://localhost:4000"
+run_entrypoint > /dev/null
+CARGO_ARGV="$(cat "$CARGO_LOG")"
+assert_contains "$CARGO_ARGV" "--endpoint http://localhost:4000" \
+  "honors a CANARY_DOCTOR_ENDPOINT override"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- Extract docker-compose.yml's inline `canary-doctor` bash command into a real, testable file (`bin/canary-doctor-entrypoint.sh`) instead of an untestable YAML string blob.
- Drop the `--api-key "$$CANARY_API_KEY"` flag passed to `cargo run -p canary-cli`; canary-cli already resolves `CANARY_API_KEY` from its own inherited process environment (`Config::resolve_with_mode`), so the flag only existed to put the raw key in the container's process argv, visible via `docker top`/`ps`/`/proc/<pid>/cmdline`.
- Declare `CANARY_API_KEY:` with no inline value in the `canary-doctor` service's `environment:` map so Compose passes it through from the invoking shell's own exported environment.
- Update `docs/self-host-docker.md` to teach `export CANARY_API_KEY=...` followed by `docker compose run --rm canary-doctor`, and stop teaching the `-e CANARY_API_KEY=<value>` copy/paste pattern that put the key on the host's own process list.

Closes canary-913 (P0).

## Evidence

- New regression test `test/bin/canary_doctor_entrypoint_test.sh` stubs `cargo` to capture its full argv (same pattern as `test/bin/entrypoint_test.sh`'s litestream stub); confirmed it fails against the pre-fix logic (catches the leak) and passes against the fix.
- Live Docker proof: built and started `canary` via `docker compose up --build -d canary`, ran `docker compose run --rm -d canary-doctor`, and sampled `docker top` while the container's `cargo run -q -p canary-cli -- --endpoint http://canary:4000 --json doctor` process was actively running/compiling — argv contains no `--api-key` flag and no key value. A subsequent foreground run confirmed the doctor still authenticates correctly via the inherited env var: `auth_configured: true`, `key_scope: admin`, `key: "CANARY_API_KEY: redacted"`.
- Canonical local gate: `./bin/validate --fast` (dagger call fast, incl. the new test via scriptsQualityContainer) OK; `./bin/validate --strict` (full gate) OK in 5m15s, no failure markers.

## Residual Risk

- No CI wiring exists for a live docker-compose smoke of this profile (matches existing self-host-docker.md convention: it's proven via manual live smoke, not the Dagger container-based gate, since that would need nested docker-in-docker). The stubbed argv-capture test is the durable CI regression guard against reintroducing the leak; the live proof above is this change's one-time manual verification.

Agent: builder-canary-lane
Agent-Surface: Claude Code
Agent-Model: claude-sonnet-5
Agent-Task: canary-913