### PR TITLE
fix(health): scope witness self-heal to its own signals, not global plane

### DIFF
--- a/bin/canary-witness
+++ b/bin/canary-witness
@@ -235,7 +235,6 @@ health_file="$tmpdir/healthz.json"
 ready_file="$tmpdir/readyz.json"
 query_file="$tmpdir/canary-query.json"
 alert_plane_file="$tmpdir/alert-plane.json"
-status_file="$tmpdir/monitor-status.json"
 check_in_file="$tmpdir/check-in.json"
 observed_at="$(now_utc)"
 encoded_window="$(urlencode "$WINDOW")"
@@ -342,7 +341,29 @@ alert_plane_ok="$(jq -r '.status == "healthy"' "$alert_plane_file")"
 query_ok="$(jq -r 'try (.curl_exit == 0 and .http_status == 200 and (.response | type == "object") and .response.service == "canary" and (.response.total_errors | type == "number")) catch false' "$query_file")"
 transport_failures="$(jq -s '[.[] | select((.skipped // false | not) and (.curl_exit != 0))] | length' "$health_file" "$ready_file" "$query_file")"
 
-if [[ "$health_ok" == "true" && "$ready_ok" == "true" && "$query_ok" == "true" && "$alert_plane_ok" == "true" ]]; then
+# Witness self-heal scope: this witness's own health verdict is scoped to
+# its own signals -- healthz, readyz worker health, and the canary-query
+# self-check -- not the entire alert plane. `monitor_overdue` tracks every
+# monitor's heartbeat schedule, including monitors owned by other services
+# (e.g. linejam-production-smoke) and this witness's own monitor
+# ($MONITOR). Neither is in scope for whether Canary/the witness process
+# itself is healthy: an unrelated service's overdue heartbeat must never
+# block this witness, and refusing the witness's own check-in while its
+# own heartbeat is the thing overdue would deadlock forever (the check-in
+# is the only thing that clears it). Any OTHER impaired worker
+# (webhook_delivery, retention_prune, target_probe, tls_scan) still blocks
+# exactly as before. See docs/canary-witness.md.
+monitor_overdue_is_sole_impairment="$(jq -r '
+  try (
+    (.workers | length) == 1
+    and (.workers[0].name == "monitor_overdue")
+    and (.workers[0].health == "pressured")
+  ) catch false
+' "$alert_plane_file")"
+witness_alert_plane_ok="$([[ "$alert_plane_ok" == "true" || "$monitor_overdue_is_sole_impairment" == "true" ]] && echo true || echo false)"
+self_heal_check_in="$([[ "$alert_plane_ok" != "true" && "$witness_alert_plane_ok" == "true" ]] && echo true || echo false)"
+
+if [[ "$health_ok" == "true" && "$ready_ok" == "true" && "$query_ok" == "true" && "$witness_alert_plane_ok" == "true" ]]; then
   status="healthy"
 elif [[ "$transport_failures" != "0" ]]; then
   status="unreachable"
@@ -350,40 +371,12 @@ else
   status="degraded"
 fi
 
-# Self-witness deadlock guard: $MONITOR's own check-in is the only thing that
-# clears its overdue pressure. If monitor_overdue is impaired *solely*
-# because $MONITOR itself is overdue -- no other worker and no other
-# monitor is unhealthy -- refusing the check-in locks $MONITOR overdue
-# forever: its own missed heartbeat permanently blocks the heartbeat that
-# would resolve it. Impairment involving any other worker or monitor still
-# blocks the check-in exactly as before (see the alert-plane rehearsal gate).
-self_only_pressure="false"
-if [[ "$health_ok" == "true" && "$ready_ok" == "true" && "$query_ok" == "true" \
-      && "$alert_plane_ok" != "true" && "$status" != "unreachable" ]]; then
-  only_monitor_overdue_pressured="$(jq -r '
-    try (
-      (.workers | length) == 1
-      and (.workers[0].name == "monitor_overdue")
-      and (.workers[0].health == "pressured")
-    ) catch false
-  ' "$alert_plane_file")"
-  if [[ "$only_monitor_overdue_pressured" == "true" ]]; then
-    request_json "monitor-status" "GET" "/api/v1/status" "read" "$status_file"
-    self_only_pressure="$(jq -r --arg monitor "$MONITOR" '
-      try (
-        (.response.monitors | type == "array")
-        and ([.response.monitors[] | select(.name != $monitor and .state != "up")] | length) == 0
-      ) catch false
-    ' "$status_file")"
-  fi
-fi
-
-if [[ "$status" == "healthy" || "$self_only_pressure" == "true" ]]; then
+if [[ "$status" == "healthy" ]]; then
   total_errors="$(jq -r '.response.total_errors // 0' "$query_file")"
   ttl_ms_json="${CHECK_IN_TTL_MS:-null}"
   summary="Canary witness saw healthy self-signals and ${total_errors} recent canary errors."
