### PR TITLE
ci(release): migrate off github.token stopgap to App-minted release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       - name: Run Landmark
         uses: misty-step/landmark@v0
         with:
           mode: full
-          # github.token (with the job's write permissions above) instead of a
-          # PAT: releases it creates do not emit `release: published` events to
-          # other workflows, so synthesis must stay inline (`synthesis: true`).
-          github-token: ${{ github.token }}
+          # Short-lived installation token from the org's misty-step-releaser
+          # GitHub App (misty-step-940), replacing the github.token stopgap
+          # from #244: unlike GITHUB_TOKEN, App tokens still trigger
+          # downstream workflows on the tags/releases they create.
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           node-version: "24"
           synthesis: "true"


### PR DESCRIPTION
## Summary
- The `github.token` workaround from #244 unblocked releases after `GH_RELEASE_TOKEN` expired, but GITHUB_TOKEN-authored tags/releases don't emit `release:published` to downstream workflows.
- Mints a short-lived token from the org's `misty-step-releaser` GitHub App instead (misty-step-940, option c) to restore that behavior and align with counterspell/landmark's release flow.
- Note: this repo has no separate `landmark-release.yml` (`release.yml` is the single release workflow); `GH_RELEASE_TOKEN` itself was already retired here on 2026-07-07 (#244) ahead of the org-wide decommission.

Release runs resume once misty-step-940's App secrets (`LANDMARK_RELEASER_APP_ID` / `LANDMARK_RELEASER_PRIVATE_KEY`) land — expected to fail at the mint step until then, no worse than today.

## Test plan
- [x] `actionlint .github/workflows/release.yml` clean
- [x] YAML validated with `yaml.safe_load`
- [x] Repo's pre-push Dagger CI check passed
- [ ] Live release run (blocked on App secrets landing, tracked in misty-step-940)

Agent-Task: misty-step-940