### PR TITLE
fix(store): prune legacy cancelled oban_jobs rows too

### DIFF
--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -4641,6 +4641,23 @@ mod tests {
         let fresh_completed =
             complete_test_webhook_job(&mut store, "DLV-fresh-completed", "2026-05-28T00:00:00Z")?;
 
+        // Legacy Elixir-era `cancelled` rows: the Rust write path never
+        // produces this state, so seed it raw exactly as a pre-cutover DB
+        // would carry it. Old cancelled rows are terminal and must prune;
+        // fresh ones must survive (PR #257 review MAJOR).
+        store.connection.execute(
+            "INSERT INTO oban_jobs (state, queue, worker, args, cancelled_at, inserted_at, scheduled_at)
+             VALUES ('cancelled', 'webhooks', 'Canary.Workers.WebhookDelivery', '{}', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z')",
+            params![],
+        )?;
+        let old_cancelled = store.connection.last_insert_rowid();
+        store.connection.execute(
+            "INSERT INTO oban_jobs (state, queue, worker, args, cancelled_at, inserted_at, scheduled_at)
+             VALUES ('cancelled', 'webhooks', 'Canary.Workers.WebhookDelivery', '{}', '2026-05-28T00:00:00Z', '2026-05-28T00:00:00Z', '2026-05-28T00:00:00Z')",
+            params![],
+        )?;
+        let fresh_cancelled = store.connection.last_insert_rowid();
+
         // Non-terminal rows at any age: must never be pruned (footgun: "Webhook
         // delivery jobs" — claimed work is never destroyed).
         let available = store.insert_webhook_delivery_job(WebhookDeliveryJobInsert {
@@ -4676,7 +4693,7 @@ mod tests {
         assert_eq!(
             report,
             RetentionPruneBatchReport {
-                deleted: 2,
+                deleted: 3,
                 complete: true,
             }
         );
@@ -4686,6 +4703,20 @@ mod tests {
         assert!(store.webhook_delivery_job(available)?.is_some());
         assert!(store.webhook_delivery_job(scheduled)?.is_some());
         assert!(store.webhook_delivery_job(executing)?.is_some());
+
+        let count_row = |id: i64| -> std::result::Result<i64, Box<dyn std::error::Error>> {
+            Ok(store.connection.query_row(
+                "SELECT COUNT(*) FROM oban_jobs WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )?)
+        };
+        assert_eq!(count_row(old_cancelled)?, 0, "old cancelled row must prune");
+        assert_eq!(
+            count_row(fresh_cancelled)?,
+            1,
+            "fresh cancelled row must survive the cutoff"
+        );
 
         Ok(())
     }

--- a/crates/canary-store/src/retention.rs
+++ b/crates/canary-store/src/retention.rs
@@ -126,11 +126,15 @@ fn table_predicate(table: RetentionPruneTable) -> (&'static str, &'static str) {
         RetentionPruneTable::ServiceEvents => ("service_events", "created_at < ?1"),
         RetentionPruneTable::TargetChecks => ("target_checks", "checked_at < ?1"),
         // Only terminal states are eligible. `available`/`scheduled`/`executing`
-        // rows never match this predicate regardless of cutoff.
+        // rows never match this predicate regardless of cutoff. `cancelled` is
+        // a legacy Elixir-era state the Rust write path never produces, but
+        // pre-cutover rows may carry it; it is terminal and prunes like the
+        // others.
         RetentionPruneTable::ObanJobsTerminal => (
             "oban_jobs",
             "((state = 'completed' AND completed_at < ?1)
-              OR (state = 'discarded' AND discarded_at < ?1))",
+              OR (state = 'discarded' AND discarded_at < ?1)
+              OR (state = 'cancelled' AND cancelled_at < ?1))",
         ),
     }
 }


### PR DESCRIPTION
## Summary

Recovery of the PR #257 review MAJOR that missed the squash (a piped `git push` masked a push failure, so #257 merged without this commit — process bug on the orchestrator side, now corrected).

The terminal-row prune predicate covered `completed` and `discarded` but not the legacy Elixir-era `cancelled` state. The Rust write path never produces it, but pre-cutover rows carrying it are terminal and would grow unbounded forever — the exact problem canary-930 child E fixes. Predicate extended with `(state='cancelled' AND cancelled_at < ?1)`; the prune test seeds raw cancelled rows exactly as a pre-cutover DB would carry them and proves old ones prune while fresh ones survive.

Cites AGENTS.md footguns: "Retention prune lock time", "Webhook delivery jobs".

## Evidence

- `cargo test -p canary-store --locked prune_retention_batch_oban` → 2/2 green (extended test asserts deleted=3 incl. the cancelled row, fresh-cancelled survives, non-terminal untouched).
- Already adversarially reviewed as part of the PR #257 verdict (the reviewer's own recommended fix).
- Strict gate green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)