-  if [[ "$self_only_pressure" == "true" ]]; then
-    summary="Canary witness self-heal: $MONITOR was the sole source of monitor_overdue pressure; sending check-in to clear it."
+  if [[ "$self_heal_check_in" == "true" ]]; then
+    summary="Canary witness self-heal: monitor_overdue pressure was out of the witness's own scope; sending check-in regardless."
   fi
   context="$(
     jq -n \
@@ -434,7 +427,7 @@ jq -n \
   --arg window "$WINDOW" \
   --arg status "$status" \
   --argjson require_check_in "$REQUIRE_CHECK_IN" \
-  --argjson self_heal_check_in "$([[ "$self_only_pressure" == "true" ]] && echo true || echo false)" \
+  --argjson self_heal_check_in "$([[ "$self_heal_check_in" == "true" ]] && echo true || echo false)" \
   --slurpfile health "$health_file" \
   --slurpfile ready "$ready_file" \
   --slurpfile query "$query_file" \

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -466,6 +466,17 @@ prefix="dagger-alert-plane-$(date -u +%Y%m%d%H%M%S)-$$"
 monitor="canary-alert-plane-$prefix"
 observed_at="$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
 
+# Seed the witness's own monitor (matches docs/canary-witness.md's
+# production monitor configuration) before impairing an unrelated
+# monitor below, so the witness's own self-heal check-in below has
+# somewhere to land instead of 404ing against an unknown monitor.
+curl --fail --silent --show-error \
+  -X POST "$CANARY_ENDPOINT/api/v1/monitors" \
+  -H "Authorization: Bearer $CANARY_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"canary-watchman","service":"canary","mode":"ttl","expected_every_ms":600000,"grace_ms":120000}' \
+  >/tmp/canary-alert-plane-watchman-monitor.json
+
 monitor_payload="$(
   jq -cn \
     --arg name "$monitor" \
@@ -531,12 +542,18 @@ for attempt in $(seq 1 30); do
       --json >/tmp/canary-alert-plane-witness.out
     witness_status=$?
     set -e
-    test "$witness_status" != "0"
+    # The synthetic monitor created above is out of this witness's own
+    # scope (it isn't the witness's own canary-watchman monitor), the same
+    # shape as an unrelated service's overdue monitor blocking the witness
+    # in production (canary-920). The witness must still report healthy
+    # and still send its own check-in -- see docs/canary-witness.md.
+    test "$witness_status" == "0"
     jq -e '
-      .status == "degraded"
+      .status == "healthy"
       and .alert_plane.status == "impaired"
       and any(.alert_plane.reasons[]?; startswith("monitor_overdue pressured"))
-      and .check_in.skipped == true
+      and .check_in.skipped == false
+      and .self_heal_check_in == true
     ' /tmp/canary-alert-plane-witness.json >/dev/null
     jq '{
       route_ready: .response.reachability.readyz.response.status,

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -22,25 +22,39 @@ is checking.
 |---|---|---|
 | Liveness | `GET /healthz` | HTTP 200 and `{"status":"ok"}` |
 | Readiness | `GET /readyz` | HTTP 200, `{"status":"ready"}`, database and supervisor `ok`, and all five worker lifecycle snapshots started with zero failures. This is route readiness, not alert-plane health. |
-| Alert plane | `/readyz` worker snapshots | Every required worker has `health: ok`, no backoff/circuit pressure, and no stale due-work pressure. A `pressured` worker can remain route-ready, but the witness reports a degraded alert plane and does not send the healthy check-in. |
+| Alert plane | `/readyz` worker snapshots | Every required worker except `monitor_overdue` has `health: ok`, no backoff/circuit pressure, and no stale due-work pressure. `monitor_overdue` pressure is out of the witness's own scope (see below) and does not by itself degrade the witness. Any other `pressured` worker still keeps route-ready but blocks the witness from reporting healthy. |
 | Error readback | `GET /api/v1/query?service=canary&window=1h` | HTTP 200, service `canary`, and numeric `total_errors` |
 
