### PR TITLE
feat(cli)!: error + delivery drill-downs and an OpenAPI contract-parity guard

### DIFF
--- a/.agents/skills/canary-qa/SKILL.md
+++ b/.agents/skills/canary-qa/SKILL.md
@@ -76,7 +76,7 @@ Default endpoint is prod `https://canary-obs.fly.dev` — **override it or you Q
 export CANARY_ENDPOINT=http://localhost:4000 CANARY_ADMIN_KEY=$KEY
 ./target/debug/canary summary --window 1h    # or ./bin/canary (rebuilds)
 ./target/debug/canary doctor
-./target/debug/canary errors qa-smoke --json
+./target/debug/canary errors list qa-smoke --json
 ```
 
 ## Workers / webhook delivery QA (async side effects)

--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -129,7 +129,7 @@ jobs:
           1. Check the uploaded \`canary-witness-receipt.json\` artifact.
           2. Check Fly.io machine status: \`flyctl status --app $CANARY_FLY_APP\`
           3. Check logs: \`flyctl logs --app $CANARY_FLY_APP\`
-          4. Check recent self-errors: \`bin/canary errors canary --window 1h\`
+          4. Check recent self-errors: \`bin/canary errors list canary --window 1h\`
           5. If DB corruption is suspected, see \`docs/backup-restore-dr.md\`.
 
           This issue will auto-close when the witness detects recovery.

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -1102,7 +1102,7 @@ pub fn integration_plan(input: &IntegrationInput) -> Result<Value> {
         "commands": {
             "patch": format!("bin/canary integrate patch {} --service {} --endpoint {}", shell_arg(&target.display().to_string()), shell_arg(service), shell_arg(&input.endpoint)),
             "enroll": health_url.map(|url| format!("bin/canary integrate enroll --service {} --url {}", shell_arg(service), shell_arg(&url))),
-            "verify": format!("bin/canary errors {} --window 1h", shell_arg(service))
+            "verify": format!("bin/canary errors list {} --window 1h", shell_arg(service))
         }
     }))
 }
@@ -1156,7 +1156,7 @@ pub fn integration_patch(input: &IntegrationInput) -> Result<Value> {
         "next_steps": [
             "Review the patch before deploying.",
             "Set Canary env names in the deployment platform without committing secret values.",
-            "Deploy, then run canary integrate enroll and canary errors <service> --window 1h."
+            "Deploy, then run canary integrate enroll and canary errors list <service> --window 1h."
         ]
     }))
 }
@@ -2107,7 +2107,7 @@ fn integration_receipt_value(
         ],
         "verification_commands": [
             format!("bin/canary integrate status {} --service {} --json", shell_arg(&input.target.display().to_string()), shell_arg(service)),
-            format!("bin/canary errors {} --window 1h --json", shell_arg(service))
+            format!("bin/canary errors list {} --window 1h --json", shell_arg(service))
         ],
         "last_verified_at": now_unix_timestamp_string()
     })
@@ -2140,7 +2140,7 @@ fn enrollment_receipt_value(
         ],
         "verification_commands": [
             format!("bin/canary integrate status . --service {} --json", shell_arg(&request.service)),
-            format!("bin/canary errors {} --window 1h --json", shell_arg(&request.service))
+            format!("bin/canary errors list {} --window 1h --json", shell_arg(&request.service))
         ],
         "last_verified_at": now_unix_timestamp_string()
     })
@@ -3192,7 +3192,12 @@ fn doctor_verdict(
     })
 }
 
-fn next_operator_action(
+/// Compute the deterministic operator remediation hint for one doctor
+/// verdict. Exposed (not just crate-private) so contract-parity tests can
+/// prove the CLI commands embedded in this hint are live-registered, the
+/// same way `integration_plan`/`integration_patch`'s embedded commands are
+/// checked.
+pub fn next_operator_action(
     overall: &str,
     witness: &Value,
     failing_workers: u64,
@@ -3217,7 +3222,7 @@ fn next_operator_action(
         return "Inspect alert-plane worker pressure and drain the named backlog before rerunning `bin/canary doctor --json`.".to_owned();
     }
     if canary_error_total > 0 {
-        return "Run `bin/canary errors canary --window 1h --json`, fix the newest error class, and rerun `bin/canary doctor --json`.".to_owned();
+        return "Run `bin/canary errors list canary --window 1h --json`, fix the newest error class, and rerun `bin/canary doctor --json`.".to_owned();
     }
     if dogfood_gap_count > 0 {
         return "No runtime blocker; run `bin/canary dogfood audit --strict --json` and close the reported coverage gaps.".to_owned();

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -673,6 +673,43 @@ pub fn summarize_timeline(value: &Value) -> Vec<String> {
     ]
 }
 
+/// Summarize one raw error detail response.
+pub fn summarize_error_detail(value: &Value) -> Vec<String> {
+    vec![
+        format!("summary: {}", string_field(value, "summary")),
+        format!("id: {}", string_field(value, "id")),
+        format!("service: {}", string_field(value, "service")),
+        format!("error_class: {}", string_field(value, "error_class")),
+        format!("severity: {}", string_field(value, "severity")),
+        format!("group_hash: {}", string_field(value, "group_hash")),
+        format!(
+            "stack_trace: {}",
+            if value.get("stack_trace").is_some_and(Value::is_string) {
+                "present"
+            } else {
+                "none"
+            }
+        ),
+        format!("incident_ids: {}", array_len(value, "incident_ids")),
+    ]
+}
+
+/// Summarize one webhook delivery ledger row.
+pub fn summarize_webhook_delivery(value: &Value) -> Vec<String> {
+    vec![
+        format!("delivery_id: {}", string_field(value, "delivery_id")),
+        format!("webhook_id: {}", string_field(value, "webhook_id")),
+        format!("event: {}", string_field(value, "event")),
+        format!("status: {}", string_field(value, "status")),
+        format!("attempt_count: {}", number_field(value, "attempt_count")),
+        format!("reason: {}", nullable_string_field(value, "reason")),
+        format!(
+            "last_attempt_at: {}",
+            nullable_string_field(value, "last_attempt_at")
+        ),
+    ]
+}
+
 /// Summarize targets.
 pub fn summarize_targets(value: &Value) -> Vec<String> {
     summarize_collection(value, "targets")
@@ -4490,6 +4527,30 @@ impl McpToolContext {
                     response,
                 ))
             }
+            "canary_error_get" => {
+                let client = self.read_client()?;
+                let error_id = required_string(arguments, "error_id")?;
+                let response =
+                    client.get_auth_json(&format!("/api/v1/errors/{}", encode(&error_id)))?;
+                Ok(json_envelope(
+                    "canary_error_get",
+                    client.endpoint(),
+                    response,
+                ))
+            }
+            "canary_webhook_delivery_get" => {
+                let client = self.read_client()?;
+                let delivery_id = required_string(arguments, "delivery_id")?;
+                let response = client.get_auth_json(&format!(
+                    "/api/v1/webhook-deliveries/{}",
+                    encode(&delivery_id)
+                ))?;
+                Ok(json_envelope(
+                    "canary_webhook_delivery_get",
+                    client.endpoint(),
+                    response,
+                ))
+            }
             "canary_targets" => {
                 let client = self.read_client()?;
                 let response = client.get_auth_json("/api/v1/targets")?;
@@ -4940,6 +5001,16 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
             name: "canary_timeline",
             description: "Inspect timeline events globally or for one service. Pass `cursor` (the prior response's `cursor` field) to page forward through crash-recovery replay; `after` takes precedence over `cursor` when both are supplied.",
             input_schema: json!({"type":"object","properties":{"service":{"type":"string"},"window":{"type":"string","enum":["1h","6h","24h","7d","30d"]},"limit":{"type":"integer","minimum":1,"maximum":100},"cursor":{"type":"string"},"after":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_error_get",
+            description: "Read one raw error by id, including stack trace and decoded context. Only fall through here from `canary_incident_get` when signals are truncated or raw stack traces are needed.",
+            input_schema: json!({"type":"object","required":["error_id"],"properties":{"error_id":{"type":"string"}}}),
+        },
+        ToolSpec {
+            name: "canary_webhook_delivery_get",
+            description: "Inspect one webhook delivery ledger row by stable delivery id for dispute or diagnostic replay; always replay `canary_timeline` afterward since webhooks are non-authoritative wake-up hints.",
+            input_schema: json!({"type":"object","required":["delivery_id"],"properties":{"delivery_id":{"type":"string"}}}),
         },
         ToolSpec {
             name: "canary_targets",

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -14,9 +14,10 @@ use canary_cli::{
     integration_plan, integration_status, json_envelope, mcp_tool_manifest, print_json,
     print_lines, resolve_endpoint_without_config, run_dogfood_inventory, summarize_annotations,
     summarize_claims, summarize_doctor, summarize_dogfood, summarize_dogfood_value,
-    summarize_event, summarize_incident_detail, summarize_incident_escalation, summarize_incidents,
-    summarize_integration, summarize_monitors, summarize_query, summarize_report,
-    summarize_services, summarize_targets, summarize_timeline, tool_manifest,
+    summarize_error_detail, summarize_event, summarize_incident_detail,
+    summarize_incident_escalation, summarize_incidents, summarize_integration, summarize_monitors,
+    summarize_query, summarize_report, summarize_services, summarize_targets, summarize_timeline,
+    summarize_webhook_delivery, tool_manifest,
 };
 use clap::{Args, Parser, Subcommand};
 use serde_json::{Value, json};
@@ -45,12 +46,14 @@ enum Commands {
     Summary(WindowArgs),
     /// List target and monitor service states.
     Services(ServicesArgs),
-    /// Inspect recent errors for one service.
-    Errors(ServiceWindowArgs),
+    /// List or read recent errors.
+    Errors(ErrorsArgs),
     /// List, read, escalate, or deescalate incidents.
     Incidents(IncidentsArgs),
     /// Inspect timeline events.
     Timeline(TimelineArgs),
+    /// Read webhook delivery diagnostics.
+    WebhookDeliveries(WebhookDeliveriesArgs),
     /// List configured HTTP targets.
     Targets,
     /// List configured non-HTTP monitors.
@@ -92,6 +95,42 @@ struct ServiceWindowArgs {
     service: String,
     #[arg(long, default_value = "24h")]
     window: String,
+}
+
+#[derive(Debug, Args)]
+struct ErrorsArgs {
+    #[command(subcommand)]
+    command: ErrorsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ErrorsCommand {
+    /// List recent error groups for one service.
+    List(ServiceWindowArgs),
+    /// Read one raw error by id, including stack trace and decoded context.
+    Get(ErrorGetArgs),
+}
+
+#[derive(Debug, Args)]
+struct ErrorGetArgs {
+    error_id: String,
+}
+
+#[derive(Debug, Args)]
+struct WebhookDeliveriesArgs {
+    #[command(subcommand)]
+    command: WebhookDeliveriesCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum WebhookDeliveriesCommand {
+    /// Read one webhook delivery by stable delivery id.
+    Get(WebhookDeliveryGetArgs),
+}
+
+#[derive(Debug, Args)]
+struct WebhookDeliveryGetArgs {
+    delivery_id: String,
 }
 
 #[derive(Debug, Args)]
@@ -597,16 +636,46 @@ fn run_http_command(
                         summarize_services(value, state.as_deref())
                     })
                 }
-                Commands::Errors(args) => {
-                    let window = Window::parse(&args.window)?;
-                    let path = format!(
-                        "/api/v1/query?service={}&window={}",
-                        encode(&args.service),
-                        window.as_str()
-                    );
-                    let response = client.get_auth_json(&path)?;
-                    render("errors", client.endpoint(), response, mode, summarize_query)
-                }
+                Commands::Errors(args) => match args.command {
+                    ErrorsCommand::List(list_args) => {
+                        let window = Window::parse(&list_args.window)?;
+                        let path = format!(
+                            "/api/v1/query?service={}&window={}",
+                            encode(&list_args.service),
+                            window.as_str()
+                        );
+                        let response = client.get_auth_json(&path)?;
+                        render("errors", client.endpoint(), response, mode, summarize_query)
+                    }
+                    ErrorsCommand::Get(get_args) => {
+                        let response = client.get_auth_json(&format!(
+                            "/api/v1/errors/{}",
+                            encode(&get_args.error_id)
+                        ))?;
+                        render(
+                            "errors get",
+                            client.endpoint(),
+                            response,
+                            mode,
+                            summarize_error_detail,
+                        )
+                    }
+                },
+                Commands::WebhookDeliveries(args) => match args.command {
+                    WebhookDeliveriesCommand::Get(get_args) => {
+                        let response = client.get_auth_json(&format!(
+                            "/api/v1/webhook-deliveries/{}",
+                            encode(&get_args.delivery_id)
+                        ))?;
+                        render(
+                            "webhook-deliveries get",
+                            client.endpoint(),
+                            response,
+                            mode,
+                            summarize_webhook_delivery,
+                        )
+                    }
+                },
                 Commands::Timeline(args) => {
                     let window = Window::parse(&args.window)?;
                     let mut path = format!(

--- a/crates/canary-cli/tests/contract_parity.rs
+++ b/crates/canary-cli/tests/contract_parity.rs
@@ -3,11 +3,27 @@
 //! and an MCP tool, or an explicitly justified allowlist entry. Adding a
 //! route to `priv/openapi/openapi.json` without updating `parity_table()`
 //! below fails this test with the exact path that needs an entry.
+//!
+//! It also carries the emitted-command-grammar regression the PR #261 review
+//! required: doctor/integrate JSON payloads embed literal `canary ...`
+//! command strings as machine-executable remediation hints, and those drift
+//! silently when a CLI grammar changes underneath them (canary-932
+//! `errors <service>` -> `errors list <service>` broke six such sites). The
+//! tests below call the real payload-building functions and prove each
+//! embedded command both uses the expected grammar AND resolves as a live
+//! CLI subcommand, reusing `cli_subcommand_registered` so this can't drift
+//! back to a hardcoded string comparison.
 
-use std::{collections::BTreeSet, process::Command};
+mod support;
 
-use canary_cli::tool_manifest;
-use serde_json::Value;
+use std::{collections::BTreeSet, fs, process::Command};
+
+use canary_cli::{
+    ApiClient, Config, DEFAULT_ENDPOINT, IntegrationEnrollRequest, IntegrationInput,
+    integration_enroll, integration_patch, integration_plan, next_operator_action, tool_manifest,
+};
+use serde_json::{Value, json};
+use support::{FixtureResponse, FixtureServer};
 
 const OPENAPI_JSON: &str = include_str!("../../../priv/openapi/openapi.json");
 
@@ -269,4 +285,176 @@ fn cli_subcommand_registered(cli_path: &[&str]) -> Result<bool, Box<dyn std::err
         .args(&args)
         .output()?;
     Ok(output.status.success())
+}
+
+// --- Emitted-command-grammar regression -----------------------------------
+//
+// Each test below drives one real payload-building function with the
+// smallest input that reaches its embedded `canary ...` command string, then
+// proves that string both contains the expected grammar and resolves as a
+// live CLI subcommand.
+
+#[test]
+fn integration_plan_verify_command_uses_registered_cli_grammar()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_project_dir("plan-verify")?;
+    fs::write(root.join("index.html"), "<h1>static</h1>")?;
+
+    let plan = integration_plan(&IntegrationInput {
+        target: root.clone(),
+        service: Some("qa-smoke".to_owned()),
+        production_url: Some("https://qa-smoke.example.com".to_owned()),
+        platform_project: None,
+        endpoint: DEFAULT_ENDPOINT.to_owned(),
+    })?;
+    let verify = plan["commands"]["verify"]
+        .as_str()
+        .ok_or("missing commands.verify")?;
+    assert_command_uses_registered_cli_grammar(verify, "canary errors list ", &["errors", "list"])?;
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn integration_patch_next_steps_and_receipt_use_registered_cli_grammar()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_project_dir("patch-next-steps")?;
+    fs::write(
+        root.join("package.json"),
+        r#"{"dependencies":{"next":"15.0.0"}}"#,
+    )?;
+
+    let patched = integration_patch(&IntegrationInput {
+        target: root.clone(),
+        service: Some("qa-smoke".to_owned()),
+        production_url: Some("https://qa-smoke.example.com".to_owned()),
+        platform_project: None,
+        endpoint: DEFAULT_ENDPOINT.to_owned(),
+    })?;
+
+    let next_steps = patched["next_steps"]
+        .as_array()
+        .ok_or("missing next_steps")?;
+    let deploy_step = next_steps
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|step| step.contains("canary errors"))
+        .ok_or("no next_steps entry mentions canary errors")?;
+    assert_command_uses_registered_cli_grammar(
+        deploy_step,
+        "canary errors list <service>",
+        &["errors", "list"],
+    )?;
+
+    // `integration_patch` also writes the on-disk `.canary/integration.json`
+    // receipt with its own independently-built verification_commands.
+    let receipt: Value =
+        serde_json::from_str(&fs::read_to_string(root.join(".canary/integration.json"))?)?;
+    let verification_commands = receipt["verification_commands"]
+        .as_array()
+        .ok_or("missing verification_commands")?;
+    let errors_command = verification_commands
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|command| command.contains("canary errors"))
+        .ok_or("no verification_commands entry mentions canary errors")?;
+    assert_command_uses_registered_cli_grammar(
+        errors_command,
+        "canary errors list ",
+        &["errors", "list"],
+    )?;
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn integration_enroll_receipt_verification_commands_use_registered_cli_grammar()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::created(json!({
+        "target": {"id": "TGT-qa-smoke"},
+        "api_key": {"id": "KEY-qa-smoke", "key": "sk_live_redacted_for_test"}
+    }))])?;
+    let root = temp_project_dir("enroll-receipt")?;
+    let client = ApiClient::new(Config::resolve(
+        Some(server.endpoint().to_owned()),
+        Some("admin-key".to_owned()),
+        None,
+    )?)?;
+
+    integration_enroll(
+        &client,
+        &IntegrationEnrollRequest {
+            service: "qa-smoke".to_owned(),
+            url: "https://qa-smoke.example.com/api/health".to_owned(),
+            environment: "production".to_owned(),
+            interval_ms: None,
+            redact: true,
+            receipt_root: Some(root.clone()),
+        },
+    )?;
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+
+    let receipt: Value =
+        serde_json::from_str(&fs::read_to_string(root.join(".canary/integration.json"))?)?;
+    let verification_commands = receipt["verification_commands"]
+        .as_array()
+        .ok_or("missing verification_commands")?;
+    let errors_command = verification_commands
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|command| command.contains("canary errors"))
+        .ok_or("no verification_commands entry mentions canary errors")?;
+    assert_command_uses_registered_cli_grammar(
+        errors_command,
+        "canary errors list ",
+        &["errors", "list"],
+    )?;
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn doctor_next_operator_action_error_hint_uses_registered_cli_grammar()
+-> Result<(), Box<dyn std::error::Error>> {
+    let witness = json!({"status": "observed", "state": "up"});
+    let hint = next_operator_action("degraded", &witness, 0, 0, 3, 0, None);
+    assert_command_uses_registered_cli_grammar(
+        &hint,
+        "canary errors list canary --window 1h --json",
+        &["errors", "list"],
+    )
+}
+
+/// Assert one emitted command string both contains the expected grammar and
+/// resolves as a live CLI subcommand -- the latter check is what makes this
+/// structurally resistant to renaming the subcommand out from under a
+/// hardcoded string comparison.
+fn assert_command_uses_registered_cli_grammar(
+    text: &str,
+    needle: &str,
+    cli_path: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    assert!(
+        text.contains(needle),
+        "expected {text:?} to contain {needle:?}"
+    );
+    assert!(
+        cli_subcommand_registered(cli_path)?,
+        "canary {} is not a registered CLI subcommand",
+        cli_path.join(" ")
+    );
+    Ok(())
+}
+
+fn temp_project_dir(name: &str) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("canary-cli-contract-parity-{name}-{nonce}"));
+    fs::create_dir_all(&root)?;
+    Ok(root)
 }

--- a/crates/canary-cli/tests/contract_parity.rs
+++ b/crates/canary-cli/tests/contract_parity.rs
@@ -1,0 +1,272 @@
+//! Contract-parity guard (canary-932 child 4): every agent-relevant `GET`
+//! operation in the checked-in OpenAPI document must have both a CLI command
+//! and an MCP tool, or an explicitly justified allowlist entry. Adding a
+//! route to `priv/openapi/openapi.json` without updating `parity_table()`
+//! below fails this test with the exact path that needs an entry.
+
+use std::{collections::BTreeSet, process::Command};
+
+use canary_cli::tool_manifest;
+use serde_json::Value;
+
+const OPENAPI_JSON: &str = include_str!("../../../priv/openapi/openapi.json");
+
+/// One parity table entry for one checked-in `GET` operation.
+enum Coverage {
+    /// Reachable from both the CLI and the MCP tool surface.
+    Covered {
+        /// Subcommand path as typed after `canary`, e.g. `["errors", "get"]`.
+        cli_path: &'static [&'static str],
+        /// MCP tool name; must be registered in `tool_manifest()`.
+        mcp_tool: &'static str,
+    },
+    /// Deliberately excluded from CLI/MCP coverage, with a one-line reason.
+    Allowlisted { reason: &'static str },
+}
+
+/// Declarative path -> coverage table. Every `GET` path in the checked-in
+/// OpenAPI document must appear here exactly once.
+fn parity_table() -> Vec<(&'static str, Coverage)> {
+    use Coverage::{Allowlisted, Covered};
+    vec![
+        (
+            "/healthz",
+            Allowlisted {
+                reason: "infra liveness probe surfaced via `canary doctor`'s reachability.healthz, not a standalone agent read model",
+            },
+        ),
+        (
+            "/readyz",
+            Allowlisted {
+                reason: "infra readiness probe surfaced via `canary doctor`'s reachability.readyz, not a standalone agent read model",
+            },
+        ),
+        (
+            "/api/v1/openapi.json",
+            Allowlisted {
+                reason: "the contract document itself, not an agent read-model route",
+            },
+        ),
+        (
+            "/metrics",
+            Allowlisted {
+                reason: "admin-only Prometheus scrape target; operator surface, not an agent coordination-loop surface",
+            },
+        ),
+        (
+            "/api/v1/query",
+            Covered {
+                cli_path: &["errors", "list"],
+                mcp_tool: "canary_errors",
+            },
+        ),
+        (
+            "/api/v1/errors/{id}",
+            Covered {
+                cli_path: &["errors", "get"],
+                mcp_tool: "canary_error_get",
+            },
+        ),
+        (
+            "/api/v1/report",
+            Covered {
+                cli_path: &["summary"],
+                mcp_tool: "canary_summary",
+            },
+        ),
+        (
+            "/api/v1/timeline",
+            Covered {
+                cli_path: &["timeline"],
+                mcp_tool: "canary_timeline",
+            },
+        ),
+        (
+            "/api/v1/webhook-deliveries",
+            Allowlisted {
+                reason: "list/paginate-by-filter surface not required by the agent replay loop (agents dedupe by x-delivery-id and drill into the singular route below); canary-932 follow-up if a `canary webhook-deliveries list` use case emerges",
+            },
+        ),
+        (
+            "/api/v1/webhook-deliveries/{delivery_id}",
+            Covered {
+                cli_path: &["webhook-deliveries", "get"],
+                mcp_tool: "canary_webhook_delivery_get",
+            },
+        ),
+        (
+            "/api/v1/status",
+            Covered {
+                cli_path: &["services"],
+                mcp_tool: "canary_services",
+            },
+        ),
+        (
+            "/api/v1/health-status",
+            Allowlisted {
+                reason: "distinct per-target/monitor state feed with no dedicated CLI/MCP surface yet; genuine gap, out of this ticket's error/webhook-delivery drill-down scope, flagged as a canary-932 follow-up",
+            },
+        ),
+        (
+            "/api/v1/targets/{id}/checks",
+            Allowlisted {
+                reason: "per-target probe-check history drill-down; genuine gap, out of this ticket's scope, flagged as a canary-932 follow-up",
+            },
+        ),
+        (
+            "/api/v1/incidents",
+            Covered {
+                cli_path: &["incidents", "list"],
+                mcp_tool: "canary_incidents",
+            },
+        ),
+        (
+            "/api/v1/incidents/{id}",
+            Covered {
+                cli_path: &["incidents", "get"],
+                mcp_tool: "canary_incident_get",
+            },
+        ),
+        (
+            "/api/v1/incidents/{incident_id}/annotations",
+            Allowlisted {
+                reason: "functionally superseded by the generic `/api/v1/annotations?subject_type=incident&subject_id=...` route, already covered by `canary annotations list`/`canary_annotations_list`",
+            },
+        ),
+        (
+            "/api/v1/groups/{group_hash}/annotations",
+            Allowlisted {
+                reason: "functionally superseded by the generic `/api/v1/annotations?subject_type=error_group&subject_id=...` route, already covered by `canary annotations list`/`canary_annotations_list`",
+            },
+        ),
+        (
+            "/api/v1/annotations",
+            Covered {
+                cli_path: &["annotations", "list"],
+                mcp_tool: "canary_annotations_list",
+            },
+        ),
+        (
+            "/api/v1/targets",
+            Covered {
+                cli_path: &["targets"],
+                mcp_tool: "canary_targets",
+            },
+        ),
+        (
+            "/api/v1/monitors",
+            Covered {
+                cli_path: &["monitors"],
+                mcp_tool: "canary_monitors",
+            },
+        ),
+        (
+            "/api/v1/webhooks",
+            Allowlisted {
+                reason: "admin-only webhook subscription listing, used internally by doctor/integration-status probes; no standalone agent read-model use case identified yet",
+            },
+        ),
+        (
+            "/api/v1/keys",
+            Allowlisted {
+                reason: "admin-only API key listing; key management is an operator concern kept out of the agent coordination-loop surface by design",
+            },
+        ),
+        (
+            "/api/v1/claims",
+            Covered {
+                cli_path: &["claims", "list"],
+                mcp_tool: "canary_claims_list",
+            },
+        ),
+        (
+            "/api/v1/claims/{id}",
+            Covered {
+                cli_path: &["claims", "get"],
+                mcp_tool: "canary_claim_get",
+            },
+        ),
+    ]
+}
+
+#[test]
+fn every_get_operation_has_cli_and_mcp_coverage_or_a_justified_allowlist_entry()
+-> Result<(), Box<dyn std::error::Error>> {
+    let document: Value = serde_json::from_str(OPENAPI_JSON)?;
+    let paths = document["paths"]
+        .as_object()
+        .ok_or_else(|| std::io::Error::other("openapi document has no paths object"))?;
+    let table = parity_table();
+
+    // Every checked-in GET path must have exactly one table entry -- this is
+    // the mechanism that fails CI the moment a route is added without an
+    // accounting decision.
+    let table_keys: BTreeSet<&str> = table.iter().map(|(path, _)| *path).collect();
+    let get_paths: BTreeSet<&str> = paths
+        .iter()
+        .filter(|(_, methods)| methods.get("get").is_some())
+        .map(|(path, _)| path.as_str())
+        .collect();
+
+    let missing_from_table: Vec<&str> = get_paths.difference(&table_keys).copied().collect();
+    assert!(
+        missing_from_table.is_empty(),
+        "GET operations added to priv/openapi/openapi.json with no parity_table() entry in \
+         crates/canary-cli/tests/contract_parity.rs -- add a Covered{{cli_path, mcp_tool}} entry \
+         or an Allowlisted{{reason}} entry for: {missing_from_table:?}"
+    );
+
+    let stale_in_table: Vec<&str> = table_keys.difference(&get_paths).copied().collect();
+    assert!(
+        stale_in_table.is_empty(),
+        "parity_table() entries reference GET operations no longer in priv/openapi/openapi.json; \
+         remove the stale entries: {stale_in_table:?}"
+    );
+
+    let mcp_tool_names: BTreeSet<&str> =
+        tool_manifest().into_iter().map(|tool| tool.name).collect();
+
+    let mut gaps = Vec::new();
+    for (path, coverage) in &table {
+        match coverage {
+            Coverage::Allowlisted { reason } => {
+                assert!(
+                    !reason.trim().is_empty(),
+                    "{path}: allowlist entry needs a non-empty one-line justification"
+                );
+            }
+            Coverage::Covered { cli_path, mcp_tool } => {
+                if !mcp_tool_names.contains(mcp_tool) {
+                    gaps.push(format!(
+                        "{path}: MCP tool `{mcp_tool}` is not registered in tool_manifest()"
+                    ));
+                }
+                if !cli_subcommand_registered(cli_path)? {
+                    gaps.push(format!(
+                        "{path}: CLI command `canary {}` is not registered",
+                        cli_path.join(" ")
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        gaps.is_empty(),
+        "contract-parity guard found gaps: {gaps:#?}"
+    );
+
+    Ok(())
+}
+
+/// Prove a CLI subcommand path is live by asking the real compiled binary
+/// for its `--help`. Clap resolves `--help` before enforcing required
+/// positionals/subcommands, so this succeeds for any registered path and
+/// fails (nonzero exit) the moment a subcommand is renamed or removed.
+fn cli_subcommand_registered(cli_path: &[&str]) -> Result<bool, Box<dyn std::error::Error>> {
+    let mut args: Vec<&str> = cli_path.to_vec();
+    args.push("--help");
+    let output = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args(&args)
+        .output()?;
+    Ok(output.status.success())
+}

--- a/crates/canary-cli/tests/fixtures.rs
+++ b/crates/canary-cli/tests/fixtures.rs
@@ -1,9 +1,10 @@
 //! Fixture-backed parser tests for the Canary CLI.
 
 use canary_cli::{
-    dogfood_strict_failure_count, summarize_doctor, summarize_dogfood, summarize_incident_detail,
-    summarize_incidents, summarize_monitors, summarize_query, summarize_report, summarize_targets,
-    summarize_timeline, tool_manifest,
+    dogfood_strict_failure_count, summarize_doctor, summarize_dogfood, summarize_error_detail,
+    summarize_incident_detail, summarize_incidents, summarize_monitors, summarize_query,
+    summarize_report, summarize_targets, summarize_timeline, summarize_webhook_delivery,
+    tool_manifest,
 };
 use serde_json::{Value, json};
 
@@ -90,6 +91,62 @@ fn parses_timeline_fixture() -> Result<(), Box<dyn std::error::Error>> {
     let lines = summarize_timeline(&value);
     assert!(lines.iter().any(|line| line == "events: 2"));
     Ok(())
+}
+
+#[test]
+fn summarizes_error_detail_with_stack_trace() {
+    let value = json!({
+        "summary": "error ERR-loop: api NullPointerException",
+        "id": "ERR-loop",
+        "service": "api",
+        "error_class": "NullPointerException",
+        "message": "boom",
+        "message_template": null,
+        "stack_trace": "at fn()\nat main()",
+        "context": null,
+        "severity": "error",
+        "environment": "production",
+        "group_hash": "GRP-abc",
+        "created_at": "2026-06-14T02:07:53Z",
+        "group": null,
+        "incident_ids": ["INC-loop"]
+    });
+
+    let lines = summarize_error_detail(&value);
+    assert!(lines.iter().any(|line| line == "id: ERR-loop"));
+    assert!(lines.iter().any(|line| line == "stack_trace: present"));
+    assert!(lines.iter().any(|line| line == "incident_ids: 1"));
+}
+
+#[test]
+fn summarizes_webhook_delivery() {
+    let value = json!({
+        "delivery_id": "WHK-delivery-1",
+        "webhook_id": "WHK-sub-1",
+        "tenant_id": "TENANT-bootstrap",
+        "project_id": "PROJECT-bootstrap",
+        "service": "api",
+        "event": "incident.opened",
+        "status": "delivered",
+        "attempt_count": 2,
+        "reason": null,
+        "first_attempt_at": "2026-06-14T02:07:00Z",
+        "last_attempt_at": "2026-06-14T02:07:05Z",
+        "delivered_at": "2026-06-14T02:07:05Z",
+        "discarded_at": null,
+        "completed_at": "2026-06-14T02:07:05Z",
+        "created_at": "2026-06-14T02:06:55Z",
+        "updated_at": "2026-06-14T02:07:05Z"
+    });
+
+    let lines = summarize_webhook_delivery(&value);
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "delivery_id: WHK-delivery-1")
+    );
+    assert!(lines.iter().any(|line| line == "status: delivered"));
+    assert!(lines.iter().any(|line| line == "attempt_count: 2"));
 }
 
 #[test]
@@ -373,6 +430,8 @@ fn mcp_manifest_exposes_operator_drilldowns() {
         "canary_dogfood_value",
         "canary_witness",
         "canary_dr_status",
+        "canary_error_get",
+        "canary_webhook_delivery_get",
     ] {
         assert!(names.contains(name), "missing {name}");
     }

--- a/crates/canary-cli/tests/mcp_stdio.rs
+++ b/crates/canary-cli/tests/mcp_stdio.rs
@@ -1,16 +1,16 @@
 //! Stdio MCP smoke tests for the Canary CLI adapter.
 
+mod support;
+
 use std::{
     collections::BTreeSet,
-    io::{Read, Write},
-    net::{TcpListener, TcpStream},
+    io::Write,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    thread,
-    time::{Duration, Instant},
 };
 
 use serde_json::{Value, json};
+use support::{FixtureResponse, FixtureServer};
 
 #[test]
 fn mcp_stdio_lists_and_calls_cli_backed_tools() -> Result<(), Box<dyn std::error::Error>> {
@@ -696,175 +696,6 @@ fn repo_root() -> Result<PathBuf, Box<dyn std::error::Error>> {
         .nth(2)
         .map(Path::to_path_buf)
         .ok_or_else(|| std::io::Error::other("repo root not found").into())
-}
-
-#[derive(Debug)]
-struct FixtureServer {
-    endpoint: String,
-    handle: thread::JoinHandle<Result<Vec<RecordedRequest>, String>>,
-}
-
-impl FixtureServer {
-    fn spawn(responses: Vec<FixtureResponse>) -> Result<Self, Box<dyn std::error::Error>> {
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        listener.set_nonblocking(true)?;
-        let endpoint = format!("http://{}", listener.local_addr()?);
-        let handle = thread::spawn(move || serve_fixture(listener, responses));
-        Ok(Self { endpoint, handle })
-    }
-
-    fn endpoint(&self) -> &str {
-        &self.endpoint
-    }
-
-    fn join(self) -> Result<Vec<RecordedRequest>, Box<dyn std::error::Error>> {
-        let result = self
-            .handle
-            .join()
-            .map_err(|_| std::io::Error::other("fixture server thread failed"))?;
-        result.map_err(|message| std::io::Error::other(message).into())
-    }
-}
-
-#[derive(Debug, Clone)]
-struct FixtureResponse {
-    status: u16,
-    body: Value,
-}
-
-impl FixtureResponse {
-    fn ok(body: Value) -> Self {
-        Self { status: 200, body }
-    }
-
-    fn created(body: Value) -> Self {
-        Self { status: 201, body }
-    }
-}
-
-#[derive(Debug)]
-struct RecordedRequest {
-    method: String,
-    path: String,
-    authorization: Option<String>,
-    body: String,
-}
-
-fn serve_fixture(
-    listener: TcpListener,
-    responses: Vec<FixtureResponse>,
-) -> Result<Vec<RecordedRequest>, String> {
-    let mut requests = Vec::new();
-    let deadline = Instant::now() + Duration::from_secs(10);
-    for response in responses {
-        loop {
-            match listener.accept() {
-                Ok((mut stream, _addr)) => {
-                    let request = read_request(&mut stream).map_err(|error| error.to_string())?;
-                    write_response(&mut stream, response).map_err(|error| error.to_string())?;
-                    requests.push(request);
-                    break;
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    if Instant::now() > deadline {
-                        return Err(format!(
-                            "timed out waiting for request {}",
-                            requests.len() + 1
-                        ));
-                    }
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Err(error) => return Err(error.to_string()),
-            }
-        }
-    }
-    Ok(requests)
-}
-
-fn read_request(stream: &mut TcpStream) -> std::io::Result<RecordedRequest> {
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let mut bytes = Vec::new();
-    let mut header_end = None;
-    let mut content_length = 0;
-    loop {
-        let mut buffer = [0_u8; 1024];
-        let count = stream.read(&mut buffer)?;
-        if count == 0 {
-            break;
-        }
-        bytes.extend_from_slice(&buffer[..count]);
-        if header_end.is_none()
-            && let Some(position) = find_header_end(&bytes)
-        {
-            content_length = parse_content_length(&bytes[..position]);
-            header_end = Some(position);
-        }
-        if let Some(position) = header_end
-            && bytes.len() >= position + 4 + content_length
-        {
-            break;
-        }
-    }
-
-    let text = String::from_utf8_lossy(&bytes).to_string();
-    let mut lines = text.split("\r\n");
-    let request_line = lines.next().unwrap_or_default();
-    let mut request_parts = request_line.split_whitespace();
-    let method = request_parts.next().unwrap_or_default().to_owned();
-    let path = request_parts.next().unwrap_or_default().to_owned();
-    let authorization = text
-        .split("\r\n")
-        .find_map(|line| {
-            line.strip_prefix("authorization: ")
-                .or_else(|| line.strip_prefix("Authorization: "))
-        })
-        .map(str::to_owned);
-    let body = header_end
-        .and_then(|position| bytes.get(position + 4..))
-        .map(|body| String::from_utf8_lossy(body).to_string())
-        .unwrap_or_default();
-
-    Ok(RecordedRequest {
-        method,
-        path,
-        authorization,
-        body,
-    })
-}
-
-fn write_response(stream: &mut TcpStream, response: FixtureResponse) -> std::io::Result<()> {
-    let body = response.body.to_string();
-    let reason = match response.status {
-        200 => "OK",
-        201 => "Created",
-        _ => "OK",
-    };
-    write!(
-        stream,
-        "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-        response.status,
-        reason,
-        body.len(),
-        body
-    )
-}
-
-fn find_header_end(bytes: &[u8]) -> Option<usize> {
-    bytes.windows(4).position(|window| window == b"\r\n\r\n")
-}
-
-fn parse_content_length(headers: &[u8]) -> usize {
-    String::from_utf8_lossy(headers)
-        .split("\r\n")
-        .find_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            if name.eq_ignore_ascii_case("content-length") {
-                value.trim().parse::<usize>().ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or(0)
 }
 
 fn incident_detail_body() -> Value {

--- a/crates/canary-cli/tests/mcp_stdio.rs
+++ b/crates/canary-cli/tests/mcp_stdio.rs
@@ -175,6 +175,180 @@ fn cli_incidents_get_reads_incident_detail() -> Result<(), Box<dyn std::error::E
 }
 
 #[test]
+fn cli_errors_get_reads_error_detail_matching_http_route_body()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(error_detail_body())])?;
+    let response = run_cli_json(&server, ["errors", "get", "ERR-loop"])?;
+
+    assert_eq!(response["command"], json!("errors get"));
+    assert_eq!(response["response"], error_detail_body());
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].path, "/api/v1/errors/ERR-loop");
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer read-key")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn cli_webhook_deliveries_get_reads_delivery_matching_http_route_body()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(webhook_delivery_body())])?;
+    let response = run_cli_json(&server, ["webhook-deliveries", "get", "WHK-delivery-1"])?;
+
+    assert_eq!(response["command"], json!("webhook-deliveries get"));
+    assert_eq!(response["response"], webhook_delivery_body());
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(
+        requests[0].path,
+        "/api/v1/webhook-deliveries/WHK-delivery-1"
+    );
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer read-key")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mcp_stdio_error_get_tool_reads_error_detail_with_read_only_key()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(error_detail_body())])?;
+    let repo_root = repo_root()?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args(["--endpoint", server.endpoint(), "mcp-server"])
+        .current_dir(&repo_root)
+        .env("CANARY_READ_KEY", "mcp-read-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("child stdin unavailable"))?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_error_get",
+                "arguments": {"error_id": "ERR-loop"}
+            }
+        })
+    )?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let responses = String::from_utf8(output.stdout)?
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["command"],
+        json!("canary_error_get")
+    );
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["response"],
+        error_detail_body()
+    );
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/api/v1/errors/ERR-loop");
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer mcp-read-key")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mcp_stdio_webhook_delivery_get_tool_reads_delivery_with_read_only_key()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = FixtureServer::spawn(vec![FixtureResponse::ok(webhook_delivery_body())])?;
+    let repo_root = repo_root()?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_canary"))
+        .args(["--endpoint", server.endpoint(), "mcp-server"])
+        .current_dir(&repo_root)
+        .env("CANARY_READ_KEY", "mcp-read-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("child stdin unavailable"))?;
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "canary_webhook_delivery_get",
+                "arguments": {"delivery_id": "WHK-delivery-1"}
+            }
+        })
+    )?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let responses = String::from_utf8(output.stdout)?
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["command"],
+        json!("canary_webhook_delivery_get")
+    );
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["response"],
+        webhook_delivery_body()
+    );
+
+    let requests = server.join()?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/api/v1/webhook-deliveries/WHK-delivery-1"
+    );
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer mcp-read-key")
+    );
+
+    Ok(())
+}
+
+#[test]
 fn cli_timeline_two_page_cursor_walk_returns_ordered_events_without_gap_or_duplicate()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = FixtureServer::spawn(vec![
@@ -712,6 +886,46 @@ fn incident_detail_body() -> Value {
         "annotations_truncated": false,
         "claims": [],
         "recent_timeline_events": []
+    })
+}
+
+fn error_detail_body() -> Value {
+    json!({
+        "summary": "error ERR-loop: api NullPointerException",
+        "id": "ERR-loop",
+        "service": "api",
+        "error_class": "NullPointerException",
+        "message": "boom",
+        "message_template": null,
+        "stack_trace": "at fn()\nat main()",
+        "context": null,
+        "severity": "error",
+        "environment": "production",
+        "group_hash": "GRP-abc",
+        "created_at": "2026-06-14T02:07:53Z",
+        "group": null,
+        "incident_ids": ["INC-loop"]
+    })
+}
+
+fn webhook_delivery_body() -> Value {
+    json!({
+        "delivery_id": "WHK-delivery-1",
+        "webhook_id": "WHK-sub-1",
+        "tenant_id": "TENANT-bootstrap",
+        "project_id": "PROJECT-bootstrap",
+        "service": "api",
+        "event": "incident.opened",
+        "status": "delivered",
+        "attempt_count": 2,
+        "reason": null,
+        "first_attempt_at": "2026-06-14T02:07:00Z",
+        "last_attempt_at": "2026-06-14T02:07:05Z",
+        "delivered_at": "2026-06-14T02:07:05Z",
+        "discarded_at": null,
+        "completed_at": "2026-06-14T02:07:05Z",
+        "created_at": "2026-06-14T02:06:55Z",
+        "updated_at": "2026-06-14T02:07:05Z"
     })
 }
 

--- a/crates/canary-cli/tests/support/mod.rs
+++ b/crates/canary-cli/tests/support/mod.rs
@@ -1,0 +1,188 @@
+//! Shared test-only fixture HTTP server, reused across the CLI's integration
+//! test binaries (`mcp_stdio.rs`, `contract_parity.rs`). Each `tests/*.rs`
+//! file compiles as its own crate, so this lives under `tests/support/mod.rs`
+//! (not `tests/support.rs`) to opt out of being treated as its own test
+//! binary while staying importable via `mod support;`.
+//!
+//! Not every consumer uses every item (e.g. `contract_parity.rs` only needs
+//! `FixtureResponse::created` and `RecordedRequest.len()`), so dead-code
+//! warnings here are per-consumer noise, not a real unused-surface signal.
+#![allow(dead_code)]
+
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde_json::Value;
+
+#[derive(Debug)]
+pub struct FixtureServer {
+    endpoint: String,
+    handle: thread::JoinHandle<Result<Vec<RecordedRequest>, String>>,
+}
+
+impl FixtureServer {
+    pub fn spawn(responses: Vec<FixtureResponse>) -> Result<Self, Box<dyn std::error::Error>> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let endpoint = format!("http://{}", listener.local_addr()?);
+        let handle = thread::spawn(move || serve_fixture(listener, responses));
+        Ok(Self { endpoint, handle })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub fn join(self) -> Result<Vec<RecordedRequest>, Box<dyn std::error::Error>> {
+        let result = self
+            .handle
+            .join()
+            .map_err(|_| std::io::Error::other("fixture server thread failed"))?;
+        result.map_err(|message| std::io::Error::other(message).into())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FixtureResponse {
+    status: u16,
+    body: Value,
+}
+
+impl FixtureResponse {
+    pub fn ok(body: Value) -> Self {
+        Self { status: 200, body }
+    }
+
+    pub fn created(body: Value) -> Self {
+        Self { status: 201, body }
+    }
+}
+
+#[derive(Debug)]
+pub struct RecordedRequest {
+    pub method: String,
+    pub path: String,
+    pub authorization: Option<String>,
+    pub body: String,
+}
+
+fn serve_fixture(
+    listener: TcpListener,
+    responses: Vec<FixtureResponse>,
+) -> Result<Vec<RecordedRequest>, String> {
+    let mut requests = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    for response in responses {
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _addr)) => {
+                    let request = read_request(&mut stream).map_err(|error| error.to_string())?;
+                    write_response(&mut stream, response).map_err(|error| error.to_string())?;
+                    requests.push(request);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() > deadline {
+                        return Err(format!(
+                            "timed out waiting for request {}",
+                            requests.len() + 1
+                        ));
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+    }
+    Ok(requests)
+}
+
+fn read_request(stream: &mut TcpStream) -> std::io::Result<RecordedRequest> {
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let mut bytes = Vec::new();
+    let mut header_end = None;
+    let mut content_length = 0;
+    loop {
+        let mut buffer = [0_u8; 1024];
+        let count = stream.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+        if header_end.is_none()
+            && let Some(position) = find_header_end(&bytes)
+        {
+            content_length = parse_content_length(&bytes[..position]);
+            header_end = Some(position);
+        }
+        if let Some(position) = header_end
+            && bytes.len() >= position + 4 + content_length
+        {
+            break;
+        }
+    }
+
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().unwrap_or_default().to_owned();
+    let path = request_parts.next().unwrap_or_default().to_owned();
+    let authorization = text
+        .split("\r\n")
+        .find_map(|line| {
+            line.strip_prefix("authorization: ")
+                .or_else(|| line.strip_prefix("Authorization: "))
+        })
+        .map(str::to_owned);
+    let body = header_end
+        .and_then(|position| bytes.get(position + 4..))
+        .map(|body| String::from_utf8_lossy(body).to_string())
+        .unwrap_or_default();
+
+    Ok(RecordedRequest {
+        method,
+        path,
+        authorization,
+        body,
+    })
+}
+
+fn write_response(stream: &mut TcpStream, response: FixtureResponse) -> std::io::Result<()> {
+    let body = response.body.to_string();
+    let reason = match response.status {
+        200 => "OK",
+        201 => "Created",
+        _ => "OK",
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        response.status,
+        reason,
+        body.len(),
+        body
+    )
+}
+
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn parse_content_length(headers: &[u8]) -> usize {
+    String::from_utf8_lossy(headers)
+        .split("\r\n")
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}

--- a/docs/agent-inspection-cli.md
+++ b/docs/agent-inspection-cli.md
@@ -41,13 +41,15 @@ without a key that matches the command's authority model.
 ```bash
 bin/canary summary --window 24h
 bin/canary services --state down --json
-bin/canary errors chrondle --window 24h
+bin/canary errors list chrondle --window 24h
+bin/canary errors get ERR-example --json  # raw error detail: stack trace, decoded context, correlated incident_ids
 bin/canary incidents list --open
 bin/canary incidents get INC-example --json
 bin/canary incidents escalate INC-example --reason "iteration guard exhausted" --owner bitterblossom/canary-triage --purpose triage_escalation --idempotency-key run-1:INC-example:escalate
 bin/canary incidents deescalate INC-example --owner operator@example.com --reason "false positive"
 bin/canary timeline --service chrondle --window 7d --limit 20
 bin/canary timeline --service chrondle --window 7d --limit 20 --cursor <cursor-from-prior-response>  # page forward; --after takes precedence over --cursor if both are given
+bin/canary webhook-deliveries get WHK-delivery-example --json  # dispute/diagnostic drill-down after deduplicating by x-delivery-id
 bin/canary claims list --subject-type incident --subject-id INC-example --json
 bin/canary claims claim --subject-type incident --subject-id INC-example --owner codex --purpose "verify fix" --json
 bin/canary annotations list --subject-type incident --subject-id INC-example --json

--- a/docs/canary-witness.md
+++ b/docs/canary-witness.md
@@ -116,7 +116,7 @@ Agents should start with:
 
 ```bash
 bin/canary doctor
-bin/canary errors canary --window 1h
+bin/canary errors list canary --window 1h
 ```
 
 `doctor` reports the external witness next to the self-target/readback view. If

--- a/docs/dogfood-watchmen-design.md
+++ b/docs/dogfood-watchmen-design.md
@@ -102,7 +102,7 @@ The user-facing shape should be:
 ```bash
 canary summary --window 24h
 canary services --state unhealthy --json
-canary errors chrondle --window 24h
+canary errors list chrondle --window 24h
 canary incidents --open
 canary dogfood audit --strict
 canary integrate plan --scope misty-step --project vanity

--- a/docs/upgrade-and-rollback.md
+++ b/docs/upgrade-and-rollback.md
@@ -35,7 +35,7 @@ scripts — the design is intentionally simpler than a clustered system.
    Also check for `service=canary` errors in the post-deploy window:
 
    ```bash
-   bin/canary errors canary --window 1h
+   bin/canary errors list canary --window 1h
    ```
 
 ## Schema Migrations

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -135,6 +135,36 @@
       "name": "canary_timeline"
     },
     {
+      "description": "Read one raw error by id, including stack trace and decoded context. Only fall through here from `canary_incident_get` when signals are truncated or raw stack traces are needed.",
+      "input_schema": {
+        "properties": {
+          "error_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error_id"
+        ],
+        "type": "object"
+      },
+      "name": "canary_error_get"
+    },
+    {
+      "description": "Inspect one webhook delivery ledger row by stable delivery id for dispute or diagnostic replay; always replay `canary_timeline` afterward since webhooks are non-authoritative wake-up hints.",
+      "input_schema": {
+        "properties": {
+          "delivery_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "delivery_id"
+        ],
+        "type": "object"
+      },
+      "name": "canary_webhook_delivery_get"
+    },
+    {
       "description": "List configured HTTP uptime targets.",
       "input_schema": {
         "properties": {},


### PR DESCRIPTION
## Summary

canary-932 ("coordination loop in anger") children 3+4. `GET /api/v1/errors/{id}` and `GET /api/v1/webhook-deliveries/{delivery_id}` already existed server-side at `read-only` scope (confirmed via `x-canary-required-scope` in the checked-in OpenAPI doc and the route registrations in `crates/canary-server/src/lib.rs`), but had no CLI or MCP surface -- a webhook-woken MCP-only agent had to drop to raw HTTP for stack traces or delivery-dispute diagnostics.

## BREAKING CHANGE

`canary errors <service>` is now `canary errors list <service>` (the bare form collided with the new `canary errors get <id>` subcommand). Scripts, agent prompts, and CI/workflow comments invoking the old bare form must add the `list` subcommand. This PR title carries `feat(cli)!:` and this repo squash-merges PR title+body into the commit, so Landmark's conventional-commit release automation will see the correct major-version signal.

### Child 3: error + webhook-delivery drill-downs

- `canary errors get <ERR-id> --json` -> `GET /api/v1/errors/{id}`; MCP `canary_error_get`.
- `canary webhook-deliveries get <delivery-id> --json` -> `GET /api/v1/webhook-deliveries/{delivery_id}`; MCP `canary_webhook_delivery_get`.
- Both use the plain read client (`Config::resolve` / `read_client()`), matching the server's `read-only` requirement -- no scope changes needed.
- Restructured `errors` into `errors list <service>` / `errors get <id>` subcommands (mirrors the existing `incidents list`/`incidents get` and `claims list`/`claims get` idiom) because a bare `errors get` collides with the pre-existing `errors <service> --window` list grammar. Updated the four docs and one workflow comment that referenced the old form.
- Regenerated `priv/mcp/canary-cli-tools.json` via `cargo run -p canary-cli --bin canary -- mcp-manifest`, guarded by the existing `checked_in_mcp_manifest_matches_generated_manifest` test.
- Oracles: `FixtureServer`-backed CLI and MCP stdio tests in `crates/canary-cli/tests/mcp_stdio.rs` assert the returned body equals the raw HTTP route body, and that a plain `read-key`/`CANARY_READ_KEY` suffices (no admin/responder-write key needed).

### Child 4: OpenAPI contract-parity guard

`crates/canary-cli/tests/contract_parity.rs` is a new test with a declarative `parity_table()`: every checked-in `GET` operation in `priv/openapi/openapi.json` must appear in the table as either `Covered { cli_path, mcp_tool }` or `Allowlisted { reason }`.

- Adding a `GET` route to the OpenAPI doc without a table entry fails with the exact path to account for.
- `Covered` entries are verified live: the MCP tool name must be registered in `tool_manifest()`, and the CLI path is proven by spawning the compiled `canary` binary and confirming `<path> --help` resolves (clap answers `--help` before enforcing required subcommands/positionals, so this works without live server state).
- Live-verified the required oracle: temporarily removing the `canary_incident_get` `ToolSpec` from `tool_manifest()` makes the guard fail with `MCP tool 'canary_incident_get' is not registered in tool_manifest()`; reverted, guard is green again.

## Allowlist contents (with justification)

| Path | Reason |
|---|---|
| `/healthz`, `/readyz` | infra liveness/readiness probes, surfaced via `canary doctor`'s `reachability.*`, not standalone agent read models |
| `/api/v1/openapi.json` | the contract document itself |
| `/metrics` | admin-only Prometheus scrape target, operator surface |
| `/api/v1/webhook-deliveries` (list) | list/paginate-by-filter surface not required by the replay loop (agents dedupe by `x-delivery-id` and drill into the singular route); follow-up if a `webhook-deliveries list` use case emerges |
| `/api/v1/health-status` | distinct per-target/monitor state feed with no dedicated CLI/MCP surface yet -- **genuine gap**, out of this ticket's scope |
| `/api/v1/targets/{id}/checks` | per-target probe-check history drill-down -- **genuine gap**, out of this ticket's scope |
| `/api/v1/incidents/{incident_id}/annotations`, `/api/v1/groups/{group_hash}/annotations` | functionally superseded by the generic `/api/v1/annotations?subject_type=...&subject_id=...` route, already covered by `canary annotations list` |
| `/api/v1/webhooks` | admin-only webhook subscription listing, used internally by doctor/integration-status probes only |
| `/api/v1/keys` | admin-only API key listing, operator concern by design |

Two entries above (`health-status`, `targets/{id}/checks`) are honest residual gaps, not "not needed" calls -- flagged for a canary-932 follow-up rather than silently expanding this ticket's scope.

## Post-review fixes (fresh-context review round 1)

The first review round returned NO-SHIP: the `errors list`/`errors get` split (needed to avoid a CLI grammar collision, see Child 3 above) left six sites still emitting the *old* `canary errors <service>` form as machine-executable remediation guidance in the product's own JSON payloads -- doctor's `next_operator_action` hint, three integration plan/patch/enroll verification-command builders, and the `canary-qa` skill's smoke command.

- Fixed all six sites to `errors list`.
- Added a regression suite (`crates/canary-cli/tests/contract_parity.rs`) that calls the *real* payload-building functions (`integration_plan`, `integration_patch`, `integration_enroll`, and the newly-`pub` `next_operator_action`) with synthetic/fixture-server-backed inputs, extracts the embedded `canary ...` command strings from their JSON/on-disk-receipt output, and proves each one both contains the expected grammar and resolves as a live CLI subcommand via the same `cli_subcommand_registered` spawn-based idiom Child 4 already established -- so this drift class can't recur silently again.
- Live-verified the regression test's own oracle: reverted the doctor hint to the old broken string, confirmed the new test failed with the exact string-mismatch message, then restored the fix and confirmed green.
- Extracted the `FixtureServer`/`FixtureResponse` test double out of `mcp_stdio.rs` into `crates/canary-cli/tests/support/mod.rs` so `contract_parity.rs` could reuse it instead of duplicating ~150 lines of TCP fixture-server code.

## Parameter-level note

The timeline `event_type` query param remains unexposed on CLI/MCP (noted in PR #260's review). This guard is operation-level (path+method), not parameter-level, so it does not catch that gap; noting it here per the dispatch brief.

## Verification

```
cargo test --workspace --locked            # 537+ tests, 0 failed
cargo clippy --workspace --all-targets --locked -- -D warnings   # clean
cargo fmt --all -- --check                 # clean
cargo run -q -p canary-cli --bin canary -- mcp-manifest | diff - priv/mcp/canary-cli-tools.json   # no drift
./bin/validate --fast   # pre-commit, green
./bin/validate --strict # pre-push, green (~7m, full Dagger gate incl. Rust workspace, TS SDK, operator scripts, Docker image build + /healthz//readyz smoke)
```

Narrow test idiom:
```
cargo test -p canary-cli --test contract_parity every_get_operation_has_cli_and_mcp_coverage_or_a_justified_allowlist_entry --locked
cargo test -p canary-cli --test mcp_stdio cli_errors_get_reads_error_detail_matching_http_route_body --locked
cargo test -p canary-cli --test mcp_stdio cli_webhook_deliveries_get_reads_delivery_matching_http_route_body --locked
```

## Boundaries respected

No server route changes, no write-surface additions. Both drill-down routes already required only `read-only` scope server-side; CLI/MCP use the existing read client, not `resolve_for_responder_write`.

Agent: builder
Agent-Surface: Claude Code
Agent-Task: canary-932 children 3+4
