### PR TITLE
docs: version-reset note (1.x/2.x → 0.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version reset: v1.15.0 → v0.15.0 (2026-07-08)
+
+The fleet moved to pre-stable 0.x semantics (Powder landmark-016/017): versions below 1.0.0 use Cargo-style bumps (breaking→minor, feat/fix→patch) and never cross 1.0.0 automatically; promotion to 1.0.0 is a deliberate manual tag. v0.15.0 is the same commit as v1.15.0. Earlier 1.x/2.x entries below record real history under the old numbering; their tags and GitHub releases were retired.
+
 # [1.15.0](https://github.com/misty-step/canary/compare/v1.14.0...v1.15.0) (2026-07-08)
 
 


### PR DESCRIPTION
## Summary
- Prepends a version-reset note to CHANGELOG.md explaining the fleet's move to pre-stable 0.x semantics (Powder landmark-016/017).
- No functional changes.

Agent-Task: landmark-017