-### Self-heal exception
+### Witness scope: `monitor_overdue` never blocks the witness alone
 
-`$MONITOR`'s own check-in is the only thing that clears its overdue pressure.
-If `monitor_overdue` is impaired *solely* because `$MONITOR` itself (normally
-`canary-watchman`) is overdue — no other worker and no other monitor is
-unhealthy, confirmed via `GET /api/v1/status` — the witness sends the
-check-in anyway instead of skipping it. Without this, a single missed
-heartbeat becomes permanent: the overdue heartbeat keeps the alert plane
-impaired, and the impaired alert plane keeps blocking the only check-in that
-would resolve it (found live in production 2026-07-02, `canary-watchman`
-stuck overdue for 11+ hours because its own pressure had locked out its own
-recovery). Impairment involving any other worker or monitor still blocks the
-check-in exactly as before — this exception does not weaken the alert-plane
-bar for unrelated degradation, and does not change the reported `status`
-(it stays `degraded`, not `healthy`, until the next run confirms recovery).
-The receipt's `self_heal_check_in` field records when this fired.
+The witness's own health verdict is scoped to its own signals — healthz,
+readyz worker health, and the canary-query self-check — not the entire alert
+plane. `monitor_overdue` tracks *every* monitor's heartbeat schedule,
+including monitors owned by other services (found live in production
+2026-07-06: `linejam-production-smoke`, an unrelated monitor, kept this
+witness's own GitHub issue open indefinitely even after its actual key fault
+was fixed) and this witness's own monitor (normally `canary-watchman`,
+found live 2026-07-02 stuck overdue for 11+ hours because its own pressure
+had locked out its own recovery check-in). Neither case is in scope for
+whether Canary/the witness process itself is healthy:
+
+- An unrelated service's overdue heartbeat must never block this witness —
+  the witness has no way to resolve someone else's monitor and should not be
+  held hostage to it.
+- The witness's own overdue heartbeat must not block its own check-in either,
+  since the check-in is the only thing that clears it — refusing it would
+  deadlock forever.
+
+So whenever `monitor_overdue` is the *only* impaired worker — regardless of
+which monitor(s) triggered it — the witness still reports `status: healthy`
+and still sends its check-in. Impairment involving any other worker
+(`webhook_delivery`, `retention_prune`, `target_probe`, `tls_scan`) still
+blocks the witness exactly as before; this scoping does not weaken the bar
+for genuine Canary-process degradation. The receipt's `alert_plane` block
+still reports the true, unscoped alert-plane status and impaired workers for
+observability, and `self_heal_check_in` records whenever the witness's own
+`healthy` verdict or check-in relied on this scoping rather than a fully
+clean alert plane.
 
 When all route and alert-plane signals are healthy, the witness sends an ingest check-in:
 

