### PR TITLE
fix(server): isolate /readyz and contain request-path panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "canary-ingest",
  "canary-store",
  "canary-workers",
+ "parking_lot",
  "rcgen",
  "reqwest",
  "rustls",
@@ -1068,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1215,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pem"
@@ -1461,6 +1494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1688,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1988,10 +2036,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/crates/canary-server/Cargo.toml
+++ b/crates/canary-server/Cargo.toml
@@ -14,6 +14,7 @@ canary-core = { path = "../canary-core" }
 canary-http = { path = "../canary-http" }
 canary-store = { path = "../canary-store" }
 canary-workers = { path = "../canary-workers" }
+parking_lot = "0.12"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive"] }
@@ -22,7 +23,7 @@ sha2 = "0.10"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1.48", features = ["macros", "net", "rt-multi-thread", "signal"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["catch-panic", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 x509-parser = "0.18"

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -120,7 +120,10 @@ pub use tls_scan::{
     TlsExpiryScanLifecycle, TlsExpiryScanLifecycleConfig, TlsExpiryScanLifecycleReport,
     TlsExpiryScanLifecycleWorker, TlsExpiryScanRuntimeError, run_tls_expiry_scan_once,
 };
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::{
+    catch_panic::CatchPanicLayer,
+    cors::{Any, CorsLayer},
+};
 pub use webhook_delivery::{
     InMemoryWebhookCircuit, WebhookCircuit, WebhookDeliveryDrain, WebhookDeliveryDrainReport,
     WebhookDeliveryDrainWorker, WebhookDeliveryRuntime,
@@ -135,6 +138,13 @@ pub(crate) use worker_health::{
 };
 
 /// Router for Canary's authenticated ingest endpoints.
+///
+/// Wrapped in [`CatchPanicLayer`] so one panicking handler yields a single
+/// RFC 9457 500 for that request instead of an aborted connection. Combined
+/// with the writer store's non-poisoning `parking_lot::Mutex`
+/// (`route_state::SharedStore`), a panic while holding the store lock can no
+/// longer wedge every subsequent authenticated request behind a poisoned
+/// mutex (canary-930: "request path must not poison the writer mutex").
 pub fn ingest_router(state: IngestState) -> Router {
     Router::<IngestState>::new()
         .route("/metrics", get(metrics))
@@ -201,6 +211,7 @@ pub fn ingest_router(state: IngestState) -> Router {
         .route("/api/v1/targets/{id}/pause", post(pause_target))
         .route("/api/v1/targets/{id}/resume", post(resume_target))
         .with_state(state)
+        .layer(CatchPanicLayer::custom(handle_request_panic))
 }
 
 fn browser_ingest_cors_layer() -> CorsLayer {
@@ -208,6 +219,27 @@ fn browser_ingest_cors_layer() -> CorsLayer {
         .allow_origin(Any)
         .allow_methods([Method::POST, Method::OPTIONS])
         .allow_headers([AUTHORIZATION, CONTENT_TYPE])
+}
+
+/// Convert a panic unwinding out of a request handler into one RFC 9457 500
+/// response. Applied to the whole authenticated router (`ingest_router`) so
+/// no single handler bug can turn into a dropped connection or -- combined
+/// with the non-poisoning writer mutex -- a stuck process (canary-930).
+fn handle_request_panic(
+    err: Box<dyn std::any::Any + Send + 'static>,
+) -> axum::http::Response<axum::body::Body> {
+    let message = if let Some(message) = err.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = err.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else {
+        "unknown panic".to_owned()
+    };
+    tracing::error!(
+        panic.message = %message,
+        "request handler panicked; converted to one 500 response"
+    );
+    http_contract::problem_response(canary_http::problem_details::internal_problem())
 }
 
 /// Headers set by the public adapter.
@@ -223,12 +255,13 @@ mod tests {
     use std::process;
     use std::str::FromStr;
     use std::sync::{
-        Arc, Mutex, Mutex as StdMutex,
+        Arc, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
     };
     use std::thread::{self, JoinHandle, ThreadId};
     use std::time::{Duration as StdDuration, Instant};
 
+    use crate::route_state::SharedStore;
     use axum::{
         body::{Body, to_bytes},
         http::{
@@ -1144,6 +1177,62 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    /// Test-only handler proving a panic while holding the writer lock
+    /// neither poisons subsequent `lock_store()` calls nor produces more
+    /// than one failed response (canary-930).
+    #[allow(clippy::expect_used, clippy::panic)]
+    async fn test_panic_handler(
+        axum::extract::State(state): axum::extract::State<IngestState>,
+    ) -> StatusCode {
+        let _guard = state
+            .lock_store()
+            .expect("lock_store is infallible under parking_lot");
+        panic!("test_panic_handler: intentional panic to prove request-path panic containment");
+    }
+
+    /// `ingest_router` plus one test-only panicking route, merged in with
+    /// the same [`CatchPanicLayer`] production applies so the panic path
+    /// under test is the real one, not a stand-in.
+    fn router_with_test_panic_route(state: IngestState) -> Router {
+        let panic_router = Router::<IngestState>::new()
+            .route("/api/v1/__test/panic", get(test_panic_handler))
+            .with_state(state.clone())
+            .layer(CatchPanicLayer::custom(handle_request_panic));
+        ingest_router(state).merge(panic_router)
+    }
+
+    #[tokio::test]
+    async fn request_handler_panic_yields_one_500_and_does_not_poison_the_writer_lock()
+    -> Result<(), Box<dyn Error>> {
+        let router = router_with_test_panic_route(test_ingest_state()?);
+
+        let panicked = router
+            .clone()
+            .oneshot(
+                Request::get("/api/v1/__test/panic")
+                    .header("authorization", format!("Bearer {ADMIN_KEY}"))
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(panicked.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let panic_body = json_body(panicked).await?;
+        assert_eq!(panic_body["code"], "internal_error");
+
+        // The writer mutex must not be poisoned: the next authenticated
+        // request against the real store must succeed, not fail closed
+        // (canary-930: "request path must not poison the writer mutex").
+        let next = router
+            .oneshot(
+                Request::get("/metrics")
+                    .header("authorization", format!("Bearer {ADMIN_KEY}"))
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(next.status(), StatusCode::OK);
 
         Ok(())
     }
@@ -2149,7 +2238,7 @@ mod tests {
         assert_eq!(requests[0].headers.delivery_id, "DLV-runtime-ok");
         drop(requests);
 
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let rows = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
             delivery_id: Some("DLV-runtime-ok".to_owned()),
             ..Default::default()
@@ -2180,7 +2269,7 @@ mod tests {
         let execution = runtime.deliver(&webhook_job("DLV-runtime-retry", 2, 4))?;
 
         assert_eq!(execution.retry_after_seconds, Some(5));
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let rows = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
             delivery_id: Some("DLV-runtime-retry".to_owned()),
             ..Default::default()
@@ -2225,7 +2314,7 @@ mod tests {
             0
         );
 
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let rows = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
             delivery_id: Some("DLV-runtime-open".to_owned()),
             ..Default::default()
@@ -2260,7 +2349,7 @@ mod tests {
                 .len(),
             0
         );
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let inactive = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
             delivery_id: Some("DLV-runtime-inactive".to_owned()),
             ..Default::default()
@@ -2516,7 +2605,7 @@ mod tests {
             header_value(&captured.head, "x-delivery-id").as_deref(),
             Some("DLV-runtime-http")
         );
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let rows = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
             delivery_id: Some("DLV-runtime-http".to_owned()),
             ..Default::default()
@@ -2535,7 +2624,7 @@ mod tests {
 
         scheduler.schedule(&webhook_job("DLV-scheduled", 1, 4))?;
 
-        let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+        let mut store = store.lock();
         let jobs = store.claim_due_webhook_delivery_jobs("9999-01-01T00:00:00Z", 10)?;
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].args["delivery_id"], "DLV-scheduled");
@@ -2574,7 +2663,7 @@ mod tests {
                 .len(),
             1
         );
-        let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+        let mut store = store.lock();
         let rows = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
             delivery_id: Some("DLV-drain-ok".to_owned()),
             ..Default::default()
@@ -2603,7 +2692,7 @@ mod tests {
         assert_webhook_drain_report(&report, 1, 0, 1, 0);
         assert_eq!(report.due_count, 1);
         assert_eq!(report.oldest_due_age_ms, Some(0));
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let job = store
             .webhook_delivery_job(job_id)?
             .ok_or("missing webhook delivery job")?;
@@ -2636,7 +2725,7 @@ mod tests {
         assert_webhook_drain_report(&report, 1, 0, 1, 0);
         assert_eq!(report.due_count, 1);
         assert_eq!(report.oldest_due_age_ms, Some(0));
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let job = store
             .webhook_delivery_job(job_id)?
             .ok_or("missing webhook delivery job")?;
@@ -2663,7 +2752,7 @@ mod tests {
         };
 
         assert!(error.contains("invalid drain timestamp"));
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let job = store
             .webhook_delivery_job(job_id)?
             .ok_or("missing webhook delivery job")?;
@@ -2688,7 +2777,7 @@ mod tests {
         assert_webhook_drain_report(&second, 1, 0, 0, 1);
         assert_eq!(second.due_count, 1);
         assert_eq!(second.oldest_due_age_ms, Some(0));
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         assert_eq!(
             store
                 .webhook_delivery_job(job_id)?
@@ -2740,7 +2829,7 @@ mod tests {
                 .len(),
             0
         );
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         assert_eq!(
             store
                 .webhook_delivery_job(job_id)?
@@ -2778,7 +2867,7 @@ mod tests {
 
         assert_eq!(thread_ids.len(), 1);
         assert_ne!(thread_ids[0], test_thread_id);
-        let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+        let mut store = store.lock();
         assert!(
             store
                 .claim_due_webhook_delivery_jobs("9999-01-01T00:00:00Z", 10)?
@@ -2867,7 +2956,7 @@ mod tests {
     fn shared_store_survives_concurrent_runtime_pressure() -> Result<(), Box<dyn Error>> {
         let store = runtime_store(true)?;
         {
-            let mut locked = store.lock().map_err(|_| "store lock poisoned")?;
+            let mut locked = store.lock();
             seed_target(&mut locked, "runtime-pressure")?;
             for index in 0..80 {
                 locked.commit_error_ingest(test_error_ingest(index, "2026-04-01T00:00:00Z"))?;
@@ -2880,9 +2969,7 @@ mod tests {
         let ingest_store = store.clone();
         let ingest = thread::spawn(move || -> Result<(), String> {
             for index in 100..140 {
-                let mut store = ingest_store
-                    .lock()
-                    .map_err(|_| "store lock poisoned".to_owned())?;
+                let mut store = ingest_store.lock();
                 store
                     .commit_error_ingest(test_error_ingest(index, "2026-05-28T20:00:00Z"))
                     .map_err(|error| error.to_string())?;
@@ -2893,9 +2980,7 @@ mod tests {
         let webhook_store = store.clone();
         let webhooks = thread::spawn(move || -> Result<(), String> {
             for _ in 0..4 {
-                let mut store = webhook_store
-                    .lock()
-                    .map_err(|_| "store lock poisoned".to_owned())?;
+                let mut store = webhook_store.lock();
                 let claimed = store
                     .claim_due_webhook_delivery_jobs("2026-05-28T20:00:10Z", 4)
                     .map_err(|error| error.to_string())?;
@@ -2926,9 +3011,7 @@ mod tests {
         let probe_store = store.clone();
         let probes = thread::spawn(move || -> Result<(), String> {
             for _ in 0..40 {
-                let store = probe_store
-                    .lock()
-                    .map_err(|_| "store lock poisoned".to_owned())?;
+                let store = probe_store.lock();
                 let schedules = store
                     .active_target_probe_schedules()
                     .map_err(|error| error.to_string())?;
@@ -2969,7 +3052,7 @@ mod tests {
             .map_err(|_| "retention pressure lane panicked")??;
         assert!(prune_report.batches >= 1);
 
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         assert_eq!(store.active_target_probe_schedules()?.len(), 1);
         assert!(
             store.health_targets()?.iter().any(|target| {
@@ -3108,7 +3191,7 @@ mod tests {
         store.migrate()?;
         seed_api_key(&mut store, "KEY-ingest", INGEST_KEY, "ingest-only", None)?;
         seed_monitor(&mut store, "desktop-active-timer")?;
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let recorder = Arc::new(EnqueueFailureRecorder::default());
         let state = IngestState::new_with_shared_fanout(
             store,
@@ -10359,14 +10442,14 @@ mod tests {
         r#"{"monitor":"desktop-active-timer","status":"alive","observed_at":"2026-05-28T20:00:00Z","ttl_ms":120000}"#
     }
 
-    fn runtime_store(active_webhook: bool) -> Result<Arc<Mutex<Store>>, Box<dyn Error>> {
+    fn runtime_store(active_webhook: bool) -> Result<SharedStore, Box<dyn Error>> {
         runtime_store_with_url(active_webhook, "https://example.test/hook")
     }
 
     fn runtime_store_with_url(
         active_webhook: bool,
         url: &str,
-    ) -> Result<Arc<Mutex<Store>>, Box<dyn Error>> {
+    ) -> Result<SharedStore, Box<dyn Error>> {
         let mut store = Store::open_in_memory()?;
         store.migrate()?;
         store.insert_webhook_subscription(webhook_subscription_insert(
@@ -10378,7 +10461,7 @@ mod tests {
             "2026-05-28T20:00:00Z",
         ))?;
 
-        Ok(Arc::new(Mutex::new(store)))
+        Ok(Arc::new(parking_lot::Mutex::new(store)))
     }
 
     fn webhook_job(delivery_id: &str, attempt: u32, max_attempts: u32) -> WebhookJob {
@@ -10500,11 +10583,11 @@ mod tests {
     }
 
     fn insert_due_webhook_job(
-        store: &Arc<Mutex<Store>>,
+        store: &SharedStore,
         delivery_id: &str,
         max_attempts: u32,
     ) -> Result<i64, Box<dyn Error>> {
-        let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+        let mut store = store.lock();
         Ok(store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
             args: json!({
                 "webhook_id": "WHK-test",
@@ -10539,14 +10622,14 @@ mod tests {
     }
 
     fn wait_for_delivery_status(
-        store: &Arc<Mutex<Store>>,
+        store: &SharedStore,
         delivery_id: &str,
         status: WebhookDeliveryStatus,
     ) -> Result<(), Box<dyn Error>> {
         let deadline = Instant::now() + StdDuration::from_secs(2);
         loop {
             {
-                let store = store.lock().map_err(|_| "store lock poisoned")?;
+                let store = store.lock();
                 let rows = store.webhook_deliveries(canary_store::WebhookDeliveryListOptions {
                     delivery_id: Some(delivery_id.to_owned()),
                     ..Default::default()

--- a/crates/canary-server/src/monitor_overdue.rs
+++ b/crates/canary-server/src/monitor_overdue.rs
@@ -16,7 +16,7 @@ use std::{
 
 use canary_core::health::state_machine::HealthState;
 use canary_http::public::WorkerDueItem;
-use canary_store::{MonitorOverdueCandidate, Store};
+use canary_store::MonitorOverdueCandidate;
 use canary_workers::health::{
     HealthPlanError, MonitorMode, MonitorOverdueSnapshot, ObservationContext, plan_monitor_overdue,
 };
@@ -25,6 +25,7 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use crate::{
     EventFanoutReport, HealthEventFanout, HealthEventSource, WorkerHealthHandle, WorkerName,
     WorkerPressureSnapshot,
+    route_state::SharedStore,
     server_time::{current_rfc3339, current_unix_millis},
 };
 
@@ -46,9 +47,6 @@ pub struct MonitorOverdueOutcome {
 /// Runtime failure that prevented one overdue candidate from completing.
 #[derive(Debug, thiserror::Error)]
 pub enum MonitorOverdueRuntimeError {
-    /// Store lock was poisoned.
-    #[error("store lock poisoned")]
-    StoreLock,
     /// Store returned an error.
     #[error("store error: {0}")]
     Store(#[from] canary_store::StoreError),
@@ -62,13 +60,13 @@ pub enum MonitorOverdueRuntimeError {
 
 /// Runtime boundary for evaluating non-HTTP monitor overdue rows.
 pub struct MonitorOverdueRuntime {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     health_fanout: HealthEventFanout,
 }
 
 impl MonitorOverdueRuntime {
     /// Build a monitor overdue runtime from explicit side-effect boundaries.
-    pub fn new(store: Arc<Mutex<Store>>, health_fanout: HealthEventFanout) -> Self {
+    pub fn new(store: SharedStore, health_fanout: HealthEventFanout) -> Self {
         Self {
             store,
             health_fanout,
@@ -124,13 +122,13 @@ pub struct MonitorOverdueLifecycleReport {
 
 /// Bounded lifecycle adapter for monitor overdue evaluation.
 pub struct MonitorOverdueLifecycle {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     runtime: MonitorOverdueRuntime,
 }
 
 impl MonitorOverdueLifecycle {
     /// Build a lifecycle adapter from the shared store and overdue runtime.
-    pub fn new(store: Arc<Mutex<Store>>, runtime: MonitorOverdueRuntime) -> Self {
+    pub fn new(store: SharedStore, runtime: MonitorOverdueRuntime) -> Self {
         Self { store, runtime }
     }
 
@@ -179,10 +177,7 @@ impl MonitorOverdueLifecycle {
     }
 
     fn load_candidates(&self) -> Result<Vec<MonitorOverdueCandidate>, String> {
-        let store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let store = self.store.lock();
         store
             .monitor_overdue_candidates()
             .map_err(|error| error.to_string())
@@ -297,7 +292,7 @@ impl Drop for MonitorOverdueLifecycleWorker {
 
 /// Evaluate and persist exactly one overdue monitor candidate.
 pub fn run_monitor_overdue_once(
-    store: &Arc<Mutex<Store>>,
+    store: &SharedStore,
     health_fanout: &HealthEventFanout,
     candidate: MonitorOverdueCandidate,
     now: String,
@@ -319,9 +314,7 @@ pub fn run_monitor_overdue_once(
     let response_monitor_id = plan.commit.monitor_id.clone();
     let response_state = plan.commit.state.clone();
     let commit = {
-        let mut store = store
-            .lock()
-            .map_err(|_| MonitorOverdueRuntimeError::StoreLock)?;
+        let mut store = store.lock();
         store.commit_monitor_overdue(plan.commit)?
     };
 
@@ -522,6 +515,7 @@ mod tests {
     use crate::EventSink;
 
     use super::*;
+    use canary_store::Store;
 
     #[derive(Default)]
     struct RecordingSink {
@@ -579,7 +573,7 @@ mod tests {
             transition: None,
         })?;
 
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let sink = Arc::new(RecordingSink::default());
         let fanout = HealthEventFanout::new_without_failure_sink(sink.clone());
         let lifecycle =
@@ -667,7 +661,7 @@ mod tests {
             transition: None,
         })?;
 
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let recorder = Arc::new(crate::EnqueueFailureRecorder::default());
         let lifecycle = MonitorOverdueLifecycle::new(
             store.clone(),
@@ -701,7 +695,7 @@ mod tests {
         seed_overdue_monitor(&mut store, "MON-overdue-a")?;
         seed_overdue_monitor(&mut store, "MON-overdue-b")?;
 
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let sink = Arc::new(RecordingSink::default());
         let fanout = HealthEventFanout::new_without_failure_sink(sink);
         let lifecycle =
@@ -731,7 +725,7 @@ mod tests {
 
     #[test]
     fn worker_records_lifecycle_failures() -> Result<(), Box<dyn Error>> {
-        let store = Arc::new(Mutex::new(Store::open_in_memory()?));
+        let store = Arc::new(parking_lot::Mutex::new(Store::open_in_memory()?));
         let sink = Arc::new(RecordingSink::default());
         let fanout = HealthEventFanout::new_without_failure_sink(sink);
         let worker = MonitorOverdueLifecycleWorker::spawn(
@@ -763,7 +757,7 @@ mod tests {
     -> Result<(), Box<dyn Error>> {
         let mut store = Store::open_in_memory()?;
         store.migrate()?;
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let sink = Arc::new(RecordingSink::default());
         let fanout = HealthEventFanout::new_without_failure_sink(sink.clone());
 

--- a/crates/canary-server/src/read_source.rs
+++ b/crates/canary-server/src/read_source.rs
@@ -15,7 +15,7 @@
 //! read, so they always run on the writer. Callers needing them still use
 //! `IngestState::lock_store`.
 
-use std::sync::MutexGuard;
+use parking_lot::MutexGuard;
 
 use canary_core::query::{ErrorDetail, ErrorsByClass, TimelineResponse};
 use canary_store::{

--- a/crates/canary-server/src/retention_prune.rs
+++ b/crates/canary-server/src/retention_prune.rs
@@ -14,12 +14,13 @@ use std::{
     time::Duration as StdDuration,
 };
 
-use canary_store::{RetentionPruneBatch, RetentionPruneTable, Store};
+use canary_store::{RetentionPruneBatch, RetentionPruneTable};
 use canary_workers::retention::{RetentionPolicy, plan_retention_prune};
 use time::OffsetDateTime;
 
 use crate::{
     WorkerHealthHandle, WorkerName, WorkerPressureSnapshot,
+    route_state::SharedStore,
     server_time::{current_unix_millis, current_utc, format_rfc3339},
 };
 
@@ -55,13 +56,13 @@ pub struct RetentionPruneLifecycleReport {
 
 /// Bounded lifecycle adapter for retention pruning.
 pub struct RetentionPruneLifecycle {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     policy: RetentionPolicy,
 }
 
 impl RetentionPruneLifecycle {
     /// Build a lifecycle adapter from the shared store and retention policy.
-    pub fn new(store: Arc<Mutex<Store>>, policy: RetentionPolicy) -> Self {
+    pub fn new(store: SharedStore, policy: RetentionPolicy) -> Self {
         Self { store, policy }
     }
 
@@ -124,10 +125,7 @@ impl RetentionPruneLifecycle {
     ) -> Result<bool, String> {
         loop {
             let batch = {
-                let mut store = self
-                    .store
-                    .lock()
-                    .map_err(|_| "store lock poisoned".to_owned())?;
+                let mut store = self.store.lock();
                 store
                     .prune_retention_batch(RetentionPruneBatch {
                         table,
@@ -366,6 +364,7 @@ mod tests {
     use time::format_description::well_known::Rfc3339;
 
     use super::*;
+    use canary_store::Store;
 
     #[test]
     fn lifecycle_prunes_all_tables_and_reports_batches() -> Result<(), Box<dyn Error>> {
@@ -376,7 +375,7 @@ mod tests {
         }
 
         let lifecycle = RetentionPruneLifecycle::new(
-            Arc::new(Mutex::new(store)),
+            Arc::new(parking_lot::Mutex::new(store)),
             RetentionPolicy {
                 error_retention_days: 30,
                 check_retention_days: 7,
@@ -407,8 +406,10 @@ mod tests {
             store.commit_error_ingest(error_ingest(index, "2026-04-01T00:00:00Z"))?;
         }
 
-        let lifecycle =
-            RetentionPruneLifecycle::new(Arc::new(Mutex::new(store)), RetentionPolicy::default());
+        let lifecycle = RetentionPruneLifecycle::new(
+            Arc::new(parking_lot::Mutex::new(store)),
+            RetentionPolicy::default(),
+        );
         let checks = AtomicU64::new(0);
         let report = lifecycle.run_due_until(
             OffsetDateTime::parse("2026-05-29T12:00:00Z", &Rfc3339)?,
@@ -435,7 +436,7 @@ mod tests {
         store.migrate()?;
         let worker = RetentionPruneLifecycleWorker::spawn(
             RetentionPruneLifecycle::new(
-                Arc::new(Mutex::new(store)),
+                Arc::new(parking_lot::Mutex::new(store)),
                 RetentionPolicy {
                     error_retention_days: -1,
                     check_retention_days: 7,

--- a/crates/canary-server/src/route_state.rs
+++ b/crates/canary-server/src/route_state.rs
@@ -5,11 +5,23 @@
 //! post-commit effects, health fanout, target control, webhook transport,
 //! rate-limit state, auth-failure identity, and private target policy.
 
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 use canary_ingest::{IngestConfig, IngestEffect};
 use canary_store::{ReadPool, Store};
 use canary_workers::webhooks::{TransportResult, WebhookRequest};
+use parking_lot::MutexGuard;
+
+/// Shared single-writer store handle.
+///
+/// Backed by `parking_lot::Mutex`, which never poisons. A panic in a request
+/// handler while holding this guard still unwinds and drops the guard
+/// normally, so the next lock acquisition succeeds instead of every
+/// subsequent authenticated request failing closed (canary-930: "request
+/// path must not poison the writer mutex"). `RateLimiter` and other
+/// process-local state below keep `std::sync::Mutex`; only the writer store
+/// carries this footgun.
+pub(crate) type SharedStore = Arc<parking_lot::Mutex<Store>>;
 
 use crate::auth_cache::AuthCache;
 use crate::{
@@ -42,7 +54,7 @@ impl EventSink for WebhookEnqueueEffectSink {
 /// Shared state needed by authenticated ingest routes.
 #[derive(Clone)]
 pub struct IngestState {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     config: IngestConfig,
     effect_sink: Arc<dyn IngestEffectSink>,
     health_fanout: HealthEventFanout,
@@ -88,7 +100,7 @@ impl IngestState {
         config: IngestConfig,
         scheduler: Arc<dyn WebhookScheduler>,
     ) -> Self {
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let webhook_sink = Arc::new(WebhookEnqueueEffectSink::new(
             store.clone(),
             scheduler,
@@ -115,12 +127,16 @@ impl IngestState {
         config: IngestConfig,
         effect_sink: Arc<dyn IngestEffectSink>,
     ) -> Self {
-        Self::new_with_shared_effect_sink(Arc::new(Mutex::new(store)), config, effect_sink)
+        Self::new_with_shared_effect_sink(
+            Arc::new(parking_lot::Mutex::new(store)),
+            config,
+            effect_sink,
+        )
     }
 
     /// Build ingest state from a shared single-writer store and explicit effect sink.
     pub fn new_with_shared_effect_sink(
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         config: IngestConfig,
         effect_sink: Arc<dyn IngestEffectSink>,
     ) -> Self {
@@ -141,7 +157,7 @@ impl IngestState {
 
     /// Build ingest state from shared store plus explicit ingest and event sinks.
     pub fn new_with_shared_sinks(
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         config: IngestConfig,
         effect_sink: Arc<dyn IngestEffectSink>,
         event_sink: Arc<dyn EventSink>,
@@ -163,7 +179,7 @@ impl IngestState {
 
     /// Build ingest state from shared store plus explicit ingest and health fanout sinks.
     pub fn new_with_shared_fanout(
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         config: IngestConfig,
         effect_sink: Arc<dyn IngestEffectSink>,
         health_fanout: HealthEventFanout,
@@ -215,14 +231,18 @@ impl IngestState {
         self
     }
 
+    /// Acquire the writer store lock.
+    ///
+    /// `parking_lot::Mutex` never poisons, so this is now infallible; the
+    /// `Result` return type is kept so the ~80 call sites across route
+    /// modules do not need to change. A panicking handler still unwinds
+    /// through this guard cleanly (canary-930).
     pub(crate) fn lock_store(&self) -> Result<MutexGuard<'_, Store>, String> {
-        self.store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())
+        Ok(self.store.lock())
     }
 
     #[cfg(test)]
-    pub(crate) fn shared_store(&self) -> Arc<Mutex<Store>> {
+    pub(crate) fn shared_store(&self) -> SharedStore {
         self.store.clone()
     }
 

--- a/crates/canary-server/src/runtime.rs
+++ b/crates/canary-server/src/runtime.rs
@@ -10,7 +10,10 @@ use std::{
     fmt,
     future::Future,
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
     thread,
     time::Duration as StdDuration,
 };
@@ -33,8 +36,22 @@ use crate::{
     TlsExpiryScanLifecycleWorker, WebhookDeliveryDrain, WebhookDeliveryDrainWorker,
     WebhookDeliveryRuntime, WebhookEnqueueEffectSink, WebhookTransport, WorkerHealthRegistry,
     dashboard_router, ingest_router, public_router,
+    route_state::SharedStore,
     server_time::{current_rfc3339, current_unix_millis},
 };
+
+/// Bounded wait for the writer lock before `/readyz` falls back to the last
+/// known-good verdict instead of queueing. Well under Fly's 5s health-check
+/// timeout (`fly.toml`), so a busy writer can never itself starve this probe
+/// into a restart-spiral timeout (canary-930).
+const READINESS_LOCK_WAIT: StdDuration = StdDuration::from_millis(200);
+
+/// Consecutive lock-wait timeouts tolerated before a queued writer is
+/// treated as wedged rather than merely busy. Readiness stays live -- a
+/// permanently stuck lock must still fail `/readyz` -- but one or two
+/// timeouts under a write burst must not flip a healthy process to
+/// `not_ready`.
+const MAX_CONSECUTIVE_LOCK_TIMEOUTS: u32 = 3;
 
 const DEFAULT_WEBHOOK_DRAIN_INTERVAL: StdDuration = StdDuration::from_secs(5);
 const DEFAULT_WEBHOOK_DRAIN_MAX_JOBS: u32 = 25;
@@ -153,7 +170,7 @@ impl CanaryServer {
         }
         let read_pool =
             Arc::new(ReadPool::open(&config.database_path).map_err(ServerBootError::Store)?);
-        let store = Arc::new(Mutex::new(store));
+        let store: SharedStore = Arc::new(parking_lot::Mutex::new(store));
         let worker_health = WorkerHealthRegistry::new();
 
         let scheduler = Arc::new(StoreWebhookScheduler::new(store.clone()));
@@ -239,10 +256,12 @@ impl CanaryServer {
             .with_auth_fail_identity(config.auth_fail_identity)
             .with_allow_private_targets(allow_private_targets)
             .with_read_pool(read_pool);
-        let readiness = PublicReadiness::from_probe(Arc::new(StoreReadinessProbe {
-            store: store.clone(),
-            workers: worker_health.clone(),
-        }));
+        let readiness = PublicReadiness::from_probe(Arc::new(StoreReadinessProbe::new(
+            store.clone(),
+            worker_health.clone(),
+            READINESS_LOCK_WAIT,
+            MAX_CONSECUTIVE_LOCK_TIMEOUTS,
+        )));
         let router = public_router(readiness)
             .merge(dashboard_router())
             .merge(ingest_router(ingest_state));
@@ -388,24 +407,112 @@ impl fmt::Display for ServerRunError {
 
 impl Error for ServerRunError {}
 
+/// Readiness probe for the single-writer store.
+///
+/// `/readyz` must prove the *writable* store is live on every request
+/// (footgun: "readiness is live" -- no static or cached verdict), but it
+/// must never let a busy writer queue it past Fly's health-check timeout
+/// and trigger a restart spiral (canary-930, live-reproduced: a 12-concurrent
+/// `/report` wave pushed one `/readyz` call to 2.822s while it queued behind
+/// writer contention).
+///
+/// Semantics: acquire the writer lock with a bounded wait
+/// (`lock_wait`). On acquisition, run the store's tiny liveness query and
+/// report its real outcome -- this is the only path that reports `Error`
+/// from an actual store failure, and it always resets the timeout streak.
+/// On a lock-wait timeout, the writer is busy, not necessarily broken;
+/// report the last known-good verdict rather than flip a healthy process to
+/// `not_ready` over one queued check. A writer that stays wedged across
+/// `max_consecutive_lock_timeouts` consecutive probes is treated as failed
+/// even though no liveness query ever ran -- readiness must still catch a
+/// permanently stuck lock, not just a temporarily busy one.
 struct StoreReadinessProbe {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     workers: WorkerHealthRegistry,
+    lock_wait: StdDuration,
+    max_consecutive_lock_timeouts: u32,
+    consecutive_lock_timeouts: AtomicU32,
+    last_known_database_ok: AtomicBool,
+}
+
+impl StoreReadinessProbe {
+    fn new(
+        store: SharedStore,
+        workers: WorkerHealthRegistry,
+        lock_wait: StdDuration,
+        max_consecutive_lock_timeouts: u32,
+    ) -> Self {
+        Self {
+            store,
+            workers,
+            lock_wait,
+            max_consecutive_lock_timeouts,
+            consecutive_lock_timeouts: AtomicU32::new(0),
+            // Optimistic until the first probe outcome, matching a freshly
+            // booted process that has not yet observed a database failure.
+            last_known_database_ok: AtomicBool::new(true),
+        }
+    }
+
+    fn database_status(&self) -> DependencyStatus {
+        let attempt = match self.store.try_lock_for(self.lock_wait) {
+            Some(store) => {
+                let ok = store.readiness_check().is_ok();
+                drop(store);
+                LockAttempt::Checked(ok)
+            }
+            None => LockAttempt::TimedOut,
+        };
+        self.classify(attempt)
+    }
+
+    /// Pure decision policy over one lock-attempt outcome, isolated from the
+    /// real mutex and store so the threshold/last-known-good behavior is
+    /// directly unit-testable (see `mod tests`) without needing to fabricate
+    /// a genuinely broken SQLite connection.
+    fn classify(&self, attempt: LockAttempt) -> DependencyStatus {
+        match attempt {
+            LockAttempt::Checked(ok) => {
+                self.consecutive_lock_timeouts.store(0, Ordering::Release);
+                self.last_known_database_ok.store(ok, Ordering::Release);
+                dependency_status(ok)
+            }
+            LockAttempt::TimedOut => {
+                let timeouts = self
+                    .consecutive_lock_timeouts
+                    .fetch_add(1, Ordering::AcqRel)
+                    + 1;
+                if timeouts >= self.max_consecutive_lock_timeouts {
+                    dependency_status(false)
+                } else {
+                    dependency_status(self.last_known_database_ok.load(Ordering::Acquire))
+                }
+            }
+        }
+    }
+}
+
+/// Outcome of one writer-lock acquisition attempt for readiness.
+enum LockAttempt {
+    /// The lock was acquired within budget; the store liveness check ran and
+    /// produced this result.
+    Checked(bool),
+    /// The lock could not be acquired within `lock_wait`.
+    TimedOut,
+}
+
+fn dependency_status(ok: bool) -> DependencyStatus {
+    if ok {
+        DependencyStatus::Ok
+    } else {
+        DependencyStatus::Error
+    }
 }
 
 impl PublicReadinessProbe for StoreReadinessProbe {
     fn snapshot(&self) -> PublicReadinessSnapshot {
-        let database = match self
-            .store
-            .lock()
-            .map_err(|_| ())
-            .and_then(|store| store.readiness_check().map_err(|_| ()))
-        {
-            Ok(()) => DependencyStatus::Ok,
-            Err(()) => DependencyStatus::Error,
-        };
         PublicReadinessSnapshot::with_workers(
-            database,
+            self.database_status(),
             DependencyStatus::Ok,
             self.workers.snapshot_at(current_unix_millis()),
         )
@@ -424,13 +531,13 @@ fn build_default_webhook_transport() -> Result<Arc<dyn WebhookTransport>, String
 
 /// Runtime sink for ingest post-commit effects.
 pub struct RuntimeIngestEffectSink {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     webhook_sink: Arc<WebhookEnqueueEffectSink>,
 }
 
 impl RuntimeIngestEffectSink {
     /// Build the runtime effect sink from explicit persistence and webhook boundaries.
-    pub fn new(store: Arc<Mutex<Store>>, webhook_sink: Arc<WebhookEnqueueEffectSink>) -> Self {
+    pub fn new(store: SharedStore, webhook_sink: Arc<WebhookEnqueueEffectSink>) -> Self {
         Self {
             store,
             webhook_sink,
@@ -482,10 +589,7 @@ impl RuntimeIngestEffectSink {
         service: &str,
     ) -> Result<(), String> {
         let event = {
-            let mut store = self
-                .store
-                .lock()
-                .map_err(|_| "store lock poisoned".to_owned())?;
+            let mut store = self.store.lock();
             store
                 .correlate_incident(IncidentCorrelation {
                     tenant_id: tenant_id.to_owned(),
@@ -506,5 +610,182 @@ impl RuntimeIngestEffectSink {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::*;
+
+    fn probe_with_policy(
+        lock_wait: StdDuration,
+        max_consecutive_lock_timeouts: u32,
+    ) -> StoreReadinessProbe {
+        let store: SharedStore = Arc::new(parking_lot::Mutex::new(
+            Store::open_in_memory().expect("open in-memory store"),
+        ));
+        StoreReadinessProbe::new(
+            store,
+            WorkerHealthRegistry::new(),
+            lock_wait,
+            max_consecutive_lock_timeouts,
+        )
+    }
+
+    // The `classify` tests below exercise the bounded-wait/consecutive-timeout
+    // policy directly against synthetic `LockAttempt` outcomes. A genuinely
+    // broken SQLite connection cannot be fabricated through Store's public
+    // API without unsafe code (this repo's WAL-file-handle footgun means
+    // even deleting the backing file leaves a live connection); `Checked(false)`
+    // is the realistic proxy for "the store answered and it was broken."
+
+    #[test]
+    fn checked_success_reports_ok_and_resets_timeout_streak() {
+        let probe = probe_with_policy(StdDuration::from_millis(50), 3);
+        probe.consecutive_lock_timeouts.store(2, Ordering::Release);
+
+        let status = probe.classify(LockAttempt::Checked(true));
+
+        assert_eq!(status, DependencyStatus::Ok);
+        assert_eq!(probe.consecutive_lock_timeouts.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn checked_failure_reports_error_immediately_regardless_of_timeout_streak() {
+        let probe = probe_with_policy(StdDuration::from_millis(50), 3);
+
+        let status = probe.classify(LockAttempt::Checked(false));
+
+        assert_eq!(
+            status,
+            DependencyStatus::Error,
+            "a genuine store failure must not wait for the timeout streak"
+        );
+        assert_eq!(probe.consecutive_lock_timeouts.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn timeouts_return_last_known_good_until_the_threshold_then_fail() {
+        let probe = probe_with_policy(StdDuration::from_millis(50), 3);
+
+        // Last known-good starts true (optimistic boot default).
+        assert_eq!(probe.classify(LockAttempt::TimedOut), DependencyStatus::Ok);
+        assert_eq!(probe.classify(LockAttempt::TimedOut), DependencyStatus::Ok);
+        // Third consecutive timeout crosses the threshold: a queued writer
+        // graduates from "busy" to "wedged".
+        assert_eq!(
+            probe.classify(LockAttempt::TimedOut),
+            DependencyStatus::Error
+        );
+    }
+
+    #[test]
+    fn timeouts_return_last_known_bad_when_the_prior_check_failed() {
+        let probe = probe_with_policy(StdDuration::from_millis(50), 3);
+        assert_eq!(
+            probe.classify(LockAttempt::Checked(false)),
+            DependencyStatus::Error
+        );
+
+        assert_eq!(
+            probe.classify(LockAttempt::TimedOut),
+            DependencyStatus::Error
+        );
+    }
+
+    #[test]
+    fn a_checked_outcome_after_timeouts_recovers_readiness() {
+        let probe = probe_with_policy(StdDuration::from_millis(50), 3);
+        probe.classify(LockAttempt::TimedOut);
+        probe.classify(LockAttempt::TimedOut);
+
+        let status = probe.classify(LockAttempt::Checked(true));
+
+        assert_eq!(status, DependencyStatus::Ok);
+        assert_eq!(probe.consecutive_lock_timeouts.load(Ordering::Acquire), 0);
+    }
+
+    /// Live lock contention through the real mutex and store: proves
+    /// `try_lock_for` wiring stays within `lock_wait` and reports the
+    /// last known-good verdict while a writer briefly holds the lock,
+    /// satisfying the "readyz p99 stays bounded under write contention"
+    /// oracle at the unit level.
+    #[test]
+    fn database_status_stays_within_budget_and_ok_while_writer_is_transiently_busy() {
+        let store: SharedStore = Arc::new(parking_lot::Mutex::new(
+            Store::open_in_memory().expect("open in-memory store"),
+        ));
+        let probe = StoreReadinessProbe::new(
+            store.clone(),
+            WorkerHealthRegistry::new(),
+            StdDuration::from_millis(50),
+            3,
+        );
+
+        let (acquired_tx, acquired_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let held_store = store.clone();
+        let holder = thread::spawn(move || {
+            let _guard = held_store.lock();
+            acquired_tx.send(()).ok();
+            let _ = release_rx.recv();
+        });
+        acquired_rx.recv().expect("holder thread acquired the lock");
+
+        let started = std::time::Instant::now();
+        let status = probe.database_status();
+        let elapsed = started.elapsed();
+
+        release_tx.send(()).expect("signal release");
+        holder.join().expect("holder thread panicked");
+
+        assert_eq!(
+            status,
+            DependencyStatus::Ok,
+            "a transiently busy writer must report last known-good, not fail readiness"
+        );
+        assert!(
+            elapsed < StdDuration::from_millis(200),
+            "probe must stay bounded by lock_wait, took {elapsed:?}"
+        );
+    }
+
+    /// A writer held across `max_consecutive_lock_timeouts` consecutive
+    /// probes must eventually fail readiness -- a permanently wedged lock
+    /// cannot hide behind "transient contention" forever (footgun:
+    /// "readiness is live").
+    #[test]
+    fn database_status_fails_once_writer_stays_wedged_past_the_threshold() {
+        let store: SharedStore = Arc::new(parking_lot::Mutex::new(
+            Store::open_in_memory().expect("open in-memory store"),
+        ));
+        let probe = StoreReadinessProbe::new(
+            store.clone(),
+            WorkerHealthRegistry::new(),
+            StdDuration::from_millis(20),
+            2,
+        );
+
+        let (acquired_tx, acquired_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let held_store = store.clone();
+        let holder = thread::spawn(move || {
+            let _guard = held_store.lock();
+            acquired_tx.send(()).ok();
+            let _ = release_rx.recv();
+        });
+        acquired_rx.recv().expect("holder thread acquired the lock");
+
+        assert_eq!(probe.database_status(), DependencyStatus::Ok);
+        assert_eq!(probe.database_status(), DependencyStatus::Error);
+
+        release_tx.send(()).expect("signal release");
+        holder.join().expect("holder thread panicked");
+
+        // Once released, the very next probe recovers.
+        assert_eq!(probe.database_status(), DependencyStatus::Ok);
     }
 }

--- a/crates/canary-server/src/target_probes.rs
+++ b/crates/canary-server/src/target_probes.rs
@@ -19,8 +19,9 @@ use std::{
     time::{Duration as StdDuration, Instant},
 };
 
+use crate::route_state::SharedStore;
 use canary_core::health::state_machine::{Counters, HealthState, Thresholds};
-use canary_store::{ActiveTargetProbeSchedule, Store, TargetProbeSnapshot};
+use canary_store::{ActiveTargetProbeSchedule, TargetProbeSnapshot};
 use canary_workers::health::{
     ObservationContext, TargetProbeObservation, TargetSnapshot, plan_target_probe,
 };
@@ -142,7 +143,7 @@ pub struct ProbeRequest {
 
 /// Runtime boundary for executing target probes.
 pub struct TargetProbeRuntime {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     health_fanout: HealthEventFanout,
     transport: Arc<dyn ProbeTransport>,
     options: TargetProbeOptions,
@@ -152,7 +153,7 @@ pub struct TargetProbeRuntime {
 impl TargetProbeRuntime {
     /// Build a target probe runtime from explicit side-effect boundaries.
     pub fn new(
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         health_fanout: HealthEventFanout,
         transport: Arc<dyn ProbeTransport>,
         options: TargetProbeOptions,
@@ -281,7 +282,7 @@ pub enum TargetProbeLifecycleCommand {
 
 /// Bounded lifecycle adapter for active HTTP target probes.
 pub struct TargetProbeLifecycle {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     runtime: Arc<TargetProbeRuntime>,
     schedules: BTreeMap<String, ScheduledTarget>,
     in_flight: BTreeSet<String>,
@@ -298,7 +299,7 @@ type TargetProbeCompletion = (
 
 impl TargetProbeLifecycle {
     /// Build a lifecycle adapter from the shared store and probe runtime.
-    pub fn new(store: Arc<Mutex<Store>>, runtime: TargetProbeRuntime) -> Self {
+    pub fn new(store: SharedStore, runtime: TargetProbeRuntime) -> Self {
         let (completion_sender, completion_receiver) = mpsc::channel();
         Self {
             store,
@@ -437,10 +438,7 @@ impl TargetProbeLifecycle {
     }
 
     fn load_active_schedules(&self) -> Result<Vec<ActiveTargetProbeSchedule>, String> {
-        let store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let store = self.store.lock();
         store
             .active_target_probe_schedules()
             .map_err(|error| error.to_string())
@@ -718,7 +716,7 @@ pub fn validate_target_probe_interval_ms(interval_ms: i64) -> Result<(), String>
 
 /// Execute and persist exactly one target probe.
 pub fn run_target_probe_once(
-    store: &Arc<Mutex<Store>>,
+    store: &SharedStore,
     health_fanout: &HealthEventFanout,
     transport: &dyn ProbeTransport,
     target_id: &str,
@@ -741,7 +739,7 @@ struct TargetProbeRun {
 }
 
 fn run_target_probe_once_with_history(
-    store: &Arc<Mutex<Store>>,
+    store: &SharedStore,
     health_fanout: &HealthEventFanout,
     transport: &dyn ProbeTransport,
     target_id: &str,
@@ -767,9 +765,7 @@ fn run_target_probe_once_with_history(
     let response_state = plan.commit.state.clone();
     let response_tls_expires_at = plan.commit.check.tls_expires_at.clone();
     let commit = {
-        let mut store = store
-            .lock()
-            .map_err(|_| TargetProbeRuntimeError::StoreLock)?;
+        let mut store = store.lock();
         store.commit_target_probe(plan.commit)?
     };
     let mut event_fanout = EventFanoutReport::default();
@@ -1032,12 +1028,10 @@ fn certificate_not_after_rfc3339(certificate: &CertificateDer<'_>) -> Option<Str
 }
 
 fn load_target_snapshot(
-    store: &Arc<Mutex<Store>>,
+    store: &SharedStore,
     target_id: &str,
 ) -> Result<TargetProbeSnapshot, TargetProbeRuntimeError> {
-    let mut store = store
-        .lock()
-        .map_err(|_| TargetProbeRuntimeError::StoreLock)?;
+    let mut store = store.lock();
     store
         .target_probe_snapshot_by_id(target_id)?
         .ok_or(TargetProbeRuntimeError::TargetNotFound)
@@ -1379,6 +1373,7 @@ mod tests {
     use crate::EventSink;
 
     use super::*;
+    use canary_store::Store;
 
     type TlsTestServer = std::thread::JoinHandle<Result<(), String>>;
 
@@ -1587,12 +1582,12 @@ mod tests {
     }
 
     struct DeactivatingTransport {
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         calls: AtomicUsize,
     }
 
     impl DeactivatingTransport {
-        fn new(store: Arc<Mutex<Store>>) -> Self {
+        fn new(store: SharedStore) -> Self {
             Self {
                 store,
                 calls: AtomicUsize::new(0),
@@ -1603,10 +1598,7 @@ mod tests {
     impl ProbeTransport for DeactivatingTransport {
         fn probe(&self, _request: ProbeRequest) -> Result<ProbeHttpResponse, ProbeTransportError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            let mut store = self
-                .store
-                .lock()
-                .map_err(|_| ProbeTransportError::Connection("store lock poisoned".to_owned()))?;
+            let mut store = self.store.lock();
             store
                 .update_target_active("TGT-api", false)
                 .map_err(|error| ProbeTransportError::Connection(error.to_string()))?;
@@ -1720,7 +1712,7 @@ mod tests {
         assert_eq!(transport.calls.load(Ordering::SeqCst), 0);
         assert_eq!(outcome.result, "connection_error");
         assert_eq!(outcome.state, "degraded");
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         assert_eq!(store.error_count()?, 0);
         assert_eq!(
             store.webhook_deliveries(Default::default())?.len(),
@@ -1781,10 +1773,7 @@ mod tests {
         assert_eq!(transport.calls.load(Ordering::SeqCst), 0);
         assert_eq!(outcome.result, "connection_error");
         assert_eq!(outcome.state, "degraded");
-        let checks = store
-            .lock()
-            .map_err(|_| "store lock poisoned")?
-            .target_checks("TGT-api", "24h")?;
+        let checks = store.lock().target_checks("TGT-api", "24h")?;
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].result, "connection_error");
         assert_eq!(
@@ -1873,7 +1862,7 @@ mod tests {
     fn successful_probe_commits_state_and_enqueues_transition() -> Result<(), Box<dyn Error>> {
         let store = seeded_store("http://127.0.0.1/health", "unknown")?;
         {
-            let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+            let mut store = store.lock();
             store.insert_webhook_subscription(WebhookSubscriptionInsert {
                 id: "WHK-health".to_owned(),
                 tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
@@ -1951,7 +1940,7 @@ mod tests {
     fn lifecycle_loads_active_targets_and_runs_due_probes() -> Result<(), Box<dyn Error>> {
         let store = seeded_store("http://127.0.0.1/health", "unknown")?;
         {
-            let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+            let mut store = store.lock();
             store.insert_target(TargetInsert {
                 id: "TGT-inactive".to_owned(),
                 url: "http://127.0.0.1/inactive".to_owned(),
@@ -2015,7 +2004,7 @@ mod tests {
     fn lifecycle_isolates_fast_due_probe_from_slow_due_probe() -> Result<(), Box<dyn Error>> {
         let store = seeded_store("http://127.0.0.1/slow", "unknown")?;
         {
-            let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+            let mut store = store.lock();
             store.insert_target(TargetInsert {
                 id: "TGT-worker".to_owned(),
                 url: "http://127.0.0.1/fast".to_owned(),
@@ -2062,7 +2051,7 @@ mod tests {
         let started = Instant::now();
         loop {
             let worker = {
-                let store = store.lock().map_err(|_| "store lock poisoned")?;
+                let store = store.lock();
                 store
                     .health_targets()?
                     .into_iter()
@@ -2107,7 +2096,7 @@ mod tests {
     fn lifecycle_caps_concurrent_due_probe_fanout() -> Result<(), Box<dyn Error>> {
         let store = seeded_store("http://127.0.0.1/target-api", "unknown")?;
         {
-            let mut store = store.lock().map_err(|_| "store lock poisoned")?;
+            let mut store = store.lock();
             for index in 0..9 {
                 store.insert_target(TargetInsert {
                     id: format!("TGT-concurrent-{index:02}"),
@@ -2273,7 +2262,7 @@ mod tests {
         let started = Instant::now();
         loop {
             let target = {
-                let store = store_for_assert.lock().map_err(|_| "store lock poisoned")?;
+                let store = store_for_assert.lock();
                 store
                     .health_targets()?
                     .into_iter()
@@ -2363,7 +2352,7 @@ mod tests {
         assert_eq!(lifecycle.run_due(1_000)?.launched, 1);
         slow_started_rx.recv_timeout(StdDuration::from_secs(1))?;
         {
-            let mut store = lifecycle.store.lock().map_err(|_| "store lock poisoned")?;
+            let mut store = lifecycle.store.lock();
             store.update_target_active("TGT-api", false)?;
         }
         lifecycle.apply_control_command(
@@ -2554,7 +2543,7 @@ mod tests {
 
     #[test]
     fn worker_records_lifecycle_failures() -> Result<(), Box<dyn Error>> {
-        let store = Arc::new(Mutex::new(Store::open_in_memory()?));
+        let store = Arc::new(parking_lot::Mutex::new(Store::open_in_memory()?));
         let sink = Arc::new(RecordingSink::default());
         let runtime = TargetProbeRuntime::new(
             store.clone(),
@@ -2679,7 +2668,7 @@ mod tests {
         }
     }
 
-    fn seeded_store(url: &str, state: &str) -> Result<Arc<Mutex<Store>>, Box<dyn Error>> {
+    fn seeded_store(url: &str, state: &str) -> Result<SharedStore, Box<dyn Error>> {
         seeded_store_with_headers(url, state, None)
     }
 
@@ -2687,7 +2676,7 @@ mod tests {
         url: &str,
         state: &str,
         headers: Option<String>,
-    ) -> Result<Arc<Mutex<Store>>, Box<dyn Error>> {
+    ) -> Result<SharedStore, Box<dyn Error>> {
         seeded_store_with_target_options(url, state, "GET".to_owned(), headers)
     }
 
@@ -2695,7 +2684,7 @@ mod tests {
         url: &str,
         state: &str,
         method: String,
-    ) -> Result<Arc<Mutex<Store>>, Box<dyn Error>> {
+    ) -> Result<SharedStore, Box<dyn Error>> {
         seeded_store_with_target_options(url, state, method, None)
     }
 
@@ -2704,7 +2693,7 @@ mod tests {
         state: &str,
         method: String,
         headers: Option<String>,
-    ) -> Result<Arc<Mutex<Store>>, Box<dyn Error>> {
+    ) -> Result<SharedStore, Box<dyn Error>> {
         let mut store = Store::open_in_memory()?;
         store.migrate()?;
         store.insert_target(TargetInsert {
@@ -2741,7 +2730,7 @@ mod tests {
             now: "2026-05-28T20:00:00Z".to_owned(),
             transition: None,
         })?;
-        Ok(Arc::new(Mutex::new(store)))
+        Ok(Arc::new(parking_lot::Mutex::new(store)))
     }
 
     fn tls_test_certificate()

--- a/crates/canary-server/src/tls_scan.rs
+++ b/crates/canary-server/src/tls_scan.rs
@@ -15,12 +15,13 @@ use std::{
 };
 
 use canary_core::ids::EventId;
-use canary_store::{Store, TlsExpiryEventInsert, TlsExpiryScanCandidate};
+use canary_store::{TlsExpiryEventInsert, TlsExpiryScanCandidate};
 use canary_workers::tls_scan::{TlsExpiryScanInput, plan_tls_expiry_event};
 use time::OffsetDateTime;
 
 use crate::{
     EventSink, WorkerHealthHandle, WorkerName, WorkerPressureSnapshot,
+    route_state::SharedStore,
     server_time::{current_unix_millis, current_utc, format_rfc3339},
 };
 
@@ -58,13 +59,13 @@ pub struct TlsExpiryScanLifecycleReport {
 
 /// Bounded lifecycle adapter for TLS-expiry warning evaluation.
 pub struct TlsExpiryScanLifecycle {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     event_sink: Arc<dyn EventSink>,
 }
 
 impl TlsExpiryScanLifecycle {
     /// Build a lifecycle adapter from explicit persistence and fanout boundaries.
-    pub fn new(store: Arc<Mutex<Store>>, event_sink: Arc<dyn EventSink>) -> Self {
+    pub fn new(store: SharedStore, event_sink: Arc<dyn EventSink>) -> Self {
         Self { store, event_sink }
     }
 
@@ -119,10 +120,7 @@ impl TlsExpiryScanLifecycle {
     }
 
     fn load_candidates(&self) -> Result<Vec<TlsExpiryScanCandidate>, String> {
-        let store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let store = self.store.lock();
         store
             .tls_expiry_scan_candidates()
             .map_err(|error| error.to_string())
@@ -238,9 +236,6 @@ impl Drop for TlsExpiryScanLifecycleWorker {
 /// Runtime failure for one TLS-expiry scan candidate.
 #[derive(Debug, thiserror::Error)]
 pub enum TlsExpiryScanRuntimeError {
-    /// Store lock was poisoned.
-    #[error("store lock poisoned")]
-    StoreLock,
     /// Store returned an error.
     #[error("store error: {0}")]
     Store(#[from] canary_store::StoreError),
@@ -251,7 +246,7 @@ pub enum TlsExpiryScanRuntimeError {
 
 /// Evaluate and persist exactly one TLS-expiry scan candidate.
 pub fn run_tls_expiry_scan_once(
-    store: &Arc<Mutex<Store>>,
+    store: &SharedStore,
     event_sink: &dyn EventSink,
     candidate: TlsExpiryScanCandidate,
     now: OffsetDateTime,
@@ -261,9 +256,7 @@ pub fn run_tls_expiry_scan_once(
         return Ok(false);
     };
     let commit = {
-        let mut store = store
-            .lock()
-            .map_err(|_| TlsExpiryScanRuntimeError::StoreLock)?;
+        let mut store = store.lock();
         store.record_tls_expiring_event(TlsExpiryEventInsert {
             event_id: EventId::generate(),
             target_id: event.target_id,
@@ -404,6 +397,7 @@ mod tests {
     use time::format_description::well_known::Rfc3339;
 
     use super::*;
+    use canary_store::Store;
 
     #[derive(Default)]
     struct RecordingSink {
@@ -436,7 +430,7 @@ mod tests {
         let now_string = format_rfc3339(now);
         let tls_expires_at = format_rfc3339(now + time::Duration::days(7));
         seed_tls_target(&mut store, &tls_expires_at)?;
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let sink = Arc::new(RecordingSink::default());
         let lifecycle = TlsExpiryScanLifecycle::new(store.clone(), sink.clone());
 
@@ -457,7 +451,7 @@ mod tests {
             sink.events.lock().map_err(|_| "events lock poisoned")?[0],
             "health_check.tls_expiring"
         );
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let timeline = store.timeline("30d", TimelineQueryOptions::default())?;
         let event = timeline.events.first().ok_or("missing timeline event")?;
         assert_eq!(event.event, "health_check.tls_expiring");
@@ -480,7 +474,7 @@ mod tests {
         let now_string = format_rfc3339(now);
         let tls_expires_at = format_rfc3339(now + time::Duration::days(7));
         seed_tls_target(&mut store, &tls_expires_at)?;
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let lifecycle = TlsExpiryScanLifecycle::new(store.clone(), Arc::new(FailingSink));
 
         let report = lifecycle.run_due(now, now_string)?;
@@ -488,7 +482,7 @@ mod tests {
         assert_eq!(report.recorded, 1);
         assert_eq!(report.event_fanout_failed, 1);
         assert!(!report.interrupted);
-        let store = store.lock().map_err(|_| "store lock poisoned")?;
+        let store = store.lock();
         let timeline = store.timeline("30d", TimelineQueryOptions::default())?;
         assert_eq!(timeline.events.len(), 1);
         assert_eq!(timeline.events[0].event, "health_check.tls_expiring");
@@ -497,7 +491,7 @@ mod tests {
 
     #[test]
     fn worker_records_lifecycle_failures() -> Result<(), Box<dyn Error>> {
-        let store = Arc::new(Mutex::new(Store::open_in_memory()?));
+        let store = Arc::new(parking_lot::Mutex::new(Store::open_in_memory()?));
         let worker = TlsExpiryScanLifecycleWorker::spawn(
             TlsExpiryScanLifecycle::new(store, Arc::new(RecordingSink::default())),
             TlsExpiryScanLifecycleConfig {
@@ -529,7 +523,7 @@ mod tests {
         store.migrate()?;
         seed_tls_target_with_id(&mut store, "TGT-api-a", "api-a", "2026-06-05T00:00:00Z")?;
         seed_tls_target_with_id(&mut store, "TGT-api-b", "api-b", "2026-06-05T00:00:00Z")?;
-        let store = Arc::new(Mutex::new(store));
+        let store = Arc::new(parking_lot::Mutex::new(store));
         let sink = Arc::new(RecordingSink::default());
         let lifecycle = TlsExpiryScanLifecycle::new(store, sink);
         let now = OffsetDateTime::parse("2026-05-29T00:00:00Z", &Rfc3339)?;

--- a/crates/canary-server/src/webhook_delivery.rs
+++ b/crates/canary-server/src/webhook_delivery.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration as StdDuration, Instant},
 };
 
-use canary_store::{Store, WebhookDeliveryJobCompletion, WebhookDeliveryJobRow};
+use canary_store::{WebhookDeliveryJobCompletion, WebhookDeliveryJobRow};
 use canary_workers::webhooks::{
     CircuitDecision, CircuitEffect, DeliveryExecution, DeliveryLedgerAction, DeliveryOutcome,
     MAX_ATTEMPTS, WebhookJob, WebhookLookup, try_execute_delivery,
@@ -25,6 +25,7 @@ use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::{
     WorkerHealthHandle, WorkerName, WorkerPressureSnapshot,
+    route_state::SharedStore,
     server_time::{current_rfc3339, current_unix_millis},
     webhooks::{
         WebhookEventAuthority, WebhookTransport, delivery_insert, endpoint_from_subscription,
@@ -146,7 +147,7 @@ impl WebhookCircuit for NoopWebhookCircuit {
 
 /// Runtime adapter for executing one scheduled webhook delivery job.
 pub struct WebhookDeliveryRuntime {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     transport: Arc<dyn WebhookTransport>,
     circuit: Arc<dyn WebhookCircuit>,
 }
@@ -154,7 +155,7 @@ pub struct WebhookDeliveryRuntime {
 impl WebhookDeliveryRuntime {
     /// Build a delivery runtime from explicit side-effect boundaries.
     pub fn new(
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         transport: Arc<dyn WebhookTransport>,
         circuit: Arc<dyn WebhookCircuit>,
     ) -> Self {
@@ -166,10 +167,7 @@ impl WebhookDeliveryRuntime {
     }
 
     /// Build a delivery runtime with a closed no-op circuit.
-    pub fn new_without_circuit(
-        store: Arc<Mutex<Store>>,
-        transport: Arc<dyn WebhookTransport>,
-    ) -> Self {
+    pub fn new_without_circuit(store: SharedStore, transport: Arc<dyn WebhookTransport>) -> Self {
         Self::new(store, transport, Arc::new(NoopWebhookCircuit))
     }
 
@@ -198,10 +196,7 @@ impl WebhookDeliveryRuntime {
     }
 
     fn lookup_webhook(&self, job: &WebhookJob) -> Result<WebhookLookup, String> {
-        let store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let store = self.store.lock();
         let subscription = store
             .webhook_subscription(&job.webhook_id)
             .map_err(|error| error.to_string())?;
@@ -219,10 +214,7 @@ impl WebhookDeliveryRuntime {
         authority: &WebhookEventAuthority,
     ) -> Result<(), String> {
         let now = current_rfc3339();
-        let mut store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let mut store = self.store.lock();
 
         match action {
             DeliveryLedgerAction::CreatePending(delivery) => store
@@ -260,7 +252,7 @@ impl WebhookDeliveryRuntime {
 
 /// Sequential scheduled-job drain for webhook delivery jobs.
 pub struct WebhookDeliveryDrain {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     runtime: WebhookDeliveryRuntime,
     max_jobs: u32,
 }
@@ -380,7 +372,7 @@ impl Drop for WebhookDeliveryDrainWorker {
 
 impl WebhookDeliveryDrain {
     /// Build a drain with an explicit maximum number of jobs per pass.
-    pub fn new(store: Arc<Mutex<Store>>, runtime: WebhookDeliveryRuntime, max_jobs: u32) -> Self {
+    pub fn new(store: SharedStore, runtime: WebhookDeliveryRuntime, max_jobs: u32) -> Self {
         Self {
             store,
             runtime,
@@ -394,10 +386,7 @@ impl WebhookDeliveryDrain {
         let stale_before = subtract_seconds(now, WEBHOOK_EXECUTION_LEASE_SECONDS)?;
 
         let jobs = {
-            let mut store = self
-                .store
-                .lock()
-                .map_err(|_| "store lock poisoned".to_owned())?;
+            let mut store = self.store.lock();
             let recovery = store
                 .recover_stale_webhook_delivery_jobs(now, &stale_before, self.max_jobs)
                 .map_err(|error| error.to_string())?;
@@ -490,10 +479,7 @@ impl WebhookDeliveryDrain {
         job: &WebhookDeliveryJobRow,
         completion: WebhookDeliveryJobCompletion,
     ) -> Result<(), String> {
-        let mut store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let mut store = self.store.lock();
         let applied = store
             .complete_webhook_delivery_job(job, completion)
             .map_err(|error| error.to_string())?;
@@ -707,6 +693,7 @@ mod tests {
     use canary_workers::webhooks::{TransportResult, WebhookRequest};
 
     use super::*;
+    use canary_store::Store;
 
     struct NoopTransport;
 
@@ -747,7 +734,7 @@ mod tests {
 
     #[test]
     fn worker_records_lifecycle_failures() -> Result<(), Box<dyn std::error::Error>> {
-        let store = Arc::new(Mutex::new(Store::open_in_memory()?));
+        let store = Arc::new(parking_lot::Mutex::new(Store::open_in_memory()?));
         let runtime =
             WebhookDeliveryRuntime::new_without_circuit(store.clone(), Arc::new(NoopTransport));
         let drain = WebhookDeliveryDrain::new(store, runtime, 1);

--- a/crates/canary-server/src/webhooks.rs
+++ b/crates/canary-server/src/webhooks.rs
@@ -6,8 +6,8 @@ use std::{
 
 use canary_ingest::IngestEffect;
 use canary_store::{
-    BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, Store, WebhookDeliveryInsert,
-    WebhookDeliveryJobInsert, WebhookSubscription,
+    BOOTSTRAP_PROJECT_ID, BOOTSTRAP_TENANT_ID, WebhookDeliveryInsert, WebhookDeliveryJobInsert,
+    WebhookSubscription,
 };
 use canary_workers::webhooks::{
     TransportResult, WebhookEndpoint, WebhookEnqueueDecision, WebhookJob, WebhookRequest,
@@ -18,6 +18,7 @@ use serde_json::{Value, json};
 use crate::{
     IngestEffectSink,
     egress::{ValidatedHttpDestination, validate_public_http_destination},
+    route_state::SharedStore,
     server_time::current_rfc3339,
 };
 
@@ -29,12 +30,12 @@ pub trait WebhookScheduler: Send + Sync + 'static {
 
 /// Store-backed scheduler for webhook delivery jobs.
 pub struct StoreWebhookScheduler {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
 }
 
 impl StoreWebhookScheduler {
     /// Build a scheduler backed by the shared single-writer store.
-    pub fn new(store: Arc<Mutex<Store>>) -> Self {
+    pub fn new(store: SharedStore) -> Self {
         Self { store }
     }
 }
@@ -42,10 +43,7 @@ impl StoreWebhookScheduler {
 impl WebhookScheduler for StoreWebhookScheduler {
     fn schedule(&self, job: &WebhookJob) -> Result<(), String> {
         let now = current_rfc3339();
-        let mut store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let mut store = self.store.lock();
         store
             .insert_webhook_delivery_job(WebhookDeliveryJobInsert {
                 args: job_args(job),
@@ -229,7 +227,7 @@ impl WebhookTransport for HttpWebhookTransport {
 
 /// Effect sink that turns ingest webhook effects into ledger rows and jobs.
 pub struct WebhookEnqueueEffectSink {
-    store: Arc<Mutex<Store>>,
+    store: SharedStore,
     scheduler: Arc<dyn WebhookScheduler>,
     cooldown: Arc<dyn WebhookCooldown>,
 }
@@ -237,7 +235,7 @@ pub struct WebhookEnqueueEffectSink {
 impl WebhookEnqueueEffectSink {
     /// Build a webhook enqueue sink from explicit runtime boundaries.
     pub fn new(
-        store: Arc<Mutex<Store>>,
+        store: SharedStore,
         scheduler: Arc<dyn WebhookScheduler>,
         cooldown: Arc<dyn WebhookCooldown>,
     ) -> Self {
@@ -279,10 +277,7 @@ impl WebhookEnqueueEffectSink {
         let authority = WebhookEventAuthority::from_payload(&payload);
         let now = current_rfc3339();
         let subscriptions = {
-            let store = self
-                .store
-                .lock()
-                .map_err(|_| "store lock poisoned".to_owned())?;
+            let store = self.store.lock();
             store
                 .active_webhook_subscriptions_for_event_scoped(
                     event,
@@ -332,10 +327,7 @@ impl WebhookEnqueueEffectSink {
         authority: &WebhookEventAuthority,
         now: &str,
     ) -> Result<(), String> {
-        let mut store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let mut store = self.store.lock();
         store
             .create_pending_webhook_delivery(delivery_insert(delivery, authority, now))
             .map_err(|error| error.to_string())
@@ -348,10 +340,7 @@ impl WebhookEnqueueEffectSink {
         reason: &str,
         now: &str,
     ) -> Result<(), String> {
-        let mut store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let mut store = self.store.lock();
         store
             .create_suppressed_webhook_delivery(delivery_insert(delivery, authority, now), reason)
             .map_err(|error| error.to_string())
@@ -361,10 +350,7 @@ impl WebhookEnqueueEffectSink {
         let Some(delivery_id) = job.delivery_id.as_deref() else {
             return Ok(());
         };
-        let mut store = self
-            .store
-            .lock()
-            .map_err(|_| "store lock poisoned".to_owned())?;
+        let mut store = self.store.lock();
         store
             .mark_webhook_delivery_discarded(delivery_id, reason, now)
             .map_err(|error| error.to_string())


### PR DESCRIPTION
## Summary

canary-930 child C — the two remaining request-path failure modes, both live-evidenced during the child A/B oracles:

- **/readyz starvation**: the readiness probe took an unbounded `lock()` on the single-writer mutex; during a 12-concurrent `/report` wave a live probe hit 2.8s — within reach of Fly's 5s health-check timeout and the restart spiral. `StoreReadinessProbe` now uses `try_lock_for(200ms)` with documented semantics: acquired → real liveness check, true verdict; transient timeout → last-known-good verdict; 3 consecutive timeouts → hard `Error` (a genuinely wedged writer still fails readiness — the "Readiness is live" footgun's intent is preserved, no cached/blind verdict). Decision logic is a pure `classify(LockAttempt)` function with direct unit tests plus real thread-contention tests.
- **Writer-mutex poisoning**: request handlers had no panic containment — one panic while holding the std `Mutex<Store>` made every later `lock_store()` 500 until restart (leading hypothesis for the live health-status 500). The writer store is now `SharedStore = Arc<parking_lot::Mutex<Store>>` (non-poisoning; `lock_store()` keeps its signature so ~80 call sites are untouched), and the whole authenticated router is wrapped in `tower_http::catch_panic::CatchPanicLayer` mapping panics to one RFC 9457 500. Two dead poisoning-only error variants deleted.

Cites AGENTS.md footguns: "Readiness is live", "Request path must not poison the writer mutex", "No CPU-bound work under the store lock" (unaffected), single-writer invariant untouched. AuthCache/RateLimiter deliberately stay on std Mutex (not the writer lock; AuthCache has tested poison recovery).

## Evidence

- New tests: panic-injection through the real router (one 500, next authenticated request 200 — no sticky failure); `classify()` semantics (7 cases); bounded-wait + consecutive-timeout-threshold under genuine thread contention; broken-store verdict path.
- `cargo test -p canary-server --locked` 259/259; workspace clippy `-D warnings` clean; `./bin/validate --fast` and `--strict` green locally (strict includes the full Docker image rebuild forced by the new deps).
- Live post-deploy oracle (orchestrator runs): /readyz p99 < 500ms and 200 throughout a 12-concurrent `/report` wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ingest requests that encounter an unexpected server error now receive a consistent 500 response instead of a dropped connection.
  * Subsequent authenticated requests continue working after an ingest handler failure.
  * Improved service stability for background processing and webhook delivery.
* **Monitoring**
  * Readiness checks now tolerate brief contention while reporting failures when lock delays persist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->