### PR TITLE
feat(cli): incident detail + timeline cursor parity across CLI and MCP

### DIFF
--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -4475,6 +4475,14 @@ impl McpToolContext {
                     path.push_str("&service=");
                     path.push_str(&encode(&service));
                 }
+                if let Some(cursor) = optional_string(arguments, "cursor")? {
+                    path.push_str("&cursor=");
+                    path.push_str(&encode(&cursor));
+                }
+                if let Some(after) = optional_string(arguments, "after")? {
+                    path.push_str("&after=");
+                    path.push_str(&encode(&after));
+                }
                 let response = client.get_auth_json(&path)?;
                 Ok(json_envelope(
                     "canary_timeline",
@@ -4930,8 +4938,8 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "canary_timeline",
-            description: "Inspect timeline events globally or for one service.",
-            input_schema: json!({"type":"object","properties":{"service":{"type":"string"},"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]},"limit":{"type":"integer","minimum":1,"maximum":100}}}),
+            description: "Inspect timeline events globally or for one service. Pass `cursor` (the prior response's `cursor` field) to page forward through crash-recovery replay; `after` takes precedence over `cursor` when both are supplied.",
+            input_schema: json!({"type":"object","properties":{"service":{"type":"string"},"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]},"limit":{"type":"integer","minimum":1,"maximum":100},"cursor":{"type":"string"},"after":{"type":"string"}}}),
         },
         ToolSpec {
             name: "canary_targets",

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -153,6 +153,10 @@ struct TimelineArgs {
     window: String,
     #[arg(long, default_value_t = 20)]
     limit: u16,
+    #[arg(long)]
+    cursor: Option<String>,
+    #[arg(long)]
+    after: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -613,6 +617,14 @@ fn run_http_command(
                     if let Some(service) = args.service {
                         path.push_str("&service=");
                         path.push_str(&encode(&service));
+                    }
+                    if let Some(cursor) = args.cursor {
+                        path.push_str("&cursor=");
+                        path.push_str(&encode(&cursor));
+                    }
+                    if let Some(after) = args.after {
+                        path.push_str("&after=");
+                        path.push_str(&encode(&after));
                     }
                     let response = client.get_auth_json(&path)?;
                     render(

--- a/crates/canary-cli/tests/mcp_stdio.rs
+++ b/crates/canary-cli/tests/mcp_stdio.rs
@@ -256,6 +256,7 @@ fn mcp_stdio_timeline_tool_forwards_after_and_cursor() -> Result<(), Box<dyn std
     let mut child = Command::new(env!("CARGO_BIN_EXE_canary"))
         .args(["--endpoint", server.endpoint(), "mcp-server"])
         .current_dir(&repo_root)
+        .env("CANARY_READ_KEY", "mcp-key")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -297,6 +298,7 @@ fn mcp_stdio_timeline_tool_forwards_after_and_cursor() -> Result<(), Box<dyn std
 
     let requests = server.join()?;
     assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].authorization.as_deref(), Some("Bearer mcp-key"));
     assert!(requests[0].path.contains("after=EVT-9"));
     assert!(requests[0].path.contains("cursor=legacy-cursor"));
 

--- a/crates/canary-cli/tests/mcp_stdio.rs
+++ b/crates/canary-cli/tests/mcp_stdio.rs
@@ -1,6 +1,7 @@
 //! Stdio MCP smoke tests for the Canary CLI adapter.
 
 use std::{
+    collections::BTreeSet,
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
@@ -174,6 +175,135 @@ fn cli_incidents_get_reads_incident_detail() -> Result<(), Box<dyn std::error::E
 }
 
 #[test]
+fn cli_timeline_two_page_cursor_walk_returns_ordered_events_without_gap_or_duplicate()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![
+        FixtureResponse::ok(timeline_page_body(
+            &["EVT-4", "EVT-3"],
+            Some("opaque-cursor-2"),
+        )),
+        FixtureResponse::ok(timeline_page_body(&["EVT-2", "EVT-1"], None)),
+    ])?;
+
+    let first = run_cli_json(&server, ["timeline", "--limit", "2"])?;
+    assert_eq!(
+        event_ids(&first["response"]),
+        vec!["EVT-4".to_owned(), "EVT-3".to_owned()]
+    );
+    let cursor = first["response"]["cursor"]
+        .as_str()
+        .ok_or_else(|| std::io::Error::other("first page did not return a next-page cursor"))?
+        .to_owned();
+    assert_eq!(cursor, "opaque-cursor-2");
+
+    let second = run_cli_json(&server, ["timeline", "--limit", "2", "--cursor", &cursor])?;
+    assert_eq!(
+        event_ids(&second["response"]),
+        vec!["EVT-2".to_owned(), "EVT-1".to_owned()]
+    );
+    assert!(second["response"]["cursor"].is_null());
+
+    let mut walked = event_ids(&first["response"]);
+    walked.extend(event_ids(&second["response"]));
+    let unique: BTreeSet<_> = walked.iter().collect();
+    assert_eq!(
+        unique.len(),
+        walked.len(),
+        "cursor walk produced a duplicate"
+    );
+    assert_eq!(
+        walked,
+        vec!["EVT-4", "EVT-3", "EVT-2", "EVT-1"],
+        "cursor walk produced a gap or reorder"
+    );
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 2);
+    assert!(!requests[0].path.contains("cursor="));
+    assert!(requests[1].path.contains("cursor=opaque-cursor-2"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_timeline_forwards_after_and_cursor_together() -> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(timeline_page_body(
+        &["EVT-1"],
+        None,
+    ))])?;
+
+    let response = run_cli_json(
+        &server,
+        ["timeline", "--after", "EVT-9", "--cursor", "legacy-cursor"],
+    )?;
+    assert_eq!(response["command"], json!("timeline"));
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].path.contains("after=EVT-9"));
+    assert!(requests[0].path.contains("cursor=legacy-cursor"));
+
+    Ok(())
+}
+
+#[test]
+fn mcp_stdio_timeline_tool_forwards_after_and_cursor() -> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(timeline_page_body(
+        &["EVT-1"],
+        None,
+    ))])?;
+    let repo_root = repo_root()?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args(["--endpoint", server.endpoint(), "mcp-server"])
+        .current_dir(&repo_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("child stdin unavailable"))?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_timeline",
+                "arguments": {"after": "EVT-9", "cursor": "legacy-cursor"}
+            }
+        })
+    )?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let responses = String::from_utf8(output.stdout)?
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["command"],
+        json!("canary_timeline")
+    );
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].path.contains("after=EVT-9"));
+    assert!(requests[0].path.contains("cursor=legacy-cursor"));
+
+    Ok(())
+}
+
+#[test]
 fn mcp_stdio_exercises_incident_loop_tools() -> Result<(), Box<dyn std::error::Error>> {
     let server = FixtureServer::spawn(vec![
         FixtureResponse::ok(incident_detail_body()),
@@ -342,6 +472,46 @@ fn mcp_stdio_exercises_incident_loop_tools() -> Result<(), Box<dyn std::error::E
     assert!(requests[2].body.contains("\"action\":\"fix-verified\""));
 
     Ok(())
+}
+
+fn run_cli_json<const N: usize>(
+    server: &FixtureServer,
+    args: [&str; N],
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let output = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args(["--endpoint", server.endpoint(), "--api-key", "read-key"])
+        .arg("--json")
+        .args(args)
+        .output()?;
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+fn event_ids(timeline_response: &Value) -> Vec<String> {
+    timeline_response["events"]
+        .as_array()
+        .map(|events| {
+            events
+                .iter()
+                .filter_map(|event| event["id"].as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn timeline_page_body(ids: &[&str], cursor: Option<&str>) -> Value {
+    json!({
+        "service": Value::Null,
+        "window": "24h",
+        "summary": format!("Returned {} timeline events in the last 24h.", ids.len()),
+        "returned_count": ids.len(),
+        "events": ids.iter().map(|id| json!({"id": id, "event": "error.ingested"})).collect::<Vec<_>>(),
+        "cursor": cursor,
+    })
 }
 
 fn repo_root() -> Result<PathBuf, Box<dyn std::error::Error>> {

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -47,6 +47,7 @@ bin/canary incidents get INC-example --json
 bin/canary incidents escalate INC-example --reason "iteration guard exhausted" --owner bitterblossom/canary-triage --purpose triage_escalation --idempotency-key run-1:INC-example:escalate
 bin/canary incidents deescalate INC-example --owner operator@example.com --reason "false positive"
 bin/canary timeline --service chrondle --window 7d --limit 20
+bin/canary timeline --service chrondle --window 7d --limit 20 --cursor <cursor-from-prior-response>  # page forward; --after takes precedence over --cursor if both are given
 bin/canary claims list --subject-type incident --subject-id INC-example --json
 bin/canary claims claim --subject-type incident --subject-id INC-example --owner codex --purpose "verify fix" --json
 bin/canary annotations list --subject-type incident --subject-id INC-example --json

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -102,9 +102,15 @@
       "name": "canary_incident_get"
     },
     {
-      "description": "Inspect timeline events globally or for one service.",
+      "description": "Inspect timeline events globally or for one service. Pass `cursor` (the prior response's `cursor` field) to page forward through crash-recovery replay; `after` takes precedence over `cursor` when both are supplied.",
       "input_schema": {
         "properties": {
+          "after": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          },
           "limit": {
             "maximum": 100,
             "minimum": 1,


### PR DESCRIPTION
## Summary

canary-932 (\"coordination loop in anger\") child 2: the `GET /api/v1/timeline` route already supports `cursor`/`after` pagination (`after` wins when both are supplied — `crates/canary-server/src/query_routes.rs:188`), but neither the CLI `timeline` command nor the MCP `canary_timeline` tool exposed those params. A webhook-woken MCP-only agent had no way to page through crash-recovery timeline replay without dropping to raw HTTP.

- Adds `--cursor`/`--after` flags to `canary timeline`.
- Adds `cursor`/`after` arguments to the MCP `canary_timeline` tool, forwarded verbatim as query params (client makes no precedence decision — the server already resolves `after` over `cursor` per the OpenAPI `x-agent-guide` `cursor_precedence` contract).
- Regenerates the checked-in MCP manifest (`priv/mcp/canary-cli-tools.json`) to match, guarded by the existing `checked_in_mcp_manifest_matches_generated_manifest` parity test.
- Updates `docs/agent-inspection-cli.md`'s command crib with a cursor-walk example.

### Child 1 (incident detail on CLI+MCP) status

Already shipped on master via #230 (`feat(agent-loop): close incident writeback loop`, merged 2026-07-04): `canary incidents get <id> --json`, MCP `canary_incident_get`, static manifest parity, and CLI/MCP stdio tests (`crates/canary-cli/tests/mcp_stdio.rs`) all predate this branch. No changes needed there; verified live against current master before starting this work.

## Test plan

- [x] `cargo test -p canary-cli --locked` — new tests: `cli_timeline_two_page_cursor_walk_returns_ordered_events_without_gap_or_duplicate` (two-page fixture walk asserts no gap/duplicate across the ordered event id sequence and correct `--cursor` passthrough on page 2), `cli_timeline_forwards_after_and_cursor_together` and `mcp_stdio_timeline_tool_forwards_after_and_cursor` (both `--after`/`--cursor` land in the outbound query string on both surfaces, no client-side precedence invented).
- [x] `cargo test --workspace --locked` — 537 tests, 0 failed.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `./bin/validate --fast` (pre-commit) and `./bin/validate --strict` (pre-push, full Dagger gate incl. Rust workspace, TS SDK, operator scripts, Docker image build + `/healthz`/`/readyz` smoke) — both green, 10m18s strict run.

## Residuals / notes for children 3+4

Read routes still missing CLI/MCP coverage, out of scope here per the dispatch brief:
- `/errors/{id}` error detail (no CLI/MCP surface found).
- Webhook-delivery diagnostics (no CLI/MCP surface found).

## Parity-artifact note

`priv/mcp/canary-cli-tools.json` is regenerated via `cargo run -p canary-cli --bin canary -- mcp-manifest > priv/mcp/canary-cli-tools.json` — the `checked_in_mcp_manifest_matches_generated_manifest` test in `crates/canary-cli/tests/fixtures.rs` fails if this drifts from `tool_manifest()` in `lib.rs`. Diff is a 7-line addition (the two new schema properties + updated description) with no other churn.

## One bug caught in the strict gate

The first push attempt failed `cargo test --workspace` inside the clean Dagger sandbox: my new MCP test had passed locally only because my dev shell has ambient `CANARY_API_KEY`/`CANARY_ENDPOINT` exported. Fixed by pinning `CANARY_READ_KEY` explicitly in the test (matching the sibling incident-loop test's `CANARY_RESPONDER_KEY` idiom) — second commit in this PR.

Agent: builder
Agent-Surface: Claude Code
Agent-Task: canary-932 child 2