--- a/test/bin/canary_witness_test.sh
+++ b/test/bin/canary_witness_test.sh
@@ -76,8 +76,6 @@ assert_check_in_payload() {
 READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 PRESSURED_READY_BODY='{"status":"ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"target_probe","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
 NOT_READY_WORKERS_BODY='{"status":"not_ready","checks":{"database":"ok","supervisor":"ok","workers":[{"name":"webhook_delivery","state":"started","health":"pressured","last_success_at":"2026-06-14T02:07:53Z","last_success_age_ms":250,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":12,"in_flight_count":0,"oldest_due_age_ms":7200000,"backoff_or_circuit_open":true},{"name":"target_probe","state":"started","health":"failing","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":3,"consecutive_failures":3,"last_error_class":"runtime_error","due_count":1,"in_flight_count":0,"oldest_due_age_ms":0,"backoff_or_circuit_open":false},{"name":"monitor_overdue","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:55Z","last_success_age_ms":100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":0,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"retention_prune","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":1,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false},{"name":"tls_scan","state":"started","health":"ok","last_success_at":"2026-06-14T02:07:23Z","last_success_age_ms":32100,"failure_count":0,"consecutive_failures":0,"last_error_class":null,"due_count":2,"in_flight_count":0,"oldest_due_age_ms":null,"backoff_or_circuit_open":false}]}}'
-OTHER_MONITOR_DOWN_STATUS_BODY='{"error_summary":[],"monitors":[{"id":"MON-a","name":"canary-watchman","state":"up","deadline_at":"2026-06-14T03:00:00Z","last_check_in_at":"2026-06-14T02:50:00Z","last_check_in_status":"alive","mode":"ttl"},{"id":"MON-b","name":"some-other-service","state":"down","deadline_at":"2026-06-14T00:00:00Z","last_check_in_at":"2026-06-13T20:00:00Z","last_check_in_status":"alive","mode":"ttl"}],"overall":"unhealthy","summary":"1 down.","targets":[]}'
-SELF_ONLY_DOWN_STATUS_BODY='{"error_summary":[],"monitors":[{"id":"MON-a","name":"canary-watchman","state":"down","deadline_at":"2026-06-14T00:00:00Z","last_check_in_at":"2026-06-13T20:00:00Z","last_check_in_status":"alive","mode":"ttl"},{"id":"MON-b","name":"some-other-service","state":"up","deadline_at":"2026-06-14T03:00:00Z","last_check_in_at":"2026-06-14T02:50:00Z","last_check_in_status":"alive","mode":"ttl"}],"overall":"unhealthy","summary":"1 down.","targets":[]}'
 
 case "${STUB_SCENARIO:?}:$method:$url" in
   healthy:GET:https://canary.example/healthz)
@@ -103,8 +101,9 @@ case "${STUB_SCENARIO:?}:$method:$url" in
   pressured:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
     ;;
-  pressured:GET:https://canary.example/api/v1/status)
-    write_response 200 0.020 "$OTHER_MONITOR_DOWN_STATUS_BODY"
+  pressured:POST:https://canary.example/api/v1/check-ins)
+    assert_check_in_payload
+    write_response 201 0.040 '{"monitor":"canary-watchman","status":"alive"}'
     ;;
 
   self-pressured:GET:https://canary.example/healthz)
@@ -115,9 +114,6 @@ case "${STUB_SCENARIO:?}:$method:$url" in
     ;;
   self-pressured:GET:https://canary.example/api/v1/query?service=canary\&window=1h)
     write_response 200 0.030 '{"service":"canary","window":"1h","summary":"0 errors in canary in the last 1h.","total_errors":0,"groups":[]}'
-    ;;
-  self-pressured:GET:https://canary.example/api/v1/status)
-    write_response 200 0.020 "$SELF_ONLY_DOWN_STATUS_BODY"
     ;;
   self-pressured:POST:https://canary.example/api/v1/check-ins)
     assert_check_in_payload
@@ -280,7 +276,7 @@ assert_json_equals "$receipt" '.status' 'healthy' "healthy ttl receipt status"
 assert_json_equals "$receipt" '.check_in.http_status' '201' "healthy ttl sends check-in"
 
 receipt="$TMPDIR_TEST/pressured.json"
-run_failure "pressured ready witness exits nonzero" \
+run_success "pressured ready (unrelated monitor overdue) witness exits zero" \
   env \
     STUB_SCENARIO=pressured \
     "${WITNESS[@]}" \
@@ -290,15 +286,16 @@ run_failure "pressured ready witness exits nonzero" \
     --receipt "$receipt" \
     --require-check-in \
     --json
-assert_json_equals "$receipt" '.status' 'degraded' "pressured ready receipt status"
+assert_json_equals "$receipt" '.status' 'healthy' "pressured ready by an unrelated monitor still reports healthy"
 assert_json_equals "$receipt" '.probes.readyz.response.checks.workers[] | select(.name == "monitor_overdue") | .health' 'pressured' "pressured ready records worker pressure"
-assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "pressured ready records alert-plane impairment"
+assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "pressured ready still records alert-plane impairment in the receipt"
 assert_json_equals "$receipt" '.alert_plane.workers[] | select(.name == "monitor_overdue") | .health' 'pressured' "pressured ready names impaired worker"
-assert_json_equals "$receipt" '.check_in.skipped' 'true' "pressured ready skips check-in"
-assert_json_equals "$receipt" '.self_heal_check_in' 'false' "pressured ready by another monitor is not a self-heal"
+assert_json_equals "$receipt" '.check_in.skipped' 'false' "pressured ready by an unrelated monitor still sends check-in"
+assert_json_equals "$receipt" '.check_in.http_status' '201' "pressured ready check-in succeeds"
+assert_json_equals "$receipt" '.self_heal_check_in' 'true' "pressured ready by another monitor is out of scope and counts as self-heal"
 
 receipt="$TMPDIR_TEST/self-pressured.json"
-run_failure "self-pressured witness exits nonzero" \
+run_success "self-pressured (witness's own monitor overdue) witness exits zero" \
   env \
     STUB_SCENARIO=self-pressured \
     "${WITNESS[@]}" \
@@ -308,8 +305,8 @@ run_failure "self-pressured witness exits nonzero" \
     --receipt "$receipt" \
     --require-check-in \
     --json
-assert_json_equals "$receipt" '.status' 'degraded' "self-pressured receipt status stays degraded"
-assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "self-pressured records alert-plane impairment"
+assert_json_equals "$receipt" '.status' 'healthy' "self-pressured receipt status becomes healthy"
+assert_json_equals "$receipt" '.alert_plane.status' 'impaired' "self-pressured still records alert-plane impairment in the receipt"
 assert_json_equals "$receipt" '.self_heal_check_in' 'true' "self-pressured triggers self-heal"
 assert_json_equals "$receipt" '.check_in.skipped' 'false' "self-pressured still sends check-in"
 assert_json_equals "$receipt" '.check_in.http_status' '201' "self-pressured check-in succeeds"


### PR DESCRIPTION
## Summary

- canary-917 fixed the underlying key fault (query 200) but the witness still failed every run because the self-heal check-in gate required the ENTIRE alert plane healthy — an out-of-scope overdue monitor owned by another service (`linejam-production-smoke`) permanently blocked it, and GH issue #228 stayed open.
- Replace the narrow "self-only-pressure" guard (which required an extra `GET /api/v1/status` call and only covered the witness's own monitor being overdue) with a broader witness-scoped rule: whenever `monitor_overdue` is the *only* impaired worker — regardless of which monitor(s) triggered it, this witness's own or any other service's — the witness reports `status: healthy` and still sends its check-in. Any other impaired worker (`webhook_delivery`, `retention_prune`, `target_probe`, `tls_scan`) still blocks exactly as before.
- Also fixes a smaller pre-existing gap: the old self-heal path fired the check-in but still reported `status: degraded`, never `healthy` — meaning the GH Actions workflow (which closes the issue on exit code 0) could never auto-close even when self-heal correctly fired.
- Deletes the now-unnecessary `/api/v1/status` round-trip and its monitor-identity comparison logic entirely — simpler and covers more cases.
- Documents the new scoping in `docs/canary-witness.md` ("Witness scope: `monitor_overdue` never blocks the witness alone").
- Updates the live Dagger `productionImageAlertPlaneRehearsalContainer` gate: seeds the witness's own `canary-watchman` monitor first (matching real production topology) and asserts the new expected behavior (`status: healthy`, check-in sent, `self_heal_check_in: true`) instead of the old one it previously locked in.

Closes canary-920 (P1).

## Evidence

- `test/bin/canary_witness_test.sh`: updated the two scenarios that encoded the old narrow behavior (`pressured ready witness exits nonzero` / `self-pressured witness exits nonzero`, both asserting `status: degraded`) to assert the new expected behavior (`status: healthy`, check-in sent, `self_heal_check_in: true`); confirmed the updated tests fail against the pre-fix logic and pass against the fix. Full suite: 44/44 passed.
- Live Dagger production-image rehearsal (part of `./bin/validate --strict`): spins up a real Canary instance, seeds the witness's own monitor, creates an unrelated synthetic monitor and lets it go overdue, confirms `bin/canary doctor` reports the alert plane impaired by that unrelated monitor, then runs the real `bin/canary-witness` against it and asserts it now reports `status: healthy` with a successful, non-skipped self-heal check-in.
- Canonical local gate: `./bin/validate --fast` OK; `./bin/validate --strict` (full gate, including the live rehearsal above) OK in 5m3s.

## Residual Risk

- Live proof that GH issue #228 actually auto-closes against the real production `canary-obs.fly.dev` instance (where `linejam-production-smoke` is the actual out-of-scope overdue monitor) is a follow-up verification step after this merges and the scheduled/dispatched witness workflow runs — the Dagger rehearsal above proves the mechanism against an equivalent live scenario, but not against the exact production issue.

Agent: builder-canary-lane
Agent-Surface: Claude Code
Agent-Model: claude-sonnet-5
Agent-Task: canary-920