### PR TITLE
perf(auth): verified-key cache + bcrypt outside the store lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "time",
  "tokio",

--- a/crates/canary-server/Cargo.toml
+++ b/crates/canary-server/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1.48", features = ["macros", "net", "rt-multi-thread", "signal"] }

--- a/crates/canary-server/src/admin_keys.rs
+++ b/crates/canary-server/src/admin_keys.rs
@@ -140,7 +140,12 @@ pub(crate) async fn revoke_api_key(
         &authority.tenant_id,
         &authority.project_id,
     ) {
-        Ok(true) => json_status_response(StatusCode::OK.as_u16(), json!({"status": "revoked"})),
+        Ok(true) => {
+            // Revocation must beat the auth cache: drop every cached token
+            // for this key so the next request re-verifies against the store.
+            state.auth_cache().invalidate_key_id(&id);
+            json_status_response(StatusCode::OK.as_u16(), json!({"status": "revoked"}))
+        }
         Ok(false) => problem_response(not_found_problem("API key not found.")),
         Err(_) => problem_response(internal_problem()),
     }

--- a/crates/canary-server/src/auth_cache.rs
+++ b/crates/canary-server/src/auth_cache.rs
@@ -87,10 +87,20 @@ impl AuthCache {
     /// Called by the revoke route so revocation takes effect on the next
     /// request instead of waiting out the TTL.
     pub(crate) fn invalidate_key_id(&self, key_id: &str) {
-        if let Ok(mut entries) = self.entries.lock() {
-            self.revocation_epoch.fetch_add(1, Ordering::AcqRel);
-            entries.retain(|_, entry| entry.key.id != key_id);
-        }
+        // Revocation must never fail open. `get`/`insert` may fail closed on a
+        // poisoned mutex (worst case: a full reverify), but a swallowed purge
+        // would leave a revoked key servable for the rest of the TTL. The
+        // critical sections only mutate the HashMap, which a panic cannot
+        // corrupt structurally — recover the map and heal the poison.
+        let mut entries = match self.entries.lock() {
+            Ok(entries) => entries,
+            Err(poisoned) => {
+                self.entries.clear_poison();
+                poisoned.into_inner()
+            }
+        };
+        self.revocation_epoch.fetch_add(1, Ordering::AcqRel);
+        entries.retain(|_, entry| entry.key.id != key_id);
     }
 }
 
@@ -133,6 +143,30 @@ mod tests {
         let cache = AuthCache::default();
         cache.insert("sk_live_token", verified("KEY-a"), 0, cache.epoch());
         assert!(cache.get("sk_live_other", 1).is_none());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::panic)]
+    fn invalidate_purges_and_heals_after_mutex_poisoning() {
+        let cache = std::sync::Arc::new(AuthCache::default());
+        cache.insert("sk_live_token", verified("KEY-a"), 0, cache.epoch());
+
+        // Poison the entries mutex: panic on a thread holding the guard.
+        let poisoner = std::sync::Arc::clone(&cache);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.entries.lock().unwrap();
+            panic!("poison the auth cache mutex");
+        })
+        .join();
+
+        // Revocation must still purge — and heal the cache for later use.
+        cache.invalidate_key_id("KEY-a");
+        cache.insert("sk_live_second", verified("KEY-b"), 0, cache.epoch());
+        assert!(cache.get("sk_live_token", 1).is_none());
+        assert_eq!(
+            cache.get("sk_live_second", 1).map(|key| key.id),
+            Some("KEY-b".to_owned())
+        );
     }
 
     #[test]

--- a/crates/canary-server/src/auth_cache.rs
+++ b/crates/canary-server/src/auth_cache.rs
@@ -1,0 +1,162 @@
+//! In-memory verified-API-key cache keyed by token digest.
+//!
+//! bcrypt verification costs ~230ms of pure CPU; paying it per request
+//! serialized the whole service (canary-930, live-reproduced). A cache hit
+//! skips bcrypt entirely. Entries are keyed by the SHA-256 of the raw bearer
+//! token — the raw token is never retained — and expire on a short TTL.
+//! Revocation goes through the single admin route in this process, which must
+//! call [`AuthCache::invalidate_key_id`] so a revoked key fails on the very
+//! next request rather than at TTL expiry.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use canary_store::VerifiedApiKey;
+use sha2::{Digest, Sha256};
+
+/// How long a verified token may be served from cache. Defense-in-depth
+/// bound only — explicit invalidation on revoke is the correctness path.
+const AUTH_CACHE_TTL_MS: i64 = 300_000;
+
+/// Hard entry bound. The map is cleared when full; legitimate deployments
+/// hold a handful of keys, so overflow only happens under token spraying,
+/// where dropping the cache is the safe behavior.
+const AUTH_CACHE_MAX_ENTRIES: usize = 4096;
+
+struct CacheEntry {
+    key: VerifiedApiKey,
+    expires_at_ms: i64,
+}
+
+/// Process-local verified-key cache shared by all authenticated routes.
+#[derive(Default)]
+pub(crate) struct AuthCache {
+    entries: Mutex<HashMap<[u8; 32], CacheEntry>>,
+    /// Bumped on every revocation. An insert staged before a revocation
+    /// (candidates fetched, lock dropped, bcrypt still running) is discarded
+    /// so a just-revoked key can never enter the cache.
+    revocation_epoch: AtomicU64,
+}
+
+impl AuthCache {
+    /// Snapshot the revocation epoch before fetching verify candidates.
+    pub(crate) fn epoch(&self) -> u64 {
+        self.revocation_epoch.load(Ordering::Acquire)
+    }
+    /// Return the cached verified key for `token` when present and fresh.
+    pub(crate) fn get(&self, token: &str, now_ms: i64) -> Option<VerifiedApiKey> {
+        let digest = token_digest(token);
+        let mut entries = self.entries.lock().ok()?;
+        match entries.get(&digest) {
+            Some(entry) if entry.expires_at_ms > now_ms => Some(entry.key.clone()),
+            Some(_) => {
+                entries.remove(&digest);
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// Cache a successfully verified token.
+    ///
+    /// `fetch_epoch` is the [`AuthCache::epoch`] value read before the
+    /// candidates were fetched; the insert is dropped when any revocation
+    /// happened since.
+    pub(crate) fn insert(&self, token: &str, key: VerifiedApiKey, now_ms: i64, fetch_epoch: u64) {
+        let Ok(mut entries) = self.entries.lock() else {
+            return;
+        };
+        if self.revocation_epoch.load(Ordering::Acquire) != fetch_epoch {
+            return;
+        }
+        if entries.len() >= AUTH_CACHE_MAX_ENTRIES {
+            entries.clear();
+        }
+        entries.insert(
+            token_digest(token),
+            CacheEntry {
+                key,
+                expires_at_ms: now_ms.saturating_add(AUTH_CACHE_TTL_MS),
+            },
+        );
+    }
+
+    /// Drop every cached token that resolved to `key_id`.
+    ///
+    /// Called by the revoke route so revocation takes effect on the next
+    /// request instead of waiting out the TTL.
+    pub(crate) fn invalidate_key_id(&self, key_id: &str) {
+        if let Ok(mut entries) = self.entries.lock() {
+            self.revocation_epoch.fetch_add(1, Ordering::AcqRel);
+            entries.retain(|_, entry| entry.key.id != key_id);
+        }
+    }
+}
+
+fn token_digest(token: &str) -> [u8; 32] {
+    Sha256::digest(token.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn verified(id: &str) -> VerifiedApiKey {
+        VerifiedApiKey {
+            id: id.to_owned(),
+            name: format!("key {id}"),
+            scope: "read-only".to_owned(),
+            tenant_id: "tenant".to_owned(),
+            project_id: "project".to_owned(),
+            service: None,
+        }
+    }
+
+    #[test]
+    fn hit_within_ttl_miss_after_expiry() {
+        let cache = AuthCache::default();
+        cache.insert("sk_live_token", verified("KEY-a"), 1_000, cache.epoch());
+
+        let hit = cache.get("sk_live_token", 1_000 + AUTH_CACHE_TTL_MS - 1);
+        assert_eq!(hit.map(|key| key.id), Some("KEY-a".to_owned()));
+
+        assert!(
+            cache
+                .get("sk_live_token", 1_000 + AUTH_CACHE_TTL_MS)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn different_token_never_hits_another_entry() {
+        let cache = AuthCache::default();
+        cache.insert("sk_live_token", verified("KEY-a"), 0, cache.epoch());
+        assert!(cache.get("sk_live_other", 1).is_none());
+    }
+
+    #[test]
+    fn insert_staged_before_a_revocation_is_discarded() {
+        let cache = AuthCache::default();
+        let fetch_epoch = cache.epoch();
+        // A revocation lands while bcrypt is still running out-of-lock.
+        cache.invalidate_key_id("KEY-any");
+        cache.insert("sk_live_token", verified("KEY-a"), 0, fetch_epoch);
+        assert!(cache.get("sk_live_token", 1).is_none());
+    }
+
+    #[test]
+    fn invalidate_key_id_drops_all_tokens_for_that_key() {
+        let cache = AuthCache::default();
+        cache.insert("sk_live_token", verified("KEY-a"), 0, cache.epoch());
+        cache.insert("sk_live_second", verified("KEY-b"), 0, cache.epoch());
+
+        cache.invalidate_key_id("KEY-a");
+
+        assert!(cache.get("sk_live_token", 1).is_none());
+        assert_eq!(
+            cache.get("sk_live_second", 1).map(|key| key.id),
+            Some("KEY-b".to_owned())
+        );
+    }
+}

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -21,6 +21,7 @@ mod admin_monitors;
 mod admin_targets;
 mod admin_webhooks;
 mod annotations;
+mod auth_cache;
 mod body_fields;
 mod claims;
 mod dashboard_routes;
@@ -4908,6 +4909,36 @@ mod tests {
             json_body(missing_response).await?["detail"],
             "API key not found."
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auth_cache_serves_repeats_but_never_wrong_prefix_tokens() -> Result<(), Box<dyn Error>>
+    {
+        let router = ingest_router(test_ingest_state()?);
+
+        // First authenticated read pays bcrypt and populates the auth cache.
+        let first = router
+            .clone()
+            .oneshot(read_request(READ_KEY, "/api/v1/incidents")?)
+            .await?;
+        assert_eq!(first.status(), StatusCode::OK);
+
+        // Repeat auth with the same token must keep working (cache hit path).
+        let second = router
+            .clone()
+            .oneshot(read_request(READ_KEY, "/api/v1/incidents")?)
+            .await?;
+        assert_eq!(second.status(), StatusCode::OK);
+
+        // A different token sharing the cached key's prefix must never be
+        // served from the cache entry.
+        let wrong = router
+            .oneshot(read_request("sk_live_read_wrong", "/api/v1/incidents")?)
+            .await?;
+        assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(json_body(wrong).await?["code"], "invalid_api_key");
 
         Ok(())
     }

--- a/crates/canary-server/src/route_state.rs
+++ b/crates/canary-server/src/route_state.rs
@@ -11,6 +11,7 @@ use canary_ingest::{IngestConfig, IngestEffect};
 use canary_store::Store;
 use canary_workers::webhooks::{TransportResult, WebhookRequest};
 
+use crate::auth_cache::AuthCache;
 use crate::{
     HealthEventFanout, HttpWebhookTransport, InMemoryWebhookCooldown, RateLimiter,
     TargetProbeLifecycleCommand, TargetProbeLifecycleController, WebhookEnqueueEffectSink,
@@ -50,6 +51,7 @@ pub struct IngestState {
     rate_limiter: Arc<Mutex<RateLimiter>>,
     auth_fail_identity: AuthFailIdentityConfig,
     allow_private_targets: bool,
+    auth_cache: Arc<AuthCache>,
 }
 
 /// Client identity source used only for invalid-key
@@ -97,6 +99,7 @@ impl IngestState {
             rate_limiter: Arc::new(Mutex::new(RateLimiter::default())),
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
+            auth_cache: Arc::new(AuthCache::default()),
         }
     }
 
@@ -125,6 +128,7 @@ impl IngestState {
             rate_limiter: Arc::new(Mutex::new(RateLimiter::default())),
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
+            auth_cache: Arc::new(AuthCache::default()),
         }
     }
 
@@ -145,6 +149,7 @@ impl IngestState {
             rate_limiter: Arc::new(Mutex::new(RateLimiter::default())),
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
+            auth_cache: Arc::new(AuthCache::default()),
         }
     }
 
@@ -165,6 +170,7 @@ impl IngestState {
             rate_limiter: Arc::new(Mutex::new(RateLimiter::default())),
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
+            auth_cache: Arc::new(AuthCache::default()),
         }
     }
 
@@ -233,6 +239,10 @@ impl IngestState {
 
     pub(crate) fn auth_fail_identity(&self) -> AuthFailIdentityConfig {
         self.auth_fail_identity
+    }
+
+    pub(crate) fn auth_cache(&self) -> &AuthCache {
+        &self.auth_cache
     }
 
     pub(crate) fn allow_private_targets(&self) -> bool {

--- a/crates/canary-server/src/server_auth.rs
+++ b/crates/canary-server/src/server_auth.rs
@@ -84,23 +84,40 @@ pub(crate) fn require_scope(
         BearerToken::Present(token) => token,
         BearerToken::Missing => return Err(Box::new(missing_authorization_problem(None))),
     };
-    let auth_fail_identity = reject_limited_unknown_prefix(state, headers, token)?;
+    let now_ms = current_unix_millis();
+    let key = match state.auth_cache().get(token, now_ms) {
+        Some(cached) => cached,
+        None => {
+            let auth_fail_identity = reject_limited_unknown_prefix(state, headers, token)?;
 
-    let key = {
-        let store = state
-            .lock_store()
-            .map_err(|_| Box::new(internal_problem()))?;
-        store
-            .verify_api_key(token)
-            .map_err(|_| Box::new(internal_problem()))?
-    };
-    let Some(key) = key else {
-        account_auth_fail_identity(state, &auth_fail_identity)?;
-        return Err(Box::new(invalid_api_key_problem(None)));
+            // Fetch candidates under a short store lock, then run the
+            // CPU-bound bcrypt loop AFTER dropping the guard: verification
+            // under the single-writer lock serialized every authenticated
+            // request behind ~230ms of bcrypt (canary-930). The epoch read
+            // fences the insert against a concurrent revocation.
+            let fetch_epoch = state.auth_cache().epoch();
+            let candidates = {
+                let store = state
+                    .lock_store()
+                    .map_err(|_| Box::new(internal_problem()))?;
+                store
+                    .api_key_verify_candidates(token)
+                    .map_err(|_| Box::new(internal_problem()))?
+            };
+            let Some(key) = canary_store::verify_key_candidates(token, candidates) else {
+                account_auth_fail_identity(state, &auth_fail_identity)?;
+                return Err(Box::new(invalid_api_key_problem(None)));
+            };
+            state
+                .auth_cache()
+                .insert(token, key.clone(), now_ms, fetch_epoch);
+            key
+        }
     };
 
     let Some(scope) = ApiKeyScope::parse(&key.scope) else {
-        account_auth_fail_identity(state, &auth_fail_identity)?;
+        let identity = auth_fail_identity(headers, state.auth_fail_identity());
+        account_auth_fail_identity(state, &identity)?;
         return Err(Box::new(invalid_api_key_problem(None)));
     };
     if scope == ApiKeyScope::Admin

--- a/crates/canary-server/src/server_auth.rs
+++ b/crates/canary-server/src/server_auth.rs
@@ -85,10 +85,11 @@ pub(crate) fn require_scope(
         BearerToken::Missing => return Err(Box::new(missing_authorization_problem(None))),
     };
     let now_ms = current_unix_millis();
+    let fail_identity = auth_fail_identity(headers, state.auth_fail_identity());
     let key = match state.auth_cache().get(token, now_ms) {
         Some(cached) => cached,
         None => {
-            let auth_fail_identity = reject_limited_unknown_prefix(state, headers, token)?;
+            reject_limited_unknown_prefix(state, &fail_identity, token)?;
 
             // Fetch candidates under a short store lock, then run the
             // CPU-bound bcrypt loop AFTER dropping the guard: verification
@@ -105,7 +106,7 @@ pub(crate) fn require_scope(
                     .map_err(|_| Box::new(internal_problem()))?
             };
             let Some(key) = canary_store::verify_key_candidates(token, candidates) else {
-                account_auth_fail_identity(state, &auth_fail_identity)?;
+                account_auth_fail_identity(state, &fail_identity)?;
                 return Err(Box::new(invalid_api_key_problem(None)));
             };
             state
@@ -116,8 +117,7 @@ pub(crate) fn require_scope(
     };
 
     let Some(scope) = ApiKeyScope::parse(&key.scope) else {
-        let identity = auth_fail_identity(headers, state.auth_fail_identity());
-        account_auth_fail_identity(state, &identity)?;
+        account_auth_fail_identity(state, &fail_identity)?;
         return Err(Box::new(invalid_api_key_problem(None)));
     };
     if scope == ApiKeyScope::Admin
@@ -180,17 +180,16 @@ pub(crate) fn responder_service_binding_problem() -> ProblemDetails {
 
 fn reject_limited_unknown_prefix(
     state: &IngestState,
-    headers: &HeaderMap,
+    identity: &str,
     token: &str,
-) -> Result<String, Box<ProblemDetails>> {
-    let identity = auth_fail_identity(headers, state.auth_fail_identity());
+) -> Result<(), Box<ProblemDetails>> {
     let mut limiter = state
         .rate_limiter()
         .lock()
         .map_err(|_| Box::new(internal_problem()))?;
 
-    let retry_after_seconds = match limiter.peek(RateLimitKind::AuthFail, &identity) {
-        RateLimitDecision::Allowed => return Ok(identity),
+    let retry_after_seconds = match limiter.peek(RateLimitKind::AuthFail, identity) {
+        RateLimitDecision::Allowed => return Ok(()),
         RateLimitDecision::Limited {
             retry_after_seconds,
         } => retry_after_seconds,
@@ -204,7 +203,7 @@ fn reject_limited_unknown_prefix(
         .active_api_key_prefix_exists(token)
         .map_err(|_| Box::new(internal_problem()))?
     {
-        Ok(identity)
+        Ok(())
     } else {
         Err(Box::new(rate_limited_problem(retry_after_seconds)))
     }

--- a/crates/canary-store/src/api_keys.rs
+++ b/crates/canary-store/src/api_keys.rs
@@ -185,26 +185,38 @@ pub(crate) fn revoke_scoped(
 pub(crate) fn verify_key(connection: &Connection, raw_key: &str) -> Result<Option<VerifiedApiKey>> {
     let prefix = key_prefix(raw_key);
     let candidates = active_candidates(connection, &prefix)?;
+    Ok(verify_key_candidates(raw_key, candidates))
+}
 
+/// Verify a raw bearer token against pre-fetched active candidates.
+///
+/// Pure CPU work with no store access, so callers can (and the server must)
+/// run the bcrypt loop after releasing the single-writer store lock. Unknown
+/// prefixes still pay one dummy-hash verify so response timing does not
+/// reveal whether a prefix exists.
+pub fn verify_key_candidates(
+    raw_key: &str,
+    candidates: Vec<ApiKeyVerifyCandidate>,
+) -> Option<VerifiedApiKey> {
     if candidates.is_empty() {
         let _ = verify(raw_key, DUMMY_BCRYPT_HASH);
-        return Ok(None);
+        return None;
     }
 
     for candidate in candidates {
         if matches!(verify(raw_key, &candidate.key_hash), Ok(true)) {
-            return Ok(Some(VerifiedApiKey {
+            return Some(VerifiedApiKey {
                 id: candidate.id,
                 name: candidate.name,
                 scope: candidate.scope,
                 tenant_id: candidate.tenant_id,
                 project_id: candidate.project_id,
                 service: candidate.service,
-            }));
+            });
         }
     }
 
-    Ok(None)
+    None
 }
 
 pub(crate) fn active_key_prefix_exists(connection: &Connection, raw_key: &str) -> Result<bool> {
@@ -224,7 +236,10 @@ pub(crate) fn key_prefix(raw_key: &str) -> String {
     raw_key.chars().take(API_KEY_PREFIX_LEN).collect()
 }
 
-fn active_candidates(connection: &Connection, key_prefix: &str) -> Result<Vec<ApiKeyCandidate>> {
+pub(crate) fn active_candidates(
+    connection: &Connection,
+    key_prefix: &str,
+) -> Result<Vec<ApiKeyVerifyCandidate>> {
     let mut statement = connection.prepare(
         "SELECT id, name, scope, key_hash, tenant_id, project_id, service
          FROM api_keys
@@ -233,7 +248,7 @@ fn active_candidates(connection: &Connection, key_prefix: &str) -> Result<Vec<Ap
     )?;
     let candidates = statement
         .query_map([key_prefix], |row| {
-            Ok(ApiKeyCandidate {
+            Ok(ApiKeyVerifyCandidate {
                 id: row.get(0)?,
                 name: row.get(1)?,
                 scope: row.get(2)?,
@@ -248,7 +263,11 @@ fn active_candidates(connection: &Connection, key_prefix: &str) -> Result<Vec<Ap
     Ok(candidates)
 }
 
-struct ApiKeyCandidate {
+/// Active same-prefix API-key row staged for out-of-lock verification.
+///
+/// Opaque outside this crate: consumers fetch candidates under a short store
+/// lock, drop the guard, and hand them to [`verify_key_candidates`].
+pub struct ApiKeyVerifyCandidate {
     id: String,
     name: String,
     scope: String,

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -34,8 +34,8 @@ pub use annotations::{
     AnnotationSubjectType, subject_types as annotation_subject_types,
 };
 pub use api_keys::{
-    API_KEY_PREFIX_LEN, ApiKeyInsert, ApiKeyRecord, BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID,
-    VerifiedApiKey,
+    API_KEY_PREFIX_LEN, ApiKeyInsert, ApiKeyRecord, ApiKeyVerifyCandidate, BOOTSTRAP_PROJECT_ID,
+    BOOTSTRAP_TENANT_ID, VerifiedApiKey, verify_key_candidates,
 };
 pub use canary_core::metrics::MetricsSnapshot;
 pub use claims::{
@@ -568,6 +568,15 @@ impl Store {
     /// Verify a raw bearer token against active bcrypt-hashed API-key rows.
     pub fn verify_api_key(&self, raw_key: &str) -> Result<Option<VerifiedApiKey>> {
         api_keys::verify_key(&self.connection, raw_key)
+    }
+
+    /// Fetch active same-prefix key candidates for out-of-lock verification.
+    ///
+    /// SQL only — no bcrypt. Callers hold the store lock just for this fetch,
+    /// drop the guard, then run [`verify_key_candidates`] on the result so the
+    /// CPU-bound bcrypt loop never serializes the single writer.
+    pub fn api_key_verify_candidates(&self, raw_key: &str) -> Result<Vec<ApiKeyVerifyCandidate>> {
+        api_keys::active_candidates(&self.connection, &api_keys::key_prefix(raw_key))
     }
 
     /// Return whether a raw bearer token has any active row with the same prefix.
@@ -3875,6 +3884,42 @@ mod tests {
         assert_eq!(verified.id, "KEY-valid");
         assert_eq!(verified.name, "key KEY-valid");
         assert_eq!(verified.scope, "ingest-only");
+        Ok(())
+    }
+
+    #[test]
+    fn verify_key_candidates_matches_after_guard_drop()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        insert_api_key(
+            &mut store,
+            "KEY-split",
+            "sk_live_split_secret",
+            "admin",
+            None,
+        )?;
+
+        let candidates = store.api_key_verify_candidates("sk_live_split_secret")?;
+        drop(store);
+
+        let Some(verified) = verify_key_candidates("sk_live_split_secret", candidates) else {
+            return Err("candidates should verify without store access".into());
+        };
+        assert_eq!(verified.id, "KEY-split");
+
+        let store = migrated_store()?;
+        let wrong = store.api_key_verify_candidates("sk_live_split_secret")?;
+        assert!(verify_key_candidates("sk_live_split_wrong!", wrong).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn verify_key_candidates_rejects_unknown_prefix_with_empty_candidates()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let store = migrated_store()?;
+        let candidates = store.api_key_verify_candidates("sk_live_nothing_here")?;
+        assert!(candidates.is_empty());
+        assert!(verify_key_candidates("sk_live_nothing_here", candidates).is_none());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

canary-930 child A — the P0 root cause behind the live slow-API symptoms (`/api/v1/keys` ~7.5s, `/api/v1/status` >10s), live-reproduced during the 2026-07-09 groom: every authenticated request paid a ~230ms bcrypt verify **while holding the single-writer store mutex** on 1 shared vCPU, serializing all authenticated traffic and queueing `/readyz` behind the same lock.

**Changes**
- `canary-store`: verification split into an SQL-only candidate fetch (`Store::api_key_verify_candidates`) + a pure `verify_key_candidates` bcrypt loop that needs no store access. Unknown prefixes keep the dummy-hash timing equalization. `Store::verify_api_key` delegates unchanged for internal callers.
- `canary-server`: `require_scope` consults a process-local `AuthCache` (SHA-256 of the raw token — token never retained — 5min TTL, 4096-entry bound) before paying bcrypt. On miss: candidates fetched under a short lock, guard dropped, bcrypt runs outside. The revoke route invalidates by key id; a revocation epoch discards inserts staged before a concurrent revocation, so a just-revoked key can never enter the cache.

**Safety/regression guards**
- Cache unit tests: TTL expiry, cross-token isolation, revocation drop, stale-epoch insert discard.
- Router test: repeated auth works; a same-prefix wrong token never rides the cache.
- Existing key-lifecycle test now covers create → cached read → revoke → 401 end to end.
- Full suites green: canary-server 248, canary-store 119+12, clippy `-D warnings` clean.

**Oracle (per canary-930)**: the live 12-concurrent-client latency test runs post-deploy — expected flat profile instead of the 0.65→1.66s staircase; will paste pre/post on the card.

Cites AGENTS.md footguns: "No CPU-bound work under the store lock", "Request path must not poison the writer mutex" (poisoning itself is child C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)