### PR TITLE
fix(store): monitor_overdue due-filter + index; bound oban_jobs growth

### DIFF
--- a/crates/canary-ingest/src/lib.rs
+++ b/crates/canary-ingest/src/lib.rs
@@ -662,6 +662,6 @@ mod tests {
     }
 
     const fn canary_store_schema_version() -> u32 {
-        2026070200
+        2026071000
     }
 }

--- a/crates/canary-server/src/monitor_overdue.rs
+++ b/crates/canary-server/src/monitor_overdue.rs
@@ -147,7 +147,7 @@ impl MonitorOverdueLifecycle {
         now_millis: i64,
         should_stop: impl Fn() -> bool,
     ) -> Result<MonitorOverdueLifecycleReport, String> {
-        let candidates = self.load_candidates()?;
+        let candidates = self.load_candidates(&now)?;
         let mut report = MonitorOverdueLifecycleReport {
             loaded: candidates.len(),
             oldest_due_age_ms: oldest_monitor_due_age_ms(now_millis, &candidates),
@@ -176,10 +176,10 @@ impl MonitorOverdueLifecycle {
         Ok(report)
     }
 
-    fn load_candidates(&self) -> Result<Vec<MonitorOverdueCandidate>, String> {
+    fn load_candidates(&self, now: &str) -> Result<Vec<MonitorOverdueCandidate>, String> {
         let store = self.store.lock();
         store
-            .monitor_overdue_candidates()
+            .monitor_overdue_candidates(now)
             .map_err(|error| error.to_string())
     }
 }

--- a/crates/canary-server/src/retention_prune.rs
+++ b/crates/canary-server/src/retention_prune.rs
@@ -48,6 +48,8 @@ pub struct RetentionPruneLifecycleReport {
     pub service_events_deleted: u64,
     /// Deleted target-check rows.
     pub target_checks_deleted: u64,
+    /// Deleted terminal (`completed`/`discarded`) webhook-delivery job rows.
+    pub oban_jobs_deleted: u64,
     /// Store delete statements executed.
     pub batches: u64,
     /// True when shutdown interrupted the pass after a completed batch.
@@ -96,7 +98,7 @@ impl RetentionPruneLifecycle {
         }
         report.interrupted = self.prune_table(
             RetentionPruneTable::ServiceEvents,
-            plan.error_cutoff,
+            plan.error_cutoff.clone(),
             |deleted| report.service_events_deleted += deleted,
             &mut report.batches,
             &should_stop,
@@ -108,6 +110,21 @@ impl RetentionPruneLifecycle {
             RetentionPruneTable::TargetChecks,
             plan.check_cutoff,
             |deleted| report.target_checks_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        // Terminal webhook-delivery job rows share the error/service-event
+        // cutoff; only `completed`/`discarded` states ever match (see
+        // canary-store::retention::RetentionPruneTable::ObanJobsTerminal), so
+        // claimed (`executing`) or pending (`available`/`scheduled`) work is
+        // never pruned. Footgun: "Webhook delivery jobs" in AGENTS.md.
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::ObanJobsTerminal,
+            plan.error_cutoff,
+            |deleted| report.oban_jobs_deleted += deleted,
             &mut report.batches,
             &should_stop,
         )?;
@@ -325,7 +342,8 @@ fn run_lifecycle_worker(
                     WorkerPressureSnapshot {
                         due_count: report.errors_deleted
                             + report.service_events_deleted
-                            + report.target_checks_deleted,
+                            + report.target_checks_deleted
+                            + report.oban_jobs_deleted,
                         in_flight_count: 0,
                         oldest_due_age_ms: None,
                         oldest_due_item: None,
@@ -360,7 +378,10 @@ mod tests {
         ids::{ErrorId, EventId},
         ingest::classification::{Category, Classification, Component, Persistence},
     };
-    use canary_store::{ErrorIngest, ErrorIngestIds, ErrorIngestPayload};
+    use canary_store::{
+        ErrorIngest, ErrorIngestIds, ErrorIngestPayload, WebhookDeliveryJobCompletion,
+        WebhookDeliveryJobInsert,
+    };
     use time::format_description::well_known::Rfc3339;
 
     use super::*;
@@ -389,10 +410,59 @@ mod tests {
                 errors_deleted: 1005,
                 service_events_deleted: 1005,
                 target_checks_deleted: 0,
-                batches: 5,
+                oban_jobs_deleted: 0,
+                batches: 6,
                 interrupted: false,
             }
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn lifecycle_prunes_terminal_oban_jobs_and_keeps_live_work() -> Result<(), Box<dyn Error>> {
+        let mut store = Store::open_in_memory()?;
+        store.migrate()?;
+
+        // Old terminal job: must be pruned.
+        let old_completed = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: serde_json::json!({"delivery_id": "DLV-old-completed"}),
+            scheduled_at: "2026-04-01T00:00:00Z".to_owned(),
+            now: "2026-04-01T00:00:00Z".to_owned(),
+            max_attempts: 5,
+        })?;
+        let claimed_old = store.claim_due_webhook_delivery_jobs("2026-04-01T00:00:01Z", 10)?;
+        store.complete_webhook_delivery_job(
+            &claimed_old[0],
+            WebhookDeliveryJobCompletion::Complete {
+                now: "2026-04-01T00:00:02Z".to_owned(),
+            },
+        )?;
+
+        // Live, unclaimed job: must survive regardless of age (footgun:
+        // "Webhook delivery jobs" — claimed work is never destroyed).
+        let live_available = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: serde_json::json!({"delivery_id": "DLV-live"}),
+            scheduled_at: "2026-04-01T00:00:00Z".to_owned(),
+            now: "2026-04-01T00:00:00Z".to_owned(),
+            max_attempts: 5,
+        })?;
+
+        let lifecycle = RetentionPruneLifecycle::new(
+            Arc::new(parking_lot::Mutex::new(store)),
+            RetentionPolicy {
+                error_retention_days: 30,
+                check_retention_days: 7,
+            },
+        );
+        let report = lifecycle.run_due(OffsetDateTime::parse("2026-05-29T12:00:00Z", &Rfc3339)?)?;
+
+        assert_eq!(report.oban_jobs_deleted, 1);
+        assert!(!report.interrupted);
+
+        let store = lifecycle.store.lock();
+        assert!(store.webhook_delivery_job(old_completed)?.is_none());
+        assert!(store.webhook_delivery_job(live_available)?.is_some());
 
         Ok(())
     }
@@ -422,6 +492,7 @@ mod tests {
                 errors_deleted: 1000,
                 service_events_deleted: 0,
                 target_checks_deleted: 0,
+                oban_jobs_deleted: 0,
                 batches: 1,
                 interrupted: true,
             }

--- a/crates/canary-store/src/health.rs
+++ b/crates/canary-store/src/health.rs
@@ -1705,6 +1705,7 @@ fn monitor_check_in_snapshot_by_name_where(
 
 pub(crate) fn monitor_overdue_candidates(
     connection: &rusqlite::Connection,
+    now: &str,
 ) -> Result<Vec<MonitorOverdueCandidate>> {
     let mut statement = connection.prepare(
         "SELECT
@@ -1713,11 +1714,11 @@ pub(crate) fn monitor_overdue_candidates(
             s.first_missed_at
          FROM monitors m
          JOIN monitor_state s ON s.monitor_id = m.id
-         WHERE s.deadline_at IS NOT NULL
+         WHERE s.deadline_at IS NOT NULL AND s.deadline_at < ?1
          ORDER BY m.id",
     )?;
     let candidates = statement
-        .query_map([], |row| {
+        .query_map([now], |row| {
             Ok(MonitorOverdueCandidate {
                 id: row.get(0)?,
                 name: row.get(1)?,

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -518,9 +518,13 @@ impl Store {
         )
     }
 
-    /// Return monitor state rows that have deadlines eligible for overdue evaluation.
-    pub fn monitor_overdue_candidates(&self) -> Result<Vec<MonitorOverdueCandidate>> {
-        health::monitor_overdue_candidates(&self.connection)
+    /// Return monitor state rows whose deadline has already passed `now`.
+    ///
+    /// Excludes monitors that are actively checking in on time (deadline in the
+    /// future) so the 1s-tick worker does not load and plan every monitor with a
+    /// persisted deadline on every pass.
+    pub fn monitor_overdue_candidates(&self, now: &str) -> Result<Vec<MonitorOverdueCandidate>> {
+        health::monitor_overdue_candidates(&self.connection, now)
     }
 
     /// Return active HTTPS targets with their latest persisted TLS expiry.
@@ -2714,6 +2718,33 @@ mod tests {
     }
 
     #[test]
+    fn claim_due_webhook_delivery_jobs_query_uses_worker_led_index() -> Result<()> {
+        let store = migrated_store()?;
+
+        let mut statement = store.connection.prepare(
+            "EXPLAIN QUERY PLAN
+             SELECT id, scheduled_at
+             FROM oban_jobs
+             WHERE worker = 'Canary.Workers.WebhookDelivery'
+               AND queue = 'webhooks'
+               AND state IN ('available', 'scheduled')
+               AND scheduled_at <= '2026-05-28T20:00:01Z'
+             ORDER BY priority ASC, scheduled_at ASC, id ASC
+             LIMIT 10",
+        )?;
+        let details = statement
+            .query_map([], |row| row.get::<_, String>(3))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let plan_text = details.join(" | ");
+
+        assert!(
+            plan_text.contains("oban_jobs_worker_state_queue_index"),
+            "expected oban_jobs_worker_state_queue_index in query plan, got: {plan_text}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn webhook_delivery_jobs_claim_due_rows_once_and_increment_attempt() -> Result<()> {
         let mut store = migrated_store()?;
         let due_job = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
@@ -4593,6 +4624,163 @@ mod tests {
         assert_eq!(row_count(&store.connection, "errors")?, 0);
 
         Ok(())
+    }
+
+    #[test]
+    fn prune_retention_batch_oban_jobs_terminal_deletes_old_completed_and_discarded_only()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+
+        // Old terminal rows: eligible for pruning.
+        let old_completed =
+            complete_test_webhook_job(&mut store, "DLV-old-completed", "2026-04-01T00:00:00Z")?;
+        let old_discarded =
+            discard_test_webhook_job(&mut store, "DLV-old-discarded", "2026-04-01T00:00:00Z")?;
+
+        // Fresh terminal row: newer than cutoff, must survive.
+        let fresh_completed =
+            complete_test_webhook_job(&mut store, "DLV-fresh-completed", "2026-05-28T00:00:00Z")?;
+
+        // Non-terminal rows at any age: must never be pruned (footgun: "Webhook
+        // delivery jobs" — claimed work is never destroyed).
+        let available = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: json!({"delivery_id": "DLV-available"}),
+            scheduled_at: "2026-04-01T00:00:00Z".to_owned(),
+            now: "2026-04-01T00:00:00Z".to_owned(),
+            max_attempts: 5,
+        })?;
+        let scheduled = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: json!({"delivery_id": "DLV-scheduled"}),
+            scheduled_at: "2026-06-01T00:00:00Z".to_owned(),
+            now: "2026-04-01T00:00:00Z".to_owned(),
+            max_attempts: 5,
+        })?;
+        let executing_source = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: json!({"delivery_id": "DLV-executing"}),
+            scheduled_at: "2026-04-01T00:00:00Z".to_owned(),
+            now: "2026-04-01T00:00:00Z".to_owned(),
+            max_attempts: 5,
+        })?;
+        let executing = store
+            .claim_due_webhook_delivery_jobs("2026-04-01T00:00:01Z", 10)?
+            .into_iter()
+            .find(|job| job.id == executing_source)
+            .ok_or("executing job not claimed")?
+            .id;
+
+        let report = store.prune_retention_batch(RetentionPruneBatch {
+            table: RetentionPruneTable::ObanJobsTerminal,
+            cutoff: "2026-05-01T00:00:00Z".to_owned(),
+        })?;
+
+        assert_eq!(
+            report,
+            RetentionPruneBatchReport {
+                deleted: 2,
+                complete: true,
+            }
+        );
+        assert!(store.webhook_delivery_job(old_completed)?.is_none());
+        assert!(store.webhook_delivery_job(old_discarded)?.is_none());
+        assert!(store.webhook_delivery_job(fresh_completed)?.is_some());
+        assert!(store.webhook_delivery_job(available)?.is_some());
+        assert!(store.webhook_delivery_job(scheduled)?.is_some());
+        assert!(store.webhook_delivery_job(executing)?.is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn prune_retention_batch_oban_jobs_terminal_deletes_only_one_bounded_batch()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+
+        for index in 0..1005 {
+            store.connection.execute(
+                "INSERT INTO oban_jobs (state, queue, worker, args, completed_at, inserted_at, scheduled_at)
+                 VALUES ('completed', 'webhooks', 'Canary.Workers.WebhookDelivery', '{}', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z')",
+                params![],
+            )?;
+            let _ = index;
+        }
+
+        let first = store.prune_retention_batch(RetentionPruneBatch {
+            table: RetentionPruneTable::ObanJobsTerminal,
+            cutoff: "2026-05-01T00:00:00Z".to_owned(),
+        })?;
+        assert_eq!(
+            first,
+            RetentionPruneBatchReport {
+                deleted: 1000,
+                complete: false,
+            }
+        );
+        assert_eq!(row_count(&store.connection, "oban_jobs")?, 5);
+
+        let second = store.prune_retention_batch(RetentionPruneBatch {
+            table: RetentionPruneTable::ObanJobsTerminal,
+            cutoff: "2026-05-01T00:00:00Z".to_owned(),
+        })?;
+        assert_eq!(
+            second,
+            RetentionPruneBatchReport {
+                deleted: 5,
+                complete: true,
+            }
+        );
+        assert_eq!(row_count(&store.connection, "oban_jobs")?, 0);
+
+        Ok(())
+    }
+
+    fn complete_test_webhook_job(
+        store: &mut Store,
+        delivery_id: &str,
+        completed_at: &str,
+    ) -> std::result::Result<i64, Box<dyn std::error::Error>> {
+        let job = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: json!({"delivery_id": delivery_id}),
+            scheduled_at: completed_at.to_owned(),
+            now: completed_at.to_owned(),
+            max_attempts: 5,
+        })?;
+        let claimed = store.claim_due_webhook_delivery_jobs(completed_at, 10)?;
+        let claimed_job = claimed
+            .into_iter()
+            .find(|row| row.id == job)
+            .ok_or("job not claimed")?;
+        store.complete_webhook_delivery_job(
+            &claimed_job,
+            WebhookDeliveryJobCompletion::Complete {
+                now: completed_at.to_owned(),
+            },
+        )?;
+        Ok(job)
+    }
+
+    fn discard_test_webhook_job(
+        store: &mut Store,
+        delivery_id: &str,
+        discarded_at: &str,
+    ) -> std::result::Result<i64, Box<dyn std::error::Error>> {
+        let job = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
+            args: json!({"delivery_id": delivery_id}),
+            scheduled_at: discarded_at.to_owned(),
+            now: discarded_at.to_owned(),
+            max_attempts: 1,
+        })?;
+        let claimed = store.claim_due_webhook_delivery_jobs(discarded_at, 10)?;
+        let claimed_job = claimed
+            .into_iter()
+            .find(|row| row.id == job)
+            .ok_or("job not claimed")?;
+        store.complete_webhook_delivery_job(
+            &claimed_job,
+            WebhookDeliveryJobCompletion::Discard {
+                now: discarded_at.to_owned(),
+            },
+        )?;
+        Ok(job)
     }
 
     #[test]
@@ -6548,7 +6736,7 @@ mod tests {
             )?;
         }
 
-        let candidates = store.monitor_overdue_candidates()?;
+        let candidates = store.monitor_overdue_candidates("2026-05-28T20:01:00Z")?;
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].id, "MON-a");
@@ -6557,6 +6745,81 @@ mod tests {
         assert_eq!(
             candidates[0].deadline_at.as_deref(),
             Some("2026-05-28T20:00:05Z")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn monitor_overdue_candidates_exclude_deadlines_not_yet_due() -> Result<()> {
+        let mut store = migrated_store()?;
+
+        for index in 0..100 {
+            let id = format!("MON-ontime-{index}");
+            store.insert_monitor(MonitorInsert {
+                id: id.clone(),
+                name: id.clone(),
+                service: "worker".to_owned(),
+                mode: "schedule".to_owned(),
+                expected_every_ms: 60_000,
+                grace_ms: 5_000,
+                created_at: "2026-05-28T19:00:00Z".to_owned(),
+            })?;
+            store.connection.execute(
+                "INSERT INTO monitor_state (monitor_id, state, last_check_in_status, deadline_at)
+                 VALUES (?1, 'up', 'alive', '2026-05-28T21:00:00Z')",
+                params![id],
+            )?;
+        }
+
+        for index in 0..3 {
+            let id = format!("MON-overdue-{index}");
+            store.insert_monitor(MonitorInsert {
+                id: id.clone(),
+                name: id.clone(),
+                service: "worker".to_owned(),
+                mode: "schedule".to_owned(),
+                expected_every_ms: 60_000,
+                grace_ms: 5_000,
+                created_at: "2026-05-28T19:00:00Z".to_owned(),
+            })?;
+            store.connection.execute(
+                "INSERT INTO monitor_state (monitor_id, state, last_check_in_status, deadline_at)
+                 VALUES (?1, 'up', 'alive', '2026-05-28T19:59:00Z')",
+                params![id],
+            )?;
+        }
+
+        let candidates = store.monitor_overdue_candidates("2026-05-28T20:00:00Z")?;
+
+        assert_eq!(candidates.len(), 3);
+        assert!(
+            candidates
+                .iter()
+                .all(|candidate| candidate.id.starts_with("MON-overdue-"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn monitor_overdue_candidates_query_uses_deadline_at_index() -> Result<()> {
+        let store = migrated_store()?;
+
+        let plan = store.connection.prepare(
+            "EXPLAIN QUERY PLAN
+             SELECT m.id FROM monitors m
+             JOIN monitor_state s ON s.monitor_id = m.id
+             WHERE s.deadline_at IS NOT NULL AND s.deadline_at < '2026-05-28T20:00:00Z'
+             ORDER BY m.id",
+        )?;
+        let mut statement = plan;
+        let details = statement
+            .query_map([], |row| row.get::<_, String>(3))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let plan_text = details.join(" | ");
+
+        assert!(
+            plan_text.contains("monitor_state_deadline_at_index"),
+            "expected monitor_state_deadline_at_index in query plan, got: {plan_text}"
         );
         Ok(())
     }

--- a/crates/canary-store/src/retention.rs
+++ b/crates/canary-store/src/retention.rs
@@ -15,6 +15,10 @@ pub enum RetentionPruneTable {
     ServiceEvents,
     /// Target check rows, keyed by `checked_at`.
     TargetChecks,
+    /// Terminal (`completed`/`discarded`) webhook-delivery job rows, keyed by
+    /// their terminal timestamp. Non-terminal rows (`available`, `scheduled`,
+    /// `executing`) are never matched, so claimed work is never pruned.
+    ObanJobsTerminal,
 }
 
 /// Cutoff timestamps for one retention prune pass.
@@ -78,12 +82,12 @@ pub(crate) fn prune_batch(
     connection: &Connection,
     batch: RetentionPruneBatch,
 ) -> Result<RetentionPruneBatchReport> {
-    let (table, column) = table_spec(batch.table);
+    let (table, predicate) = table_predicate(batch.table);
     let sql = format!(
         "DELETE FROM {table}
          WHERE rowid IN (
              SELECT rowid FROM {table}
-             WHERE {column} < ?1
+             WHERE {predicate}
              LIMIT ?2
          )"
     );
@@ -115,10 +119,18 @@ fn prune_table(connection: &Connection, table: RetentionPruneTable, cutoff: &str
     Ok(total)
 }
 
-fn table_spec(table: RetentionPruneTable) -> (&'static str, &'static str) {
+/// Table name and cutoff predicate (bound to `?1`) for one bounded delete batch.
+fn table_predicate(table: RetentionPruneTable) -> (&'static str, &'static str) {
     match table {
-        RetentionPruneTable::Errors => ("errors", "created_at"),
-        RetentionPruneTable::ServiceEvents => ("service_events", "created_at"),
-        RetentionPruneTable::TargetChecks => ("target_checks", "checked_at"),
+        RetentionPruneTable::Errors => ("errors", "created_at < ?1"),
+        RetentionPruneTable::ServiceEvents => ("service_events", "created_at < ?1"),
+        RetentionPruneTable::TargetChecks => ("target_checks", "checked_at < ?1"),
+        // Only terminal states are eligible. `available`/`scheduled`/`executing`
+        // rows never match this predicate regardless of cutoff.
+        RetentionPruneTable::ObanJobsTerminal => (
+            "oban_jobs",
+            "((state = 'completed' AND completed_at < ?1)
+              OR (state = 'discarded' AND discarded_at < ?1))",
+        ),
     }
 }

--- a/crates/canary-store/src/schema.rs
+++ b/crates/canary-store/src/schema.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use rusqlite::Connection;
 
 /// Current Rust schema version.
-pub const SCHEMA_VERSION: u32 = 2026070200;
+pub const SCHEMA_VERSION: u32 = 2026071000;
 
 pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
     let transaction = connection.transaction()?;
@@ -17,6 +17,7 @@ pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
     add_incident_escalation_columns(&transaction)?;
     scope_monitor_name_index(&transaction)?;
     scope_incident_open_service_index(&transaction)?;
+    scope_oban_jobs_claim_index(&transaction)?;
     validate_schema_columns(&transaction)?;
     transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
     transaction.commit()?;
@@ -199,6 +200,20 @@ fn scope_monitor_name_index(connection: &Connection) -> rusqlite::Result<()> {
     connection.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS monitors_owner_name_index
          ON monitors(tenant_id, project_id, name)",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Lead the oban_jobs claim index with `worker` so `claim_due_webhook_delivery_jobs`
+/// (which always filters `worker = ?1` first) does not scan every row matching
+/// state alone. Existing installs carry the old `state`-led index; drop it so it
+/// does not silently shadow the new one.
+fn scope_oban_jobs_claim_index(connection: &Connection) -> rusqlite::Result<()> {
+    connection.execute("DROP INDEX IF EXISTS oban_jobs_state_queue_index", [])?;
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS oban_jobs_worker_state_queue_index
+         ON oban_jobs(worker, state, queue, priority, scheduled_at, id)",
         [],
     )?;
     Ok(())
@@ -604,8 +619,8 @@ CREATE TABLE IF NOT EXISTS oban_jobs (
   discarded_at TEXT
 );
 
-CREATE INDEX IF NOT EXISTS oban_jobs_state_queue_index
-ON oban_jobs(state, queue, priority, scheduled_at, id);
+CREATE INDEX IF NOT EXISTS oban_jobs_worker_state_queue_index
+ON oban_jobs(worker, state, queue, priority, scheduled_at, id);
 
 CREATE TABLE IF NOT EXISTS incidents (
   id TEXT PRIMARY KEY,
@@ -839,6 +854,9 @@ CREATE TABLE IF NOT EXISTS monitor_state (
   last_transition_at TEXT,
   sequence INTEGER NOT NULL DEFAULT 0
 );
+
+CREATE INDEX IF NOT EXISTS monitor_state_deadline_at_index
+ON monitor_state(deadline_at);
 
 CREATE TABLE IF NOT EXISTS monitor_check_ins (
   id TEXT PRIMARY KEY,

--- a/crates/canary-store/tests/legacy_fixture_compat.rs
+++ b/crates/canary-store/tests/legacy_fixture_compat.rs
@@ -24,7 +24,7 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 const LEGACY_FIXTURE: &str = "tests/fixtures/legacy_schema.db";
 const POPULATED_LEGACY_FIXTURE: &str = "tests/fixtures/legacy_read_models.db";
-const RUST_SCHEMA_VERSION: u32 = 2026070200;
+const RUST_SCHEMA_VERSION: u32 = 2026071000;
 
 const LEGACY_MIGRATIONS: &[&str] = &[
     "20260314000001",
@@ -616,7 +616,7 @@ fn rust_health_read_models_read_populated_legacy_rows() -> Result<(), Box<dyn Er
     assert_eq!(monitor_snapshot.grace_ms, 5_000);
     assert_eq!(monitor_snapshot.state, "degraded");
 
-    let overdue = store.monitor_overdue_candidates()?;
+    let overdue = store.monitor_overdue_candidates("2026-06-01T00:00:00Z")?;
     assert_eq!(overdue.len(), 1);
     assert_eq!(overdue[0].id, "MON-readmodel-cron");
     assert_eq!(overdue[0].last_check_in_status.as_deref(), Some("alive"));


### PR DESCRIPTION
## Summary

Two canary-930 hygiene fixes (children D and E) on the request-path concurrency card.

**monitor_overdue scan fix (child D).** `monitor_overdue_candidates` selected `WHERE deadline_at IS NOT NULL` with no `deadline_at < now` filter, so the 1s-tick worker loaded and planned every actively-checking-in monitor on every pass while holding the store lock. `WorkerPressureSnapshot.due_count` fed from `report.loaded`, so due_count reported total monitors with deadlines, not overdue ones — the misleading metric flagged as canary-918. Now filters `deadline_at < now` (now threaded from the worker tick through the store call), and adds a `monitor_state(deadline_at)` index. The pure planner already rejected not-yet-due candidates, so behavior is unchanged — only load shrinks.

**oban_jobs bounded growth (child E).** Retention pruning covered errors/service_events/target_checks but never oban_jobs, so terminal webhook-delivery job rows accumulated forever on the 512MB box. Retention pruning now deletes terminal (`completed`/`discarded`) oban_jobs rows past the existing error/service-event cutoff, in the same bounded-batch, lock-released-between-batches loop already used for the other tables. The delete predicate only ever matches `state = 'completed'` or `state = 'discarded'` — non-terminal rows (`available`/`scheduled`/`executing`) are excluded by construction, so claimed work is never destroyed.

Also: the oban_jobs claim index was `(state, queue, priority, scheduled_at, id)`, but the claim query's first filter is `worker = ?1` — every claim scanned all matching-state rows regardless of worker. The index now leads with `worker`. Existing installs get the old index dropped and the new one created via a `migrate()` step (same pattern as `scope_monitor_name_index`).

Does not touch canary-066's planned oban_jobs rename/restamp — this is strictly an index change and a prune predicate on the existing table/columns, compatible with existing Elixir-era `worker` string values (`Canary.Workers.WebhookDelivery`).

Footguns cited: "No CPU-bound work under the store lock" (monitor_overdue scan runs inside the lock every tick), "Webhook delivery jobs" (claimed work never destroyed), "Retention prune lock time" (bounded batches, lock released between batches), "Schema ownership" (migrate() fails closed, index rename follows the established drop-and-recreate pattern).

## Test plan

- [x] `cargo test --workspace --locked` — all crates green (including two new `EXPLAIN QUERY PLAN` oracles, each manually confirmed to fail against the prior index shape before the fix and pass after)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `./bin/validate --fast` (pre-commit) and `./bin/validate --strict` (pre-push, full gate incl. TS client + Docker smoke) — both green
- [x] New store-level test: 100 on-time monitors + 3 overdue ⇒ `monitor_overdue_candidates` returns exactly 3
- [x] New store-level tests: terminal oban_jobs rows past cutoff are pruned; non-terminal rows (available/scheduled/executing) and fresh terminal rows survive; batch-boundedness mirrors the existing 1005-row/1000-batch idiom used for errors/service_events
- [x] New server-level lifecycle test: `RetentionPruneLifecycle::run_due` prunes an old completed job and keeps a live unclaimed job

Agent: builder
Agent-Surface: Claude Code
Agent-Task: canary-930