### PR TITLE
fix(ci): release with the workflow token instead of the expired PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
         uses: misty-step/landmark@v1
         with:
           mode: full
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          # github.token (with the job's write permissions above) instead of a
+          # PAT: releases it creates do not emit `release: published` events to
+          # other workflows, so synthesis must stay inline (`synthesis: true`).
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           node-version: "24"
           synthesis: "true"


### PR DESCRIPTION
## What

Point Landmark's `github-token` at `github.token` instead of `secrets.GH_RELEASE_TOKEN`.

## Why

The release pipeline has been dead since **2026-07-04 ~09:00Z** (last good release: v1.14.0). Every master push since fails `Run Landmark` with:

- `EGITNOPERMISSION` — `git push --dry-run ... HEAD:master` → 403
- `Resource not accessible by personal access token` on the issues API

Root cause: `GH_RELEASE_TOKEN` expired. The replacement PAT in the Agents vault is fine-grained without Contents/Issues write on misty-step (verified live: API metadata reads succeed, git push denied), so refreshing the secret from the vault does not fix it (attempted 23:49Z, run 28906894122 failed the same way).

## Why this fix is safe

The job already declares `contents: write, issues: write, pull-requests: write`, and master has no branch protection or rulesets — `github.token` covers the dry-run push check, tag + release-commit push, release creation, and label/issue writes.

**Known tradeoff (documented inline):** releases created with `GITHUB_TOKEN` do not emit `release: published` to other workflows, so `landmark-release.yml` (synthesis-only) will not fire on them. Synthesis already runs inline here (`synthesis: "true"`), so nothing is lost. To restore PAT-authored releases later: mint an org-scoped PAT with Contents+Issues+PR write, set `GH_RELEASE_TOKEN`, and point `github-token` back at the secret.

## Verification plan

After merge: dispatch the Release workflow and confirm a new tag > v1.14.0 publishes, covering the six coverage merges shipped today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)