### PR TITLE
perf(store): serve read models from read-only connections

### DIFF
--- a/crates/canary-server/src/admin_keys.rs
+++ b/crates/canary-server/src/admin_keys.rs
@@ -42,12 +42,12 @@ pub(crate) async fn list_api_keys(
         Err(problem) => return problem_response(*problem),
     };
 
-    let store = match state.lock_store() {
-        Ok(store) => store,
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
 
-    match store.list_api_keys_scoped(&authority.tenant_id, &authority.project_id) {
+    match reader.list_api_keys_scoped(&authority.tenant_id, &authority.project_id) {
         Ok(keys) => json_status_response(
             StatusCode::OK.as_u16(),
             json!({"keys": keys.into_iter().map(api_key_response).collect::<Vec<_>>()}),

--- a/crates/canary-server/src/health_routes.rs
+++ b/crates/canary-server/src/health_routes.rs
@@ -39,15 +39,15 @@ pub(crate) async fn health_status(
         Err(problem) => return problem_response(*problem),
     };
 
-    let store = match state.lock_store() {
-        Ok(store) => store,
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut targets = match store.health_targets_scoped(&key.tenant_id, &key.project_id) {
+    let mut targets = match reader.health_targets_scoped(&key.tenant_id, &key.project_id) {
         Ok(targets) => targets,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut monitors = match store.health_monitors_scoped(&key.tenant_id, &key.project_id) {
+    let mut monitors = match reader.health_monitors_scoped(&key.tenant_id, &key.project_id) {
         Ok(monitors) => monitors,
         Err(_) => return problem_response(internal_problem()),
     };
@@ -77,20 +77,20 @@ pub(crate) async fn status(
     };
 
     let window = params.window.as_deref().unwrap_or("1h");
-    let store = match state.lock_store() {
-        Ok(store) => store,
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut targets = match store.health_targets_scoped(&key.tenant_id, &key.project_id) {
+    let mut targets = match reader.health_targets_scoped(&key.tenant_id, &key.project_id) {
         Ok(targets) => targets,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut monitors = match store.health_monitors_scoped(&key.tenant_id, &key.project_id) {
+    let mut monitors = match reader.health_monitors_scoped(&key.tenant_id, &key.project_id) {
         Ok(monitors) => monitors,
         Err(_) => return problem_response(internal_problem()),
     };
     let mut error_summary =
-        match store.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
+        match reader.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
             Ok(summary) => summary,
             Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
             Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
@@ -126,19 +126,19 @@ pub(crate) async fn target_checks(
     };
 
     let window = params.window.as_deref().unwrap_or("24h");
-    let store = match state.lock_store() {
-        Ok(store) => store,
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
     let checks = match key.service.as_deref() {
-        Some(service) => store.target_checks_scoped_for_service(
+        Some(service) => reader.target_checks_scoped_for_service(
             &id,
             window,
             &key.tenant_id,
             &key.project_id,
             service,
         ),
-        None => store.target_checks_scoped(&id, window, &key.tenant_id, &key.project_id),
+        None => reader.target_checks_scoped(&id, window, &key.tenant_id, &key.project_id),
     };
     let checks = match checks {
         Ok(checks) => checks,

--- a/crates/canary-server/src/health_routes.rs
+++ b/crates/canary-server/src/health_routes.rs
@@ -43,12 +43,26 @@ pub(crate) async fn health_status(
         Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut targets = match reader.health_targets_scoped(&key.tenant_id, &key.project_id) {
-        Ok(targets) => targets,
-        Err(_) => return problem_response(internal_problem()),
-    };
-    let mut monitors = match reader.health_monitors_scoped(&key.tenant_id, &key.project_id) {
-        Ok(monitors) => monitors,
+    // Both queries must agree with each other, so they run inside one
+    // read-transaction snapshot instead of each independently observing
+    // whatever the database looks like when it happens to run (canary-930
+    // child B review fix).
+    type HealthStatusReads = (Vec<HealthTargetStatus>, Vec<HealthMonitorStatus>);
+    let reads = reader.with_snapshot(
+        || -> std::result::Result<HealthStatusReads, Box<Response<Body>>> {
+            let targets = reader
+                .health_targets_scoped(&key.tenant_id, &key.project_id)
+                .map_err(|_| Box::new(problem_response(internal_problem())))?;
+            let monitors = reader
+                .health_monitors_scoped(&key.tenant_id, &key.project_id)
+                .map_err(|_| Box::new(problem_response(internal_problem())))?;
+            Ok((targets, monitors))
+        },
+    );
+    drop(reader);
+    let (mut targets, mut monitors) = match reads {
+        Ok(Ok(pair)) => pair,
+        Ok(Err(problem)) => return *problem,
         Err(_) => return problem_response(internal_problem()),
     };
     if let Some(bound_service) = key.service.as_deref() {
@@ -81,20 +95,43 @@ pub(crate) async fn status(
         Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut targets = match reader.health_targets_scoped(&key.tenant_id, &key.project_id) {
-        Ok(targets) => targets,
+    // All three queries must agree with each other (overall status is
+    // derived by combining them), so they share one read-transaction
+    // snapshot instead of each independently observing whatever the
+    // database looks like when it happens to run (canary-930 child B review
+    // fix).
+    type StatusReads = (
+        Vec<HealthTargetStatus>,
+        Vec<HealthMonitorStatus>,
+        Vec<ErrorSummaryItem>,
+    );
+    let reads = reader.with_snapshot(
+        || -> std::result::Result<StatusReads, Box<Response<Body>>> {
+            let targets = reader
+                .health_targets_scoped(&key.tenant_id, &key.project_id)
+                .map_err(|_| Box::new(problem_response(internal_problem())))?;
+            let monitors = reader
+                .health_monitors_scoped(&key.tenant_id, &key.project_id)
+                .map_err(|_| Box::new(problem_response(internal_problem())))?;
+            let error_summary =
+                match reader.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
+                    Ok(summary) => summary,
+                    Err(QueryError::InvalidWindow) => {
+                        return Err(Box::new(problem_response(invalid_window_problem())));
+                    }
+                    Err(QueryError::Sqlite(_)) => {
+                        return Err(Box::new(problem_response(internal_problem())));
+                    }
+                };
+            Ok((targets, monitors, error_summary))
+        },
+    );
+    drop(reader);
+    let (mut targets, mut monitors, mut error_summary) = match reads {
+        Ok(Ok(triple)) => triple,
+        Ok(Err(problem)) => return *problem,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut monitors = match reader.health_monitors_scoped(&key.tenant_id, &key.project_id) {
-        Ok(monitors) => monitors,
-        Err(_) => return problem_response(internal_problem()),
-    };
-    let mut error_summary =
-        match reader.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
-            Ok(summary) => summary,
-            Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-            Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
-        };
     if let Some(bound_service) = key.service.as_deref() {
         targets.retain(|target| target.service == bound_service);
         monitors.retain(|monitor| monitor.service == bound_service);

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -865,6 +865,75 @@ mod tests {
         Ok(())
     }
 
+    /// `report_error_groups_scoped` and `active_incidents` deliberately stay
+    /// off the read pool because they fuse a claim-expiry write into the
+    /// read (see `read_pool.rs` and `read_source.rs`). This guards that the
+    /// exclusion actually keeps a pooled `/api/v1/report` read correct end
+    /// to end: an expired claim must not still show as `current_claim`
+    /// (canary-930 child B review MINOR).
+    #[tokio::test]
+    async fn read_pool_report_reflects_claim_expiry_done_via_writer() -> Result<(), Box<dyn Error>>
+    {
+        let path = temp_db_path("read-pool-claim-expiry");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        seed_api_key(&mut store, "KEY-admin", ADMIN_KEY, "admin", None)?;
+        seed_api_key(&mut store, "KEY-read", READ_KEY, "read-only", None)?;
+        seed_api_key(&mut store, "KEY-ingest", INGEST_KEY, "ingest-only", None)?;
+        let read_pool = Arc::new(ReadPool::open(&path)?);
+        let state = IngestState::new(store, IngestConfig::default()).with_read_pool(read_pool);
+        let router = ingest_router(state);
+
+        let ingested = router
+            .clone()
+            .oneshot(error_request(
+                INGEST_KEY,
+                r#"{"service":"claim-svc","error_class":"RuntimeError","message":"claim expiry regression"}"#,
+            )?)
+            .await?;
+        assert_eq!(ingested.status(), StatusCode::CREATED);
+        let ingested_body = json_body(ingested).await?;
+        let group_hash = ingested_body["group_hash"]
+            .as_str()
+            .ok_or("missing error group hash")?
+            .to_owned();
+
+        let claimed = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/claims",
+                ADMIN_KEY,
+                &format!(
+                    r#"{{"subject_type":"error_group","subject_id":"{group_hash}","owner":"codex","purpose":"inspect","ttl_ms":1,"idempotency_key":"run-expiry"}}"#
+                ),
+            )?)
+            .await?;
+        assert_eq!(claimed.status(), StatusCode::CREATED);
+
+        // Let the 1ms TTL lapse so the claim is due for expiry by the time
+        // the report handler's writer block runs it.
+        thread::sleep(StdDuration::from_millis(50));
+
+        let report = router
+            .clone()
+            .oneshot(read_request(READ_KEY, "/api/v1/report?window=30d")?)
+            .await?;
+        assert_eq!(report.status(), StatusCode::OK);
+        let report_body = json_body(report).await?;
+        assert_eq!(report_body["error_groups"][0]["group_hash"], group_hash);
+        assert!(
+            report_body["error_groups"][0]["current_claim"].is_null(),
+            "expired claim must not still be reported as current: {report_body}"
+        );
+
+        fs::remove_file(&path)?;
+        let _ = fs::remove_file(format!("{}-wal", path.display()));
+        let _ = fs::remove_file(format!("{}-shm", path.display()));
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn dashboard_shell_serves_assets_without_private_data() -> Result<(), Box<dyn Error>> {
         let router = dashboard_router();

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -38,6 +38,7 @@ mod public_routes;
 mod query_routes;
 mod rate_limit;
 mod read_audit;
+mod read_source;
 mod report_routes;
 mod responder_context;
 mod retention_prune;
@@ -249,10 +250,10 @@ mod tests {
     use canary_ingest::{IngestConfig, IngestEffect};
     use canary_store::{
         API_KEY_PREFIX_LEN, AnnotationInsert, ApiKeyInsert, ErrorIngest, ErrorIngestIds,
-        ErrorIngestPayload, MonitorCheckInCommit, MonitorCheckInObservation, MonitorInsert, Store,
-        TargetCheckObservation, TargetInsert, TargetProbeCommit, WebhookDeliveryInsert,
-        WebhookDeliveryJobCompletion, WebhookDeliveryJobInsert, WebhookDeliveryJobState,
-        WebhookDeliveryStatus, WebhookSubscriptionInsert,
+        ErrorIngestPayload, MonitorCheckInCommit, MonitorCheckInObservation, MonitorInsert,
+        ReadPool, Store, TargetCheckObservation, TargetInsert, TargetProbeCommit,
+        WebhookDeliveryInsert, WebhookDeliveryJobCompletion, WebhookDeliveryJobInsert,
+        WebhookDeliveryJobState, WebhookDeliveryStatus, WebhookSubscriptionInsert,
     };
     use canary_workers::{
         retention::RetentionPolicy,
@@ -799,6 +800,67 @@ mod tests {
         assert_eq!(keys[0].name, "bootstrap");
         assert_eq!(keys[0].scope, "admin");
         fs::remove_file(path)?;
+
+        Ok(())
+    }
+
+    /// Read routes must return identical results whether or not a
+    /// `ReadPool` is wired: booting with one (the production path) reads
+    /// through read-only connections instead of the writer, and the
+    /// response must match the pre-existing writer-only behavior exactly.
+    #[tokio::test]
+    async fn read_pool_serves_report_route_with_matching_data() -> Result<(), Box<dyn Error>> {
+        let path = temp_db_path("read-pool-parity");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        seed_api_key(&mut store, "KEY-read", READ_KEY, "read-only", None)?;
+        seed_api_key(&mut store, "KEY-ingest", INGEST_KEY, "ingest-only", None)?;
+        let read_pool = Arc::new(ReadPool::open(&path)?);
+        let state =
+            IngestState::new(store, IngestConfig::default()).with_read_pool(read_pool.clone());
+        let router = ingest_router(state.clone());
+
+        let ingested = router
+            .clone()
+            .oneshot(error_request(INGEST_KEY, valid_error_body())?)
+            .await?;
+        assert_eq!(ingested.status(), StatusCode::CREATED);
+
+        let pooled = router
+            .clone()
+            .oneshot(read_request(READ_KEY, "/api/v1/report?window=1h")?)
+            .await?;
+        assert_eq!(pooled.status(), StatusCode::OK);
+        let pooled_body = json_body(pooled).await?;
+
+        let writer_only_state = IngestState::new_with_shared_effect_sink(
+            state.shared_store(),
+            IngestConfig::default(),
+            Arc::new(TestNoopIngestEffectSink),
+        );
+        let writer_only_router = ingest_router(writer_only_state);
+        let writer_only = writer_only_router
+            .oneshot(read_request(READ_KEY, "/api/v1/report?window=1h")?)
+            .await?;
+        assert_eq!(writer_only.status(), StatusCode::OK);
+        let writer_only_body = json_body(writer_only).await?;
+
+        assert_eq!(
+            pooled_body["error_groups"],
+            writer_only_body["error_groups"]
+        );
+        assert_eq!(pooled_body["summary"], writer_only_body["summary"]);
+        assert_eq!(
+            pooled_body["error_groups"]
+                .as_array()
+                .map(Vec::len)
+                .unwrap_or_default(),
+            1
+        );
+
+        fs::remove_file(&path)?;
+        let _ = fs::remove_file(format!("{}-wal", path.display()));
+        let _ = fs::remove_file(format!("{}-shm", path.display()));
 
         Ok(())
     }

--- a/crates/canary-server/src/query_routes.rs
+++ b/crates/canary-server/src/query_routes.rs
@@ -120,13 +120,16 @@ pub(crate) async fn query_errors(
         without_annotation: params.without_annotation,
     };
 
-    let mut store = match state.lock_store() {
-        Ok(store) => store,
-        Err(_) => return problem_response(internal_problem()),
-    };
-
+    // `errors_by_service` and `errors_by_error_class` fuse a claim-expiry
+    // write into the read (Store::errors_by_service/_by_error_class take
+    // `&mut self`), so those two branches stay on the writer. Only the
+    // class-listing branch is a pure read and can use the read pool.
     match query_kind {
         QueryKind::Service { service } => {
+            let mut store = match state.lock_store() {
+                Ok(store) => store,
+                Err(_) => return problem_response(internal_problem()),
+            };
             match store.errors_by_service(&service, window, options) {
                 Ok(result) => json_status_response(StatusCode::OK.as_u16(), result),
                 Err(ErrorGroupQueryError::InvalidWindow) => {
@@ -141,14 +144,28 @@ pub(crate) async fn query_errors(
         QueryKind::ErrorClass {
             error_class,
             service,
-        } => match store.errors_by_error_class(&error_class, window, service.as_deref(), options) {
-            Ok(result) => json_status_response(StatusCode::OK.as_u16(), result),
-            Err(ErrorGroupQueryError::InvalidWindow) => problem_response(invalid_window_problem()),
-            Err(ErrorGroupQueryError::InvalidCursor) => problem_response(invalid_cursor_problem()),
-            Err(ErrorGroupQueryError::Sqlite(_)) => problem_response(internal_problem()),
-        },
+        } => {
+            let mut store = match state.lock_store() {
+                Ok(store) => store,
+                Err(_) => return problem_response(internal_problem()),
+            };
+            match store.errors_by_error_class(&error_class, window, service.as_deref(), options) {
+                Ok(result) => json_status_response(StatusCode::OK.as_u16(), result),
+                Err(ErrorGroupQueryError::InvalidWindow) => {
+                    problem_response(invalid_window_problem())
+                }
+                Err(ErrorGroupQueryError::InvalidCursor) => {
+                    problem_response(invalid_cursor_problem())
+                }
+                Err(ErrorGroupQueryError::Sqlite(_)) => problem_response(internal_problem()),
+            }
+        }
         QueryKind::ErrorClasses => {
-            match store.errors_by_class_scoped(window, &key.tenant_id, &key.project_id) {
+            let reader = match state.read_source() {
+                Ok(reader) => reader,
+                Err(_) => return problem_response(internal_problem()),
+            };
+            match reader.errors_by_class_scoped(window, &key.tenant_id, &key.project_id) {
                 Ok(result) => json_status_response(StatusCode::OK.as_u16(), result),
                 Err(QueryError::InvalidWindow) => problem_response(invalid_window_problem()),
                 Err(QueryError::Sqlite(_)) => problem_response(internal_problem()),
@@ -187,12 +204,12 @@ pub(crate) async fn timeline(
         cursor,
         event_type: params.event_type,
     };
-    let store = match state.lock_store() {
-        Ok(store) => store,
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
 
-    match store.timeline(window, options) {
+    match reader.timeline(window, options) {
         Ok(result) => json_status_response(StatusCode::OK.as_u16(), result),
         Err(TimelineQueryError::InvalidWindow) => problem_response(invalid_window_problem()),
         Err(TimelineQueryError::InvalidLimit) => problem_response(invalid_limit_problem()),
@@ -249,12 +266,12 @@ pub(crate) async fn show_error(
         Err(problem) => return problem_response(*problem),
     };
 
-    let mut store = match state.lock_store() {
-        Ok(store) => store,
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
 
-    let response = match store.error_detail_scoped(&id, &key.tenant_id, &key.project_id) {
+    let response = match reader.error_detail_scoped(&id, &key.tenant_id, &key.project_id) {
         Ok(Some(result)) => {
             if let Some(bound_service) = key.service.as_deref()
                 && result.service != bound_service
@@ -267,7 +284,14 @@ pub(crate) async fn show_error(
         Err(QueryError::InvalidWindow) => problem_response(invalid_window_problem()),
         Err(QueryError::Sqlite(_)) => problem_response(internal_problem()),
     };
+    drop(reader);
 
+    // The audit event is a write, so it stays on the writer; the heavy read
+    // above already ran off the writer connection.
+    let mut store = match state.lock_store() {
+        Ok(store) => store,
+        Err(_) => return problem_response(internal_problem()),
+    };
     crate::read_audit::record_read_audit(&mut store, &key, "GET /api/v1/errors/{id}");
     response
 }

--- a/crates/canary-server/src/read_source.rs
+++ b/crates/canary-server/src/read_source.rs
@@ -1,0 +1,200 @@
+//! Uniform read handle for authenticated read-model routes.
+//!
+//! Route handlers that only run `SELECT`-shaped queries call
+//! [`IngestState::read_source`] instead of [`IngestState::lock_store`]. When
+//! the runtime was wired with a [`ReadPool`] (the production boot path in
+//! `runtime.rs`), the returned [`ReadSource`] serves queries from a
+//! read-only WAL connection so read traffic no longer serializes behind the
+//! single-writer mutex. When no pool was wired (every in-memory test store
+//! in this crate), `ReadSource` falls back to the writer connection with
+//! identical query results — this module is the only place that fallback
+//! lives, so call sites never branch on it themselves.
+//!
+//! `report_error_groups_scoped` and `active_incidents` are deliberately not
+//! mirrored here: `Store`'s versions fuse a claim-expiry write into the
+//! read, so they always run on the writer. Callers needing them still use
+//! `IngestState::lock_store`.
+
+use std::sync::MutexGuard;
+
+use canary_core::query::{ErrorDetail, ErrorsByClass, TimelineResponse};
+use canary_store::{
+    ApiKeyRecord, ErrorSummaryItem, HealthMonitorStatus, HealthTargetStatus, QueryResult, Result,
+    Store, TargetCheckRead, TimelineQueryOptions, TimelineQueryResult,
+};
+use canary_store::{RecentTransition, SearchResult, ServiceSliSummary};
+
+use crate::IngestState;
+
+impl IngestState {
+    /// Return a read handle for one request: a pooled read-only connection
+    /// when a [`canary_store::ReadPool`] is wired, otherwise the writer
+    /// store guard.
+    pub(crate) fn read_source(&self) -> std::result::Result<ReadSource<'_>, String> {
+        match self.read_pool() {
+            Some(pool) => Ok(ReadSource::Pool(
+                pool.checkout().map_err(|error| error.to_string())?,
+            )),
+            None => Ok(ReadSource::Writer(self.lock_store()?)),
+        }
+    }
+}
+
+/// One request's read handle, backed by either a pooled read-only
+/// connection or the single-writer store guard.
+pub(crate) enum ReadSource<'a> {
+    Pool(canary_store::ReadConnection),
+    Writer(MutexGuard<'a, Store>),
+}
+
+impl ReadSource<'_> {
+    pub(crate) fn health_targets_scoped(
+        &self,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> Result<Vec<HealthTargetStatus>> {
+        match self {
+            Self::Pool(conn) => conn.health_targets_scoped(tenant_id, project_id),
+            Self::Writer(store) => store.health_targets_scoped(tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn health_monitors_scoped(
+        &self,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> Result<Vec<HealthMonitorStatus>> {
+        match self {
+            Self::Pool(conn) => conn.health_monitors_scoped(tenant_id, project_id),
+            Self::Writer(store) => store.health_monitors_scoped(tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn target_checks_scoped(
+        &self,
+        target_id: &str,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<TargetCheckRead>> {
+        match self {
+            Self::Pool(conn) => conn.target_checks_scoped(target_id, window, tenant_id, project_id),
+            Self::Writer(store) => {
+                store.target_checks_scoped(target_id, window, tenant_id, project_id)
+            }
+        }
+    }
+
+    pub(crate) fn target_checks_scoped_for_service(
+        &self,
+        target_id: &str,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+        service: &str,
+    ) -> QueryResult<Vec<TargetCheckRead>> {
+        match self {
+            Self::Pool(conn) => conn.target_checks_scoped_for_service(
+                target_id, window, tenant_id, project_id, service,
+            ),
+            Self::Writer(store) => store.target_checks_scoped_for_service(
+                target_id, window, tenant_id, project_id, service,
+            ),
+        }
+    }
+
+    pub(crate) fn error_summary_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<ErrorSummaryItem>> {
+        match self {
+            Self::Pool(conn) => conn.error_summary_scoped(window, tenant_id, project_id),
+            Self::Writer(store) => store.error_summary_scoped(window, tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn errors_by_class_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<ErrorsByClass> {
+        match self {
+            Self::Pool(conn) => conn.errors_by_class_scoped(window, tenant_id, project_id),
+            Self::Writer(store) => store.errors_by_class_scoped(window, tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn error_detail_scoped(
+        &self,
+        error_id: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Option<ErrorDetail>> {
+        match self {
+            Self::Pool(conn) => conn.error_detail_scoped(error_id, tenant_id, project_id),
+            Self::Writer(store) => store.error_detail_scoped(error_id, tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn service_sli_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<ServiceSliSummary>> {
+        match self {
+            Self::Pool(conn) => conn.service_sli_scoped(window, tenant_id, project_id),
+            Self::Writer(store) => store.service_sli_scoped(window, tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn recent_transitions_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<RecentTransition>> {
+        match self {
+            Self::Pool(conn) => conn.recent_transitions_scoped(window, tenant_id, project_id),
+            Self::Writer(store) => store.recent_transitions_scoped(window, tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn search_errors_scoped(
+        &self,
+        query: &str,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<SearchResult>> {
+        match self {
+            Self::Pool(conn) => conn.search_errors_scoped(query, window, tenant_id, project_id),
+            Self::Writer(store) => store.search_errors_scoped(query, window, tenant_id, project_id),
+        }
+    }
+
+    pub(crate) fn timeline(
+        &self,
+        window: &str,
+        options: TimelineQueryOptions,
+    ) -> TimelineQueryResult<TimelineResponse> {
+        match self {
+            Self::Pool(conn) => conn.timeline(window, options),
+            Self::Writer(store) => store.timeline(window, options),
+        }
+    }
+
+    pub(crate) fn list_api_keys_scoped(
+        &self,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> Result<Vec<ApiKeyRecord>> {
+        match self {
+            Self::Pool(conn) => conn.list_api_keys_scoped(tenant_id, project_id),
+            Self::Writer(store) => store.list_api_keys_scoped(tenant_id, project_id),
+        }
+    }
+}

--- a/crates/canary-server/src/read_source.rs
+++ b/crates/canary-server/src/read_source.rs
@@ -40,6 +40,25 @@ impl IngestState {
     }
 }
 
+impl ReadSource<'_> {
+    /// Run `f` so every read-model query it issues observes one consistent
+    /// snapshot. Callers whose block reads more than one row set that must
+    /// agree with each other (a multi-section report, for example) must use
+    /// this instead of calling query methods directly: a pool-backed source
+    /// gives each bare query its own WAL snapshot, so two sequential
+    /// queries could otherwise straddle a concurrent write and return a
+    /// self-contradictory result. A writer-backed source is already atomic
+    /// for the whole call because `IngestState::lock_store` holds the
+    /// single-writer mutex for as long as the guard lives, so this is a
+    /// plain call for that variant.
+    pub(crate) fn with_snapshot<T>(&self, f: impl FnOnce() -> T) -> std::result::Result<T, String> {
+        match self {
+            Self::Pool(conn) => conn.with_snapshot(f).map_err(|error| error.to_string()),
+            Self::Writer(_) => Ok(f()),
+        }
+    }
+}
+
 /// One request's read handle, backed by either a pooled read-only
 /// connection or the single-writer store guard.
 pub(crate) enum ReadSource<'a> {

--- a/crates/canary-server/src/report_routes.rs
+++ b/crates/canary-server/src/report_routes.rs
@@ -10,15 +10,16 @@ use axum::{
     http::{HeaderMap, HeaderName, Response, StatusCode},
 };
 use canary_core::query::{
-    ErrorGroupSummary, ReportCursor, decode_report_cursor, encode_report_cursor,
+    ErrorGroupSummary, ReportCursor, TimelineEvent, decode_report_cursor, encode_report_cursor,
 };
 use canary_http::problem_details::{
     ProblemDetails, internal_problem, invalid_report_cursor_problem, invalid_report_limit_problem,
     invalid_string_param_problem, invalid_window_problem,
 };
 use canary_store::{
-    IncidentListOptions, QueryError, RecentTransition, SearchResult, ServiceSliSummary,
-    ServiceSliTrajectory, TimelineQueryError, TimelineQueryOptions,
+    HealthMonitorStatus, HealthTargetStatus, IncidentListOptions, QueryError, RecentTransition,
+    SearchResult, ServiceSliSummary, ServiceSliTrajectory, TimelineQueryError,
+    TimelineQueryOptions,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -38,6 +39,26 @@ pub(crate) struct ReportParams {
     q: Option<String>,
     limit: Option<String>,
     cursor: Option<String>,
+}
+
+/// Bundle of every pure-read query the report handler runs inside one
+/// `ReadSource::with_snapshot` block, so every field below agrees with
+/// every other field (see the consistency note in `report`).
+struct ReportPoolReads {
+    targets: Vec<HealthTargetStatus>,
+    monitors: Vec<HealthMonitorStatus>,
+    error_summary: Vec<canary_store::ErrorSummaryItem>,
+    service_sli: Vec<ServiceSliSummary>,
+    transitions: Vec<RecentTransition>,
+    recent_events: Vec<TimelineEvent>,
+    search_results: Option<Vec<SearchResult>>,
+}
+
+fn report_query_problem(error: QueryError) -> Box<Response<Body>> {
+    Box::new(match error {
+        QueryError::InvalidWindow => problem_response(invalid_window_problem()),
+        QueryError::Sqlite(_) => problem_response(internal_problem()),
+    })
 }
 
 pub(crate) async fn report(
@@ -71,6 +92,17 @@ pub(crate) async fn report(
     // it no longer serializes behind the writer mutex (canary-930 child B).
     // The audit write at the bottom of this handler still runs on the writer
     // too, once the response is known to succeed.
+    //
+    // Residual tradeoff: this writer block and the pool block below run as
+    // two separate critical sections (plus a third for the audit write), not
+    // one atomic snapshot across the whole response the way the pre-split
+    // handler was. A write landing between them can make error_groups/
+    // incidents reflect a slightly different instant than targets/monitors/
+    // etc. That cross-block skew is accepted deliberately in exchange for
+    // concurrency — the pool block itself stays internally consistent via
+    // `with_snapshot` (canary-930 child B review fix), which is the property
+    // that actually matters for a report reader: every field sourced from
+    // the pool agrees with every other field sourced from the pool.
     let (mut error_groups, mut incidents) = {
         let mut store = match state.lock_store() {
             Ok(store) => store,
@@ -100,60 +132,80 @@ pub(crate) async fn report(
         Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut targets = match reader.health_targets_scoped(&key.tenant_id, &key.project_id) {
-        Ok(targets) => targets,
-        Err(_) => return problem_response(internal_problem()),
-    };
-    let mut monitors = match reader.health_monitors_scoped(&key.tenant_id, &key.project_id) {
-        Ok(monitors) => monitors,
-        Err(_) => return problem_response(internal_problem()),
-    };
-    let mut error_summary =
-        match reader.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
-            Ok(summary) => summary,
-            Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-            Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
+    let pool_reads = reader.with_snapshot(|| -> Result<ReportPoolReads, Box<Response<Body>>> {
+        let targets = reader
+            .health_targets_scoped(&key.tenant_id, &key.project_id)
+            .map_err(|_| Box::new(problem_response(internal_problem())))?;
+        let monitors = reader
+            .health_monitors_scoped(&key.tenant_id, &key.project_id)
+            .map_err(|_| Box::new(problem_response(internal_problem())))?;
+        let error_summary = reader
+            .error_summary_scoped(window, &key.tenant_id, &key.project_id)
+            .map_err(report_query_problem)?;
+        let service_sli = reader
+            .service_sli_scoped(window, &key.tenant_id, &key.project_id)
+            .map_err(report_query_problem)?;
+        let transitions = reader
+            .recent_transitions_scoped(window, &key.tenant_id, &key.project_id)
+            .map_err(report_query_problem)?;
+        let recent_events = reader
+            .timeline(
+                window,
+                TimelineQueryOptions {
+                    tenant_id: Some(key.tenant_id.clone()),
+                    project_id: Some(key.project_id.clone()),
+                    service: key.service.clone(),
+                    limit: Some("10".to_owned()),
+                    event_type: Some("telemetry.event".to_owned()),
+                    ..TimelineQueryOptions::default()
+                },
+            )
+            .map(|events| events.events)
+            .map_err(|error| {
+                Box::new(match error {
+                    TimelineQueryError::InvalidWindow => problem_response(invalid_window_problem()),
+                    TimelineQueryError::InvalidLimit
+                    | TimelineQueryError::InvalidCursor
+                    | TimelineQueryError::InvalidEventType(_)
+                    | TimelineQueryError::Sqlite(_) => problem_response(internal_problem()),
+                })
+            })?;
+        let search_results = match params.q.as_deref() {
+            Some(query) => Some(
+                match reader.search_errors_scoped(query, window, &key.tenant_id, &key.project_id) {
+                    Ok(results) => results,
+                    Err(QueryError::InvalidWindow) => {
+                        return Err(Box::new(problem_response(invalid_window_problem())));
+                    }
+                    Err(QueryError::Sqlite(_)) => Vec::new(),
+                },
+            ),
+            None => None,
         };
-    let mut service_sli = match reader.service_sli_scoped(window, &key.tenant_id, &key.project_id) {
-        Ok(service_sli) => service_sli,
-        Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-        Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
-    };
-    let mut transitions =
-        match reader.recent_transitions_scoped(window, &key.tenant_id, &key.project_id) {
-            Ok(transitions) => transitions,
-            Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-            Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
-        };
-    let recent_events = match reader.timeline(
-        window,
-        TimelineQueryOptions {
-            tenant_id: Some(key.tenant_id.clone()),
-            project_id: Some(key.project_id.clone()),
-            service: key.service.clone(),
-            limit: Some("10".to_owned()),
-            event_type: Some("telemetry.event".to_owned()),
-            ..TimelineQueryOptions::default()
-        },
-    ) {
-        Ok(events) => events.events,
-        Err(TimelineQueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-        Err(TimelineQueryError::InvalidLimit)
-        | Err(TimelineQueryError::InvalidCursor)
-        | Err(TimelineQueryError::InvalidEventType(_))
-        | Err(TimelineQueryError::Sqlite(_)) => return problem_response(internal_problem()),
-    };
-    let mut search_results = match params.q.as_deref() {
-        Some(query) => {
-            match reader.search_errors_scoped(query, window, &key.tenant_id, &key.project_id) {
-                Ok(results) => Some(results),
-                Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-                Err(QueryError::Sqlite(_)) => Some(Vec::new()),
-            }
-        }
-        None => None,
-    };
+        Ok(ReportPoolReads {
+            targets,
+            monitors,
+            error_summary,
+            service_sli,
+            transitions,
+            recent_events,
+            search_results,
+        })
+    });
     drop(reader);
+    let ReportPoolReads {
+        mut targets,
+        mut monitors,
+        mut error_summary,
+        mut service_sli,
+        mut transitions,
+        recent_events,
+        mut search_results,
+    } = match pool_reads {
+        Ok(Ok(reads)) => reads,
+        Ok(Err(problem)) => return *problem,
+        Err(_) => return problem_response(internal_problem()),
+    };
     if let Some(bound_service) = key.service.as_deref() {
         targets.retain(|target| target.service == bound_service);
         monitors.retain(|monitor| monitor.service == bound_service);

--- a/crates/canary-server/src/report_routes.rs
+++ b/crates/canary-server/src/report_routes.rs
@@ -64,51 +64,68 @@ pub(crate) async fn report(
         Err(problem) => return problem_response(*problem),
     };
 
-    let mut store = match state.lock_store() {
-        Ok(store) => store,
+    // `active_incidents` and `report_error_groups_scoped` fuse a claim-expiry
+    // write into the read (Store methods take `&mut self`), so this brief
+    // critical section covers just those two queries. Every other query in
+    // this handler is a pure read served from a read-only pool connection so
+    // it no longer serializes behind the writer mutex (canary-930 child B).
+    // The audit write at the bottom of this handler still runs on the writer
+    // too, once the response is known to succeed.
+    let (mut error_groups, mut incidents) = {
+        let mut store = match state.lock_store() {
+            Ok(store) => store,
+            Err(_) => return problem_response(internal_problem()),
+        };
+        let error_groups =
+            match store.report_error_groups_scoped(window, &key.tenant_id, &key.project_id) {
+                Ok(groups) => groups,
+                Err(QueryError::InvalidWindow) => {
+                    return problem_response(invalid_window_problem());
+                }
+                Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
+            };
+        let incidents = match store.active_incidents(IncidentListOptions {
+            tenant_id: Some(key.tenant_id.clone()),
+            project_id: Some(key.project_id.clone()),
+            ..IncidentListOptions::default()
+        }) {
+            Ok(incidents) => incidents.incidents,
+            Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
+            Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
+        };
+        (error_groups, incidents)
+    };
+
+    let reader = match state.read_source() {
+        Ok(reader) => reader,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut targets = match store.health_targets_scoped(&key.tenant_id, &key.project_id) {
+    let mut targets = match reader.health_targets_scoped(&key.tenant_id, &key.project_id) {
         Ok(targets) => targets,
         Err(_) => return problem_response(internal_problem()),
     };
-    let mut monitors = match store.health_monitors_scoped(&key.tenant_id, &key.project_id) {
+    let mut monitors = match reader.health_monitors_scoped(&key.tenant_id, &key.project_id) {
         Ok(monitors) => monitors,
         Err(_) => return problem_response(internal_problem()),
     };
     let mut error_summary =
-        match store.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
+        match reader.error_summary_scoped(window, &key.tenant_id, &key.project_id) {
             Ok(summary) => summary,
             Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
             Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
         };
-    let mut service_sli = match store.service_sli_scoped(window, &key.tenant_id, &key.project_id) {
+    let mut service_sli = match reader.service_sli_scoped(window, &key.tenant_id, &key.project_id) {
         Ok(service_sli) => service_sli,
         Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
         Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
     };
-    let mut error_groups =
-        match store.report_error_groups_scoped(window, &key.tenant_id, &key.project_id) {
-            Ok(groups) => groups,
-            Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-            Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
-        };
-    let mut incidents = match store.active_incidents(IncidentListOptions {
-        tenant_id: Some(key.tenant_id.clone()),
-        project_id: Some(key.project_id.clone()),
-        ..IncidentListOptions::default()
-    }) {
-        Ok(incidents) => incidents.incidents,
-        Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
-        Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
-    };
     let mut transitions =
-        match store.recent_transitions_scoped(window, &key.tenant_id, &key.project_id) {
+        match reader.recent_transitions_scoped(window, &key.tenant_id, &key.project_id) {
             Ok(transitions) => transitions,
             Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
             Err(QueryError::Sqlite(_)) => return problem_response(internal_problem()),
         };
-    let recent_events = match store.timeline(
+    let recent_events = match reader.timeline(
         window,
         TimelineQueryOptions {
             tenant_id: Some(key.tenant_id.clone()),
@@ -128,7 +145,7 @@ pub(crate) async fn report(
     };
     let mut search_results = match params.q.as_deref() {
         Some(query) => {
-            match store.search_errors_scoped(query, window, &key.tenant_id, &key.project_id) {
+            match reader.search_errors_scoped(query, window, &key.tenant_id, &key.project_id) {
                 Ok(results) => Some(results),
                 Err(QueryError::InvalidWindow) => return problem_response(invalid_window_problem()),
                 Err(QueryError::Sqlite(_)) => Some(Vec::new()),
@@ -136,6 +153,7 @@ pub(crate) async fn report(
         }
         None => None,
     };
+    drop(reader);
     if let Some(bound_service) = key.service.as_deref() {
         targets.retain(|target| target.service == bound_service);
         monitors.retain(|monitor| monitor.service == bound_service);
@@ -200,6 +218,10 @@ pub(crate) async fn report(
         json_status_response(StatusCode::OK.as_u16(), body)
     };
 
+    let mut store = match state.lock_store() {
+        Ok(store) => store,
+        Err(_) => return problem_response(internal_problem()),
+    };
     crate::read_audit::record_read_audit(&mut store, &key, "GET /api/v1/report");
     result
 }

--- a/crates/canary-server/src/route_state.rs
+++ b/crates/canary-server/src/route_state.rs
@@ -8,7 +8,7 @@
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use canary_ingest::{IngestConfig, IngestEffect};
-use canary_store::Store;
+use canary_store::{ReadPool, Store};
 use canary_workers::webhooks::{TransportResult, WebhookRequest};
 
 use crate::auth_cache::AuthCache;
@@ -52,6 +52,11 @@ pub struct IngestState {
     auth_fail_identity: AuthFailIdentityConfig,
     allow_private_targets: bool,
     auth_cache: Arc<AuthCache>,
+    /// Read-only connection source for read-model routes. `None` for
+    /// in-memory stores (all of this crate's test fixtures), which have no
+    /// second file to open a sibling connection against; those routes fall
+    /// back to the writer connection, exactly as before this existed.
+    read_pool: Option<Arc<ReadPool>>,
 }
 
 /// Client identity source used only for invalid-key
@@ -100,6 +105,7 @@ impl IngestState {
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
             auth_cache: Arc::new(AuthCache::default()),
+            read_pool: None,
         }
     }
 
@@ -129,6 +135,7 @@ impl IngestState {
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
             auth_cache: Arc::new(AuthCache::default()),
+            read_pool: None,
         }
     }
 
@@ -150,6 +157,7 @@ impl IngestState {
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
             auth_cache: Arc::new(AuthCache::default()),
+            read_pool: None,
         }
     }
 
@@ -171,6 +179,7 @@ impl IngestState {
             auth_fail_identity: AuthFailIdentityConfig::default(),
             allow_private_targets: false,
             auth_cache: Arc::new(AuthCache::default()),
+            read_pool: None,
         }
     }
 
@@ -196,6 +205,13 @@ impl IngestState {
     /// Allow admin target creation to accept private/non-global probe hosts.
     pub fn with_allow_private_targets(mut self, allow_private_targets: bool) -> Self {
         self.allow_private_targets = allow_private_targets;
+        self
+    }
+
+    /// Attach a read pool so read-model routes serve queries from read-only
+    /// WAL connections instead of the single-writer store.
+    pub fn with_read_pool(mut self, read_pool: Arc<ReadPool>) -> Self {
+        self.read_pool = Some(read_pool);
         self
     }
 
@@ -243,6 +259,11 @@ impl IngestState {
 
     pub(crate) fn auth_cache(&self) -> &AuthCache {
         &self.auth_cache
+    }
+
+    /// Read pool for read-model routes, when this state was wired with one.
+    pub(crate) fn read_pool(&self) -> Option<&Arc<ReadPool>> {
+        self.read_pool.as_ref()
     }
 
     pub(crate) fn allow_private_targets(&self) -> bool {

--- a/crates/canary-server/src/runtime.rs
+++ b/crates/canary-server/src/runtime.rs
@@ -18,7 +18,7 @@ use std::{
 use axum::Router;
 use canary_http::public::DependencyStatus;
 use canary_ingest::{IngestConfig, IngestEffect};
-use canary_store::{IncidentCorrelation, Store};
+use canary_store::{IncidentCorrelation, ReadPool, Store};
 use canary_workers::retention::RetentionPolicy;
 
 use crate::{
@@ -151,6 +151,8 @@ impl CanaryServer {
                 eprintln!("Bootstrap API key created but not disclosed by process config.");
             }
         }
+        let read_pool =
+            Arc::new(ReadPool::open(&config.database_path).map_err(ServerBootError::Store)?);
         let store = Arc::new(Mutex::new(store));
         let worker_health = WorkerHealthRegistry::new();
 
@@ -235,7 +237,8 @@ impl CanaryServer {
         let ingest_state = ingest_state
             .with_target_control(Arc::new(target_probe_worker.controller()))
             .with_auth_fail_identity(config.auth_fail_identity)
-            .with_allow_private_targets(allow_private_targets);
+            .with_allow_private_targets(allow_private_targets)
+            .with_read_pool(read_pool);
         let readiness = PublicReadiness::from_probe(Arc::new(StoreReadinessProbe {
             store: store.clone(),
             workers: worker_health.clone(),

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -21,6 +21,7 @@ mod metrics;
 mod oban_jobs;
 mod query;
 mod rate_limits;
+mod read_pool;
 mod retention;
 mod schema;
 mod scope;
@@ -69,6 +70,7 @@ pub use query::{
     TimelineQueryOptions, TimelineQueryResult,
 };
 pub use rate_limits::DurableRateLimitDecision;
+pub use read_pool::{ReadConnection, ReadPool};
 pub use retention::{
     RetentionPrune, RetentionPruneBatch, RetentionPruneBatchReport, RetentionPruneReport,
     RetentionPruneTable,
@@ -96,6 +98,10 @@ pub enum StoreError {
     /// API-key hashing failed while preparing a persisted secret.
     #[error("secret hash error: {0}")]
     SecretHash(#[from] bcrypt::BcryptError),
+    /// A read pool was opened against a database that is not running in WAL
+    /// journal mode, so concurrent readers are not guaranteed.
+    #[error("read pool requires WAL journal mode, found `{0}`")]
+    ReadPoolNotWal(String),
     /// A service-onboarding target conflicts with an existing target row.
     #[error("target conflict")]
     TargetConflict(TargetConflict),

--- a/crates/canary-store/src/read_pool.rs
+++ b/crates/canary-store/src/read_pool.rs
@@ -1,0 +1,353 @@
+//! Read-only SQLite connections for concurrent read-model queries.
+//!
+//! [`Store`](crate::Store) keeps a single writable connection behind the
+//! server's mutex (see the crate-level single-writer invariant). Read-model
+//! routes historically ran on that same connection, so concurrent read
+//! traffic serialized behind the writer mutex even though SQLite's WAL
+//! journal mode already supports many concurrent readers against one file.
+//!
+//! `ReadPool` opens a fresh read-only connection per checkout against the
+//! database file backing a `Store`. Opening a small WAL-mode connection is
+//! cheap, and a per-checkout connection avoids pool-exhaustion and
+//! checkout-deadlock failure modes entirely: there is no shared pool state
+//! to contend on. `ReadPool` refuses to open a database that is not already
+//! running in WAL journal mode, since a rollback-journal database still
+//! serializes readers against the writer at the SQLite layer.
+//!
+//! In-memory stores (used throughout this crate's and canary-server's test
+//! suites) have no second file to open a sibling connection against, so
+//! `ReadPool` only supports file-backed databases. Callers that have not
+//! wired a `ReadPool` keep reading through the writer connection exactly as
+//! before; that fallback lives in canary-server's route state, not here.
+//!
+//! Deliberately absent: `report_error_groups_scoped`. `Store`'s version
+//! fuses a claim-expiry write with the read (`&mut self`), and a read-only
+//! connection cannot perform that write. Callers that need it stay on the
+//! writer connection.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use canary_core::query::{ErrorDetail, ErrorsByClass};
+use rusqlite::{Connection, OpenFlags};
+
+use crate::{
+    ApiKeyRecord, ErrorSummaryItem, HealthMonitorStatus, HealthTargetStatus, QueryResult, Result,
+    ServiceSliSummary, StoreError, TargetCheckRead, TimelineQueryOptions, TimelineQueryResult,
+};
+use crate::{RecentTransition, SearchResult};
+use crate::{api_keys, health, query, service_sli};
+
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Opens read-only SQLite connections against the file backing a [`Store`](crate::Store).
+#[derive(Clone)]
+pub struct ReadPool {
+    path: PathBuf,
+}
+
+impl ReadPool {
+    /// Open a read pool against the database at `path`.
+    ///
+    /// Fails loudly if the database cannot be opened read-only or is not
+    /// already running in WAL journal mode, instead of silently degrading to
+    /// serialized readers.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let probe = Self::connect(&path)?;
+        let journal_mode: String =
+            probe.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
+        if !journal_mode.eq_ignore_ascii_case("wal") {
+            return Err(StoreError::ReadPoolNotWal(journal_mode));
+        }
+        Ok(Self { path })
+    }
+
+    fn connect(path: &Path) -> Result<Connection> {
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        connection.pragma_update(None, "query_only", true)?;
+        connection.busy_timeout(BUSY_TIMEOUT)?;
+        Ok(connection)
+    }
+
+    /// Check out a fresh read-only connection scoped to one request.
+    pub fn checkout(&self) -> Result<ReadConnection> {
+        Ok(ReadConnection {
+            connection: Self::connect(&self.path)?,
+        })
+    }
+}
+
+/// One read-only SQLite connection checked out from a [`ReadPool`] for a
+/// single request. Every method here mirrors the read-only subset of
+/// [`Store`](crate::Store)'s query surface used by canary-server's
+/// authenticated read routes.
+pub struct ReadConnection {
+    connection: Connection,
+}
+
+impl ReadConnection {
+    /// Return target health rows for one tenant/project.
+    pub fn health_targets_scoped(
+        &self,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> Result<Vec<HealthTargetStatus>> {
+        health::health_targets_scoped(&self.connection, tenant_id, project_id)
+    }
+
+    /// Return monitor health rows for one tenant/project.
+    pub fn health_monitors_scoped(
+        &self,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> Result<Vec<HealthMonitorStatus>> {
+        health::health_monitors_scoped(&self.connection, tenant_id, project_id)
+    }
+
+    /// Query recent target checks when the target belongs to one tenant/project.
+    pub fn target_checks_scoped(
+        &self,
+        target_id: &str,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<TargetCheckRead>> {
+        health::target_checks_scoped(&self.connection, target_id, window, tenant_id, project_id)
+    }
+
+    /// Query recent target checks when the target belongs to one service authority.
+    pub fn target_checks_scoped_for_service(
+        &self,
+        target_id: &str,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+        service: &str,
+    ) -> QueryResult<Vec<TargetCheckRead>> {
+        health::target_checks_scoped_for_service(
+            &self.connection,
+            target_id,
+            window,
+            tenant_id,
+            project_id,
+            service,
+        )
+    }
+
+    /// Query active error counts grouped by service for one tenant/project.
+    pub fn error_summary_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<ErrorSummaryItem>> {
+        query::error_summary_scoped(&self.connection, window, tenant_id, project_id)
+    }
+
+    /// Query recent error counts grouped by error class for one tenant/project.
+    pub fn errors_by_class_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<ErrorsByClass> {
+        query::errors_by_class_scoped(&self.connection, window, tenant_id, project_id)
+    }
+
+    /// Return one error detail read model for one tenant/project.
+    pub fn error_detail_scoped(
+        &self,
+        error_id: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Option<ErrorDetail>> {
+        query::error_detail_scoped(&self.connection, error_id, tenant_id, project_id)
+    }
+
+    /// Query windowed service SLI aggregates for one tenant/project.
+    pub fn service_sli_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<ServiceSliSummary>> {
+        service_sli::service_sli_scoped(&self.connection, window, tenant_id, project_id)
+    }
+
+    /// Query recent target and monitor transitions for one tenant/project.
+    pub fn recent_transitions_scoped(
+        &self,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<RecentTransition>> {
+        query::recent_transitions_scoped(&self.connection, window, tenant_id, project_id)
+    }
+
+    /// Search recent errors for one tenant/project.
+    pub fn search_errors_scoped(
+        &self,
+        query_text: &str,
+        window: &str,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> QueryResult<Vec<SearchResult>> {
+        query::search_errors_scoped(&self.connection, query_text, window, tenant_id, project_id)
+    }
+
+    /// Query the durable service-event timeline.
+    pub fn timeline(
+        &self,
+        window: &str,
+        options: TimelineQueryOptions,
+    ) -> TimelineQueryResult<canary_core::query::TimelineResponse> {
+        query::timeline(&self.connection, window, options)
+    }
+
+    /// Return admin-visible API keys for one tenant/project.
+    pub fn list_api_keys_scoped(
+        &self,
+        tenant_id: &str,
+        project_id: &str,
+    ) -> Result<Vec<ApiKeyRecord>> {
+        api_keys::list_scoped(&self.connection, tenant_id, project_id)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::{BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, Store};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn temp_db_path(name: &str) -> PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        std::env::temp_dir().join(format!(
+            "canary-read-pool-{name}-{}-{suffix}.db",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn open_rejects_non_wal_database() -> Result<()> {
+        let path = temp_db_path("non-wal");
+        {
+            let connection = Connection::open(&path)?;
+            connection.pragma_update(None, "journal_mode", "DELETE")?;
+        }
+
+        let result = ReadPool::open(&path);
+
+        let _ = std::fs::remove_file(&path);
+        assert!(matches!(result, Err(StoreError::ReadPoolNotWal(_))));
+        Ok(())
+    }
+
+    fn sample_target_insert(id: &str) -> crate::TargetInsert {
+        crate::TargetInsert {
+            id: id.to_owned(),
+            url: "https://example.test/health".to_owned(),
+            name: "read pool target".to_owned(),
+            service: "canary".to_owned(),
+            method: "GET".to_owned(),
+            headers: None,
+            interval_ms: 60_000,
+            timeout_ms: 10_000,
+            expected_status: "200".to_owned(),
+            body_contains: None,
+            degraded_after: 1,
+            down_after: 3,
+            up_after: 1,
+            active: true,
+            created_at: "2026-05-28T19:00:00Z".to_owned(),
+        }
+    }
+
+    #[test]
+    fn checkout_reads_committed_rows_without_touching_writer() -> Result<()> {
+        let path = temp_db_path("reads-committed");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        store.insert_target_scoped(
+            sample_target_insert("TGT-read-pool-1"),
+            BOOTSTRAP_TENANT_ID,
+            BOOTSTRAP_PROJECT_ID,
+        )?;
+        drop(store);
+
+        let pool = ReadPool::open(&path)?;
+        let conn = pool.checkout()?;
+        let targets = conn.health_targets_scoped(BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)?;
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].id, "TGT-read-pool-1");
+        Ok(())
+    }
+
+    /// A concurrent read via [`ReadPool`] must make progress while another
+    /// thread holds an open SQLite write transaction on the writer
+    /// connection, proving reads no longer serialize behind the writer.
+    #[test]
+    fn concurrent_read_makes_progress_while_writer_transaction_is_open() -> Result<()> {
+        let path = temp_db_path("concurrent-progress");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        store.insert_target_scoped(
+            sample_target_insert("TGT-during-write"),
+            BOOTSTRAP_TENANT_ID,
+            BOOTSTRAP_PROJECT_ID,
+        )?;
+
+        let pool = ReadPool::open(&path)?;
+        let writer_holding = Arc::new(Barrier::new(2));
+        let release_writer = Arc::new(Barrier::new(2));
+
+        let writer_thread = {
+            let writer_holding = writer_holding.clone();
+            let release_writer = release_writer.clone();
+            thread::spawn(move || {
+                store
+                    .connection
+                    .execute_batch("BEGIN IMMEDIATE")
+                    .expect("begin writer transaction");
+                writer_holding.wait();
+                release_writer.wait();
+                store
+                    .connection
+                    .execute_batch("COMMIT")
+                    .expect("commit writer transaction");
+            })
+        };
+
+        writer_holding.wait();
+        let conn = pool.checkout()?;
+        let started = std::time::Instant::now();
+        let targets = conn.health_targets_scoped(BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)?;
+        let elapsed = started.elapsed();
+        release_writer.wait();
+        writer_thread.join().expect("writer thread panicked");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+
+        assert_eq!(targets.len(), 1);
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "read blocked on open writer transaction: took {elapsed:?}"
+        );
+        Ok(())
+    }
+}

--- a/crates/canary-store/src/read_pool.rs
+++ b/crates/canary-store/src/read_pool.rs
@@ -24,8 +24,29 @@
 //! fuses a claim-expiry write with the read (`&mut self`), and a read-only
 //! connection cannot perform that write. Callers that need it stay on the
 //! writer connection.
+//!
+//! Two more properties callers must not assume away:
+//!
+//! - **Cross-query consistency is not automatic.** A bare `checkout()`
+//!   connection gives each individual query its own WAL snapshot; two
+//!   sequential queries on the same [`ReadConnection`] can observe two
+//!   different, non-atomic points in time if another connection commits a
+//!   write in between. Callers that read more than one table/row set that
+//!   must agree with each other (a multi-section report, for example) must
+//!   wrap the whole read in [`ReadConnection::with_snapshot`], which opens
+//!   one read transaction so every query inside it shares a single
+//!   snapshot.
+//! - **Concurrent checkouts are bounded.** `ReadPool` opens a fresh
+//!   connection per checkout rather than pooling connections, but an
+//!   unbounded number of simultaneously open connections on a small box
+//!   would still be a resource-exhaustion footgun. `checkout()` blocks past
+//!   [`DEFAULT_MAX_CONCURRENT_CHECKOUTS`] concurrently open connections
+//!   (configurable via [`ReadPool::open_with_capacity`]) instead of falling
+//!   back to the writer, keeping read behavior uniform; the wait is brief
+//!   in practice because checked-out connections are held for one request.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
 use canary_core::query::{ErrorDetail, ErrorsByClass};
@@ -40,19 +61,35 @@ use crate::{api_keys, health, query, service_sli};
 
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Default cap on simultaneously open [`ReadPool`] checkouts. Chosen for a
+/// small (1-2 vCPU) single-instance deployment: high enough that ordinary
+/// request concurrency never waits, low enough to bound worst-case
+/// connection/file-descriptor fan-out.
+pub const DEFAULT_MAX_CONCURRENT_CHECKOUTS: usize = 12;
+
 /// Opens read-only SQLite connections against the file backing a [`Store`](crate::Store).
 #[derive(Clone)]
 pub struct ReadPool {
     path: PathBuf,
+    limiter: Arc<CheckoutLimiter>,
 }
 
 impl ReadPool {
-    /// Open a read pool against the database at `path`.
+    /// Open a read pool against the database at `path`, allowing up to
+    /// [`DEFAULT_MAX_CONCURRENT_CHECKOUTS`] simultaneously open connections.
     ///
     /// Fails loudly if the database cannot be opened read-only or is not
     /// already running in WAL journal mode, instead of silently degrading to
     /// serialized readers.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        Self::open_with_capacity(path, DEFAULT_MAX_CONCURRENT_CHECKOUTS)
+    }
+
+    /// Open a read pool against the database at `path`, bounding
+    /// simultaneously open connections to `capacity`. `checkout()` blocks
+    /// once `capacity` connections are outstanding, instead of falling back
+    /// to the writer or opening unboundedly many connections.
+    pub fn open_with_capacity(path: impl AsRef<Path>, capacity: usize) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
         let probe = Self::connect(&path)?;
         let journal_mode: String =
@@ -60,7 +97,10 @@ impl ReadPool {
         if !journal_mode.eq_ignore_ascii_case("wal") {
             return Err(StoreError::ReadPoolNotWal(journal_mode));
         }
-        Ok(Self { path })
+        Ok(Self {
+            path,
+            limiter: Arc::new(CheckoutLimiter::new(capacity)),
+        })
     }
 
     fn connect(path: &Path) -> Result<Connection> {
@@ -73,11 +113,65 @@ impl ReadPool {
         Ok(connection)
     }
 
-    /// Check out a fresh read-only connection scoped to one request.
+    /// Check out a fresh read-only connection scoped to one request. Blocks
+    /// while the pool's concurrent-checkout capacity is exhausted.
     pub fn checkout(&self) -> Result<ReadConnection> {
+        let permit = self.limiter.clone().acquire();
         Ok(ReadConnection {
             connection: Self::connect(&self.path)?,
+            _permit: permit,
         })
+    }
+}
+
+/// Dependency-free counting semaphore bounding concurrent [`ReadPool`]
+/// checkouts.
+struct CheckoutLimiter {
+    available: Mutex<usize>,
+    freed: Condvar,
+}
+
+impl CheckoutLimiter {
+    fn new(capacity: usize) -> Self {
+        Self {
+            available: Mutex::new(capacity),
+            freed: Condvar::new(),
+        }
+    }
+
+    fn acquire(self: Arc<Self>) -> CheckoutPermit {
+        let mut available = self
+            .available
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        while *available == 0 {
+            available = self
+                .freed
+                .wait(available)
+                .unwrap_or_else(|poison| poison.into_inner());
+        }
+        *available -= 1;
+        drop(available);
+        CheckoutPermit { limiter: self }
+    }
+}
+
+/// RAII permit returned by [`CheckoutLimiter::acquire`]; releases capacity
+/// back to the limiter on drop.
+struct CheckoutPermit {
+    limiter: Arc<CheckoutLimiter>,
+}
+
+impl Drop for CheckoutPermit {
+    fn drop(&mut self) {
+        let mut available = self
+            .limiter
+            .available
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        *available += 1;
+        drop(available);
+        self.limiter.freed.notify_one();
     }
 }
 
@@ -87,6 +181,21 @@ impl ReadPool {
 /// authenticated read routes.
 pub struct ReadConnection {
     connection: Connection,
+    _permit: CheckoutPermit,
+}
+
+impl ReadConnection {
+    /// Run `f` inside one read transaction so every query it issues shares
+    /// a single WAL snapshot, instead of each query independently grabbing
+    /// whatever snapshot is current when it runs. Required whenever a
+    /// caller reads more than one row set that must agree with each other;
+    /// see the module-level docs for the consistency footgun this closes.
+    pub fn with_snapshot<T>(&self, f: impl FnOnce() -> T) -> Result<T> {
+        self.connection.execute_batch("BEGIN DEFERRED")?;
+        let result = f();
+        self.connection.execute_batch("COMMIT")?;
+        Ok(result)
+    }
 }
 
 impl ReadConnection {
@@ -223,7 +332,7 @@ impl ReadConnection {
 mod tests {
     use super::*;
     use crate::{BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, Store};
-    use std::sync::{Arc, Barrier};
+    use std::sync::{Arc, Barrier, mpsc};
     use std::thread;
 
     fn temp_db_path(name: &str) -> PathBuf {
@@ -348,6 +457,121 @@ mod tests {
             elapsed < Duration::from_millis(500),
             "read blocked on open writer transaction: took {elapsed:?}"
         );
+        Ok(())
+    }
+
+    /// `with_snapshot` must give every query inside it one consistent view:
+    /// a write committed by another connection strictly between two of its
+    /// queries must not be visible to the second query, only to a later,
+    /// separate checkout. This is the regression guard for the review
+    /// finding that a bare `checkout()` gives each query its own snapshot.
+    #[test]
+    fn with_snapshot_gives_every_query_inside_it_one_consistent_view() -> Result<()> {
+        let path = temp_db_path("snapshot-consistency");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        store.insert_target_scoped(
+            sample_target_insert("TGT-before-snapshot"),
+            BOOTSTRAP_TENANT_ID,
+            BOOTSTRAP_PROJECT_ID,
+        )?;
+        drop(store);
+
+        let pool = ReadPool::open(&path)?;
+        let conn = pool.checkout()?;
+
+        let ready_for_write = Arc::new(Barrier::new(2));
+        let write_done = Arc::new(Barrier::new(2));
+        let writer_thread = {
+            let path = path.clone();
+            let ready_for_write = ready_for_write.clone();
+            let write_done = write_done.clone();
+            thread::spawn(move || {
+                ready_for_write.wait();
+                let mut writer = Store::open(&path).expect("reopen writer");
+                writer
+                    .insert_target_scoped(
+                        sample_target_insert("TGT-during-snapshot"),
+                        BOOTSTRAP_TENANT_ID,
+                        BOOTSTRAP_PROJECT_ID,
+                    )
+                    .expect("insert during snapshot");
+                write_done.wait();
+            })
+        };
+
+        let (first_count, second_count) = conn.with_snapshot(|| {
+            let first = conn
+                .health_targets_scoped(BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)
+                .expect("first read")
+                .len();
+            ready_for_write.wait();
+            write_done.wait();
+            let second = conn
+                .health_targets_scoped(BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)
+                .expect("second read")
+                .len();
+            (first, second)
+        })?;
+        writer_thread.join().expect("writer thread panicked");
+
+        let after_snapshot = pool
+            .checkout()?
+            .health_targets_scoped(BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)?
+            .len();
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+
+        assert_eq!(first_count, 1);
+        assert_eq!(
+            second_count, 1,
+            "second read inside the same snapshot must not observe the concurrent insert"
+        );
+        assert_eq!(
+            after_snapshot, 2,
+            "a fresh checkout after the snapshot ends must observe the committed insert"
+        );
+        Ok(())
+    }
+
+    /// `checkout()` must block once the pool's concurrency cap is
+    /// exhausted rather than opening unboundedly many connections.
+    #[test]
+    fn checkout_blocks_when_pool_capacity_is_exhausted() -> Result<()> {
+        let path = temp_db_path("capacity");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        drop(store);
+
+        let pool = ReadPool::open_with_capacity(&path, 1)?;
+        let first = pool.checkout()?;
+
+        let pool_clone = pool.clone();
+        let (done_tx, done_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let _second = pool_clone
+                .checkout()
+                .expect("checkout should eventually succeed");
+            done_tx.send(()).expect("send completion");
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "checkout should block while capacity is exhausted"
+        );
+
+        drop(first);
+        done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("checkout should complete once capacity frees up");
+        handle.join().expect("checkout thread panicked");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

canary-930 child B. Child A (merged, PR #253) took bcrypt off the request path; the live post-A oracle isolated the residual bottleneck to the report query itself serializing on the single-writer store lock (12 concurrent `GET /api/v1/report?window=1h` staircased 0.625->5.169s, wall 5.216s, while `/api/v1/keys` stayed flat at 0.269s).

- Adds `canary_store::ReadPool`, which opens a fresh read-only WAL connection per checkout against the same database file backing `Store`. WAL already supports many concurrent readers; `ReadPool::open` fails loudly if the file isn't already in WAL mode instead of silently degrading to serialized reads. Per-checkout connections (not a shared pool) sidestep pool-exhaustion/deadlock failure modes entirely.
- Wires it through a new `ReadSource` abstraction in canary-server (`read_source.rs`) that route handlers call instead of `lock_store()` for pure-read queries. It falls back to the writer transparently when no pool is configured, so every existing in-memory-store test is unaffected. Production boot (`runtime.rs`) always wires a `ReadPool` from the same `database_path` used to open the writer `Store`.
- Moved off the writer: `/api/v1/status`, `/api/v1/health-status`, `/api/v1/keys` (GET), target checks, timeline, the class-listing branch of `/api/v1/query`, error detail, and the bulk of `/api/v1/report`.
- Deliberately left on the writer, called out in both modules' doc comments: `Store::errors_by_service` / `errors_by_error_class` / `active_incidents` / `report_error_groups_scoped` / `incident_detail_scoped` fuse a claim-expiry write into the read (`&mut self`), and responder read-audit events are themselves durable writes. Rate-limit accounting and the auth candidate fetch are untouched per the card's explicit boundary — `report`'s writer critical section is now bounded to exactly two queries plus the audit insert instead of eight fused SELECTs.

## Test plan

- [x] `cargo test --workspace --locked` — all green (canary-store 122+12, canary-server 250, workspace unaffected)
- [x] `cargo clippy --workspace --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `./bin/validate --fast` (pre-commit) and `./bin/validate --strict` (pre-push) — both green
- [x] New canary-store test `concurrent_read_makes_progress_while_writer_transaction_is_open` proves the core mechanism: a `ReadPool` read completes while a second connection holds an open `BEGIN IMMEDIATE` writer transaction on the same file
- [x] New canary-store test `open_rejects_non_wal_database` proves the WAL fail-loud contract
- [x] New canary-server test `read_pool_serves_report_route_with_matching_data` proves the pooled and writer-only code paths return byte-identical report data
- [ ] Live oracle (residual, post-deploy): 12 concurrent `GET /api/v1/report?window=1h` against production, compared against the pre-fix baseline wall of 5.216s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Faster, lower-contention reads for health, report, query, and API key pages by using a dedicated read path.
  * Improved startup support for databases that can serve read-only requests alongside writes.

* **Bug Fixes**
  * Search, timeline, and detail views now avoid unnecessary write-side locking, helping reduce timeouts and slow responses.
  * Report data and health checks are now fetched more reliably under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->