### PR TITLE
chore(deploy): parameterize litestream endpoint/region

### DIFF
--- a/litestream.yml
+++ b/litestream.yml
@@ -4,7 +4,7 @@ dbs:
       - type: s3
         bucket: ${BUCKET_NAME}
         path: canary.db
-        endpoint: https://fly.storage.tigris.dev
-        region: auto
+        endpoint: ${LITESTREAM_ENDPOINT}
+        region: ${LITESTREAM_REGION}
         force-path-style: true
         snapshot-interval: 1h


### PR DESCRIPTION
DigitalOcean migration: the litestream S3 endpoint was hardcoded to Fly Tigris — running the same image against DO Spaces (or any substrate) requires it env-driven, and two writers on one replica path corrupt it. Fly secrets LITESTREAM_ENDPOINT/LITESTREAM_REGION are set to current values (verified) so the next Fly deploy is behavior-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)