### PR TITLE
fix(release): version truth — stamped artifacts, honest npm claim, changelog reconciliation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the flyctl/Docker build context to what the Dockerfile actually COPYs
+# (Cargo.toml, Cargo.lock, crates/, priv/, litestream.yml, bin/). Without this
+# file the full-history deploy checkout (fetch-depth: 0, needed for git
+# describe version stamping) ships the entire .git to the remote builder on
+# every deploy, growing unbounded.
+.git
+.github
+.githooks
+.ci
+.claude
+.agents
+.codex
+docs
+site
+test
+dagger
+clients
+target
+canary.db*
+*.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,22 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
-      - run: flyctl deploy --app "$FLY_APP" --remote-only
+      - name: Resolve deployed version
+        id: version
+        run: |
+          # The release commit (which carries the next tag) lands on a
+          # separate, later push with [skip ci] — see .github/workflows/release.yml
+          # — so this checkout is never exactly on a tag. `git describe`
+          # reports the nearest ancestor tag plus how far ahead we are, which
+          # is the truthful answer to "what is this build, relative to the
+          # last cut release".
+          version="$(git describe --tags --always --dirty 2>/dev/null || echo 0.0.0-dev)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - run: flyctl deploy --app "$FLY_APP" --remote-only --build-arg "CANARY_VERSION=${VERSION}"
         env:
           FLY_APP: ${{ vars.CANARY_FLY_APP }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ## Version reset: v1.15.0 → v0.15.0 (2026-07-08)
 
-The fleet moved to pre-stable 0.x semantics (Powder landmark-016/017): versions below 1.0.0 use Cargo-style bumps (breaking→minor, feat/fix→patch) and never cross 1.0.0 automatically; promotion to 1.0.0 is a deliberate manual tag. v0.15.0 is the same commit as v1.15.0. Earlier 1.x/2.x entries below record real history under the old numbering; their tags and GitHub releases were retired.
+The fleet moved to pre-stable 0.x semantics (Powder landmark-016/017): versions below 1.0.0 use Cargo-style bumps (breaking→minor, feat/fix→patch) and never cross 1.0.0 automatically; promotion to 1.0.0 is a deliberate manual tag. v0.15.0 is the same commit as v1.15.0. Earlier 1.x/2.x entries below record real history under the old numbering; their tags and GitHub releases were retired, so every `compare/vX.Y.Z...vX.Y.Z` link in those entries 404s today (verified 2026-07-10) — the commit and issue/PR links beside them still resolve and are the reliable way to find that history. These entries are left as originally generated, not rewritten.
 
 # [1.15.0](https://github.com/misty-step/canary/compare/v1.14.0...v1.15.0) (2026-07-08)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM rust:1.94.0-bookworm@sha256:365468470075493dc4583f47387001854321c5a8583ea9604b297e67f01c5a4f AS build
 
+# Deploy passes the CI runner's `git describe` output (a real tag, or a real
+# tag plus the commits/sha ahead of it — see .github/workflows/deploy.yml).
+# Builds outside that pipeline (this default, dagger's image smoke test)
+# report the honest, recognizable "0.0.0-dev" dev version.
+ARG CANARY_VERSION=0.0.0-dev
+ENV CANARY_VERSION=${CANARY_VERSION}
+
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -6,8 +6,20 @@ webhooks.
 
 ## Install
 
+Not yet published to npm — the `@canary-obs` org and an npm publish token are
+operator setup steps that haven't happened yet
+([`sdk-publish.yml`](../../.github/workflows/sdk-publish.yml) is ready and
+gated on the `NPM_TOKEN` secret; see
+[`docs/compatibility-policy.md`](https://github.com/misty-step/canary/blob/master/docs/compatibility-policy.md)
+for the publish plan). Until then, build and link from source:
+
 ```bash
-npm install @canary-obs/sdk
+# From the Canary repo, build the SDK:
+git clone https://github.com/misty-step/canary.git
+cd canary/clients/typescript && npm install && npm run build
+
+# In your app, link it via file: (adjust the relative path):
+npm install file:../path/to/canary/clients/typescript
 ```
 
 ## Usage

--- a/crates/canary-http/build.rs
+++ b/crates/canary-http/build.rs
@@ -1,0 +1,15 @@
+//! Stamps the crate's compiled `CANARY_VERSION` from the environment.
+//!
+//! The release pipeline (`.github/workflows/deploy.yml`) resolves the
+//! deployed commit's `git describe` output on the CI runner (where full tag
+//! history is available) and threads it through the Docker build as
+//! `--build-arg CANARY_VERSION=...`. The Dockerfile exports it as an `ENV`
+//! before `cargo build`, so it lands here as a process environment variable.
+//! Builds outside that pipeline (local `cargo build`, the strict-gate image
+//! smoke test) leave it unset and get the `0.0.0-dev` fallback.
+
+fn main() {
+    let version = std::env::var("CANARY_VERSION").unwrap_or_else(|_| "0.0.0-dev".to_string());
+    println!("cargo:rustc-env=CANARY_VERSION={version}");
+    println!("cargo:rerun-if-env-changed=CANARY_VERSION");
+}

--- a/crates/canary-http/src/public.rs
+++ b/crates/canary-http/src/public.rs
@@ -4,10 +4,30 @@
 //! router framework. The Axum handlers are thin adapters over these response
 //! builders.
 
+use std::sync::LazyLock;
+
 use serde::{Deserialize, Serialize};
 
-/// The OpenAPI document served by `GET /api/v1/openapi.json`.
+/// The OpenAPI document served by `GET /api/v1/openapi.json`, as checked in.
+/// `info.version` here is the `0.0.0-dev` placeholder; the served response
+/// stamps it with [`CANARY_VERSION`] (see [`openapi_response`]).
 pub const OPENAPI_JSON: &str = include_str!("../../../priv/openapi/openapi.json");
+
+/// Placeholder `info.version` field in the checked-in [`OPENAPI_JSON`]
+/// document, substituted with [`CANARY_VERSION`] at serve time.
+const OPENAPI_VERSION_PLACEHOLDER: &str = "\"version\": \"0.0.0-dev\"";
+
+/// The version this build was compiled with, stamped by `build.rs` from the
+/// `CANARY_VERSION` environment variable (the deploy pipeline's
+/// `git describe` output; `0.0.0-dev` for builds outside that pipeline).
+pub const CANARY_VERSION: &str = env!("CANARY_VERSION");
+
+/// [`OPENAPI_JSON`] with `info.version` replaced by [`CANARY_VERSION`],
+/// computed once on first access.
+static OPENAPI_JSON_STAMPED: LazyLock<String> = LazyLock::new(|| {
+    let stamped = format!("\"version\": \"{CANARY_VERSION}\"");
+    OPENAPI_JSON.replacen(OPENAPI_VERSION_PLACEHOLDER, &stamped, 1)
+});
 
 /// JSON content type for these public endpoints.
 pub const APPLICATION_JSON: &str = "application/json; charset=utf-8";
@@ -265,12 +285,13 @@ pub fn readyz_response(
     }
 }
 
-/// Build the `GET /api/v1/openapi.json` response.
-pub const fn openapi_response() -> PublicResponse<&'static str> {
+/// Build the `GET /api/v1/openapi.json` response, with `info.version`
+/// stamped to [`CANARY_VERSION`].
+pub fn openapi_response() -> PublicResponse<&'static str> {
     PublicResponse {
         status: 200,
         content_type: APPLICATION_JSON,
-        body: OPENAPI_JSON,
+        body: OPENAPI_JSON_STAMPED.as_str(),
     }
 }
 
@@ -468,6 +489,20 @@ mod tests {
     }
 
     #[test]
+    fn openapi_response_stamps_canary_version_and_changes_nothing_else() {
+        let response = openapi_response();
+
+        let mut served: Value = serde_json::from_str(response.body).unwrap_or(Value::Null);
+        let mut checked_in: Value = serde_json::from_str(OPENAPI_JSON).unwrap_or(Value::Null);
+
+        assert_eq!(served["info"]["version"], CANARY_VERSION);
+
+        served["info"]["version"] = Value::Null;
+        checked_in["info"]["version"] = Value::Null;
+        assert_eq!(served, checked_in);
+    }
+
+    #[test]
     fn openapi_response_serves_the_checked_in_contract_unchanged() {
         let response = openapi_response();
         let document: Value = serde_json::from_str(response.body).unwrap_or(Value::Null);
@@ -482,6 +517,7 @@ mod tests {
             document["paths"]["/api/v1/openapi.json"]["get"]["security"],
             json!([])
         );
+        assert_eq!(document["info"]["version"], CANARY_VERSION);
         assert_eq!(
             document["components"]["schemas"]["ReadyzResponse"]["required"],
             json!(["status", "checks"])

--- a/crates/canary-http/src/public.rs
+++ b/crates/canary-http/src/public.rs
@@ -4,7 +4,7 @@
 //! router framework. The Axum handlers are thin adapters over these response
 //! builders.
 
-use std::sync::LazyLock;
+use std::{fmt, sync::LazyLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -22,11 +22,49 @@ const OPENAPI_VERSION_PLACEHOLDER: &str = "\"version\": \"0.0.0-dev\"";
 /// `git describe` output; `0.0.0-dev` for builds outside that pipeline).
 pub const CANARY_VERSION: &str = env!("CANARY_VERSION");
 
+/// [`stamp_openapi_version`] failed because `doc` does not contain the
+/// expected `info.version` placeholder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenApiVersionStampError {
+    placeholder: &'static str,
+}
+
+impl fmt::Display for OpenApiVersionStampError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "checked-in openapi.json is missing the expected info.version placeholder {:?}; \
+             version stamping cannot run",
+            self.placeholder
+        )
+    }
+}
+
+impl std::error::Error for OpenApiVersionStampError {}
+
+/// Replace `info.version` in `doc` with `version`, substituting the checked-in
+/// placeholder exactly once. Errors when the placeholder is absent (for
+/// example, a reformatted `openapi.json`) instead of silently serving the
+/// un-stamped document — `canary-server`'s `CanaryServer::boot` calls this at
+/// startup so a broken placeholder match fails the process before it ever
+/// serves traffic, rather than silently serving a stale version forever.
+pub fn stamp_openapi_version(doc: &str, version: &str) -> Result<String, OpenApiVersionStampError> {
+    if !doc.contains(OPENAPI_VERSION_PLACEHOLDER) {
+        return Err(OpenApiVersionStampError {
+            placeholder: OPENAPI_VERSION_PLACEHOLDER,
+        });
+    }
+    let stamped = format!("\"version\": \"{version}\"");
+    Ok(doc.replacen(OPENAPI_VERSION_PLACEHOLDER, &stamped, 1))
+}
+
 /// [`OPENAPI_JSON`] with `info.version` replaced by [`CANARY_VERSION`],
-/// computed once on first access.
+/// computed once on first access. `CanaryServer::boot` validates the
+/// substitution succeeds before the server accepts traffic, so the fallback
+/// to the un-stamped document here is unreachable in a correctly booted
+/// process; it exists only so this static can never itself panic.
 static OPENAPI_JSON_STAMPED: LazyLock<String> = LazyLock::new(|| {
-    let stamped = format!("\"version\": \"{CANARY_VERSION}\"");
-    OPENAPI_JSON.replacen(OPENAPI_VERSION_PLACEHOLDER, &stamped, 1)
+    stamp_openapi_version(OPENAPI_JSON, CANARY_VERSION).unwrap_or_else(|_| OPENAPI_JSON.to_owned())
 });
 
 /// JSON content type for these public endpoints.
@@ -489,17 +527,44 @@ mod tests {
     }
 
     #[test]
-    fn openapi_response_stamps_canary_version_and_changes_nothing_else() {
-        let response = openapi_response();
+    fn stamp_openapi_version_replaces_only_the_version_field()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // A version distinct from the checked-in placeholder: proves the
+        // substitution actually fires, rather than the placeholder and the
+        // stamped value coincidentally matching (as they do for the real
+        // CANARY_VERSION fallback in every environment that runs `cargo
+        // test` without CANARY_VERSION set).
+        let stamped = stamp_openapi_version(OPENAPI_JSON, "v9.9.9-test")?;
 
-        let mut served: Value = serde_json::from_str(response.body).unwrap_or(Value::Null);
+        let mut served: Value = serde_json::from_str(&stamped).unwrap_or(Value::Null);
         let mut checked_in: Value = serde_json::from_str(OPENAPI_JSON).unwrap_or(Value::Null);
 
-        assert_eq!(served["info"]["version"], CANARY_VERSION);
+        assert_eq!(served["info"]["version"], "v9.9.9-test");
+        assert_ne!(served["info"]["version"], checked_in["info"]["version"]);
 
         served["info"]["version"] = Value::Null;
         checked_in["info"]["version"] = Value::Null;
         assert_eq!(served, checked_in);
+
+        Ok(())
+    }
+
+    #[test]
+    fn stamp_openapi_version_fails_loudly_without_the_placeholder() {
+        let result = stamp_openapi_version("{\"info\": {\"version\": \"1.2.3\"}}", "v9.9.9-test");
+
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert!(error.to_string().contains("0.0.0-dev"));
+        }
+    }
+
+    #[test]
+    fn openapi_response_reflects_the_compiled_canary_version() {
+        let response = openapi_response();
+        let served: Value = serde_json::from_str(response.body).unwrap_or(Value::Null);
+
+        assert_eq!(served["info"]["version"], CANARY_VERSION);
     }
 
     #[test]

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -276,7 +276,7 @@ mod tests {
     use canary_http::{
         public::{
             APPLICATION_JSON, CANARY_VERSION, DependencyStatus, OPENAPI_JSON, WorkerHealthStatus,
-            WorkerLifecycleState, WorkerPressureShape, WorkerReadyzCheck,
+            WorkerLifecycleState, WorkerPressureShape, WorkerReadyzCheck, stamp_openapi_version,
         },
         request::MAX_JSON_BODY_BYTES,
     };
@@ -1621,14 +1621,9 @@ mod tests {
 
         // The served document matches the checked-in contract byte-for-byte
         // except for `info.version`, which is stamped to CANARY_VERSION at
-        // build time (see crates/canary-http/build.rs). The checked-in
-        // `0.0.0-dev` placeholder is a fixed-length substring, so a plain
-        // substitution round-trips exactly.
-        let expected = OPENAPI_JSON.replacen(
-            "\"version\": \"0.0.0-dev\"",
-            &format!("\"version\": \"{CANARY_VERSION}\""),
-            1,
-        );
+        // build time via the same substitution the router uses (see
+        // crates/canary-http/build.rs and stamp_openapi_version).
+        let expected = stamp_openapi_version(OPENAPI_JSON, CANARY_VERSION)?;
         assert_eq!(body.as_ref(), expected.as_bytes());
 
         Ok(())

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -275,7 +275,7 @@ mod tests {
     };
     use canary_http::{
         public::{
-            APPLICATION_JSON, DependencyStatus, OPENAPI_JSON, WorkerHealthStatus,
+            APPLICATION_JSON, CANARY_VERSION, DependencyStatus, OPENAPI_JSON, WorkerHealthStatus,
             WorkerLifecycleState, WorkerPressureShape, WorkerReadyzCheck,
         },
         request::MAX_JSON_BODY_BYTES,
@@ -1606,7 +1606,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openapi_serves_the_checked_in_document_unchanged() -> Result<(), Box<dyn Error>> {
+    async fn openapi_serves_the_checked_in_document_with_stamped_version()
+    -> Result<(), Box<dyn Error>> {
         let response = public_router(PublicReadiness::ready())
             .oneshot(Request::get("/api/v1/openapi.json").body(Body::empty())?)
             .await?;
@@ -1617,7 +1618,18 @@ mod tests {
             content_type,
             Some(HeaderValue::from_static(APPLICATION_JSON))
         );
-        assert_eq!(body.as_ref(), OPENAPI_JSON.as_bytes());
+
+        // The served document matches the checked-in contract byte-for-byte
+        // except for `info.version`, which is stamped to CANARY_VERSION at
+        // build time (see crates/canary-http/build.rs). The checked-in
+        // `0.0.0-dev` placeholder is a fixed-length substring, so a plain
+        // substitution round-trips exactly.
+        let expected = OPENAPI_JSON.replacen(
+            "\"version\": \"0.0.0-dev\"",
+            &format!("\"version\": \"{CANARY_VERSION}\""),
+            1,
+        );
+        assert_eq!(body.as_ref(), expected.as_bytes());
 
         Ok(())
     }

--- a/crates/canary-server/src/runtime.rs
+++ b/crates/canary-server/src/runtime.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use axum::Router;
-use canary_http::public::DependencyStatus;
+use canary_http::public::{CANARY_VERSION, DependencyStatus, OPENAPI_JSON, stamp_openapi_version};
 use canary_ingest::{IngestConfig, IngestEffect};
 use canary_store::{IncidentCorrelation, ReadPool, Store};
 use canary_workers::retention::RetentionPolicy;
@@ -129,6 +129,14 @@ pub struct CanaryServer {
 impl CanaryServer {
     /// Open storage, run migrations, wire HTTP routes, and start webhook draining.
     pub fn boot(config: ServerConfig) -> Result<Self, ServerBootError> {
+        // Fail before ever accepting a connection if the checked-in OpenAPI
+        // contract can't be stamped with this build's version (for example,
+        // a reformatted priv/openapi/openapi.json that moved the info.version
+        // placeholder) — the alternative is silently serving a stale version
+        // forever from a process that otherwise looks healthy.
+        stamp_openapi_version(OPENAPI_JSON, CANARY_VERSION)
+            .map_err(ServerBootError::OpenApiContract)?;
+
         if config.webhook_drain_max_jobs == 0 {
             return Err(ServerBootError::InvalidConfig(
                 "webhook drain max jobs must be greater than zero".to_owned(),
@@ -356,6 +364,9 @@ pub enum ServerBootError {
     RetentionPruneWorker(String),
     /// TLS-expiry scan lifecycle worker failed to start.
     TlsExpiryScanWorker(String),
+    /// The checked-in OpenAPI contract can't be stamped with the compiled
+    /// version (see `canary_http::public::stamp_openapi_version`).
+    OpenApiContract(canary_http::public::OpenApiVersionStampError),
 }
 
 impl fmt::Display for ServerBootError {
@@ -369,6 +380,7 @@ impl fmt::Display for ServerBootError {
             Self::MonitorOverdueWorker(error) => formatter.write_str(error),
             Self::RetentionPruneWorker(error) => formatter.write_str(error),
             Self::TlsExpiryScanWorker(error) => formatter.write_str(error),
+            Self::OpenApiContract(error) => write!(formatter, "openapi contract error: {error}"),
         }
     }
 }

--- a/docs/architecture/rust-rewrite.md
+++ b/docs/architecture/rust-rewrite.md
@@ -788,7 +788,7 @@ the Rust server accepts production traffic:
     `healthz_adapts_the_public_contract`,
     `readyz_returns_ready_when_all_dependencies_are_ok`,
     `readyz_returns_503_when_any_dependency_fails`,
-    `openapi_serves_the_checked_in_document_unchanged`,
+    `openapi_serves_the_checked_in_document_with_stamped_version`,
     `public_router_does_not_mount_private_routes`,
     `annotations_create_list_paginate_and_emit_webhook_effect`, and
     `legacy_annotation_routes_and_errors_follow_phoenix_contract` lock the

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Canary API",
-    "version": "0.1.0",
+    "version": "0.0.0-dev",
     "description": "Machine-consumable contract for the Canary observability API. Canary exposes deterministic, bounded responses for error ingestion, health checks, incidents, timelines, operator management, and webhook delivery visibility.",
     "x-agent-guide": {
       "summary": "Register webhooks as wake-up hints, then treat the timeline as the durable source of truth for correctness.",


### PR DESCRIPTION
## Summary

Closes the three remaining release-pipeline truth gaps from the canary-931 groom:

1. **Version stamping.** `GET /api/v1/openapi.json` `info.version` was hardcoded `0.1.0` forever. Cargo crate versions aren't wired to anything runtime-visible in this workspace (nothing publishes them, and Landmark/semantic-release doesn't rewrite `Cargo.toml`), so I made the *deployed image* the source of truth instead: `deploy.yml` resolves `git describe --tags --always --dirty` on the CI runner (which has full tag history via `fetch-depth: 0` + `fetch-tags: true`) and threads it through `flyctl deploy --build-arg CANARY_VERSION=...`. The Dockerfile `ARG CANARY_VERSION=0.0.0-dev` default covers builds outside that pipeline (local `cargo build`, dagger's strict-gate image smoke test). `crates/canary-http/build.rs` bakes the value into the binary via `cargo:rustc-env`, and `openapi_response()` substitutes it into the checked-in document's `info.version` placeholder at serve time — the checked-in `priv/openapi/openapi.json` keeps an honest `0.0.0-dev` placeholder rather than the old false `0.1.0`.

   Because the release commit that carries the next tag lands on a *separate*, later `[skip ci]` push (see `release.yml`), the Deploy workflow's checkout is never exactly on a tag — `git describe` reports the nearest ancestor tag plus how far ahead the deployed commit is (e.g. `v0.15.6-1-gabc1234`), which is the truthful answer rather than a guessed future tag.

2. **npm publish claim.** `clients/typescript/README.md` claimed `npm install @canary-obs/sdk`, which 404s. `sdk-publish.yml` (from #231) is already correctly built: it publishes on every `sdk-v*` tag and is gated on the `NPM_TOKEN` secret being present, with a clear warning when it's missing. `NPM_TOKEN` is confirmed absent from `gh secret list` — this is operator-gated, not something I can or should fake. I replaced the false install claim with the same verified `file:`-protocol build-and-link flow `INTEGRATION.md` already documents (confirmed working live: `npm pack` + install and the `file:` link both load the package correctly).

3. **CHANGELOG link reconciliation.** Swept all 231 unique changelog links; every pre-reset 1.x/2.x `compare/vX.Y.Z...vX.Y.Z` link 404s (tags were retired), while issue/PR and commit links all resolve fine, and every post-reset v0.15.x compare link resolves — so the generator config needs no fix. Strengthened the existing reset preamble (already present from an earlier commit) to name the 404s explicitly and point at the still-working commit/issue links, without rewriting the historical entries.

## Design notes

- **Why build-time git-describe instead of coupling Landmark to rewrite Cargo.toml:** a `.releaserc` + exec-plugin approach to bump 7 `Cargo.toml` files every release is a heavier, more failure-prone integration (new config file, custom script, another moving part in the release pipeline) for a value nothing else reads. The build-arg → build.rs → `env!()` pattern is self-contained, needs zero coupling to the external Landmark tool, and directly answers the ticket's actual oracle (the deployed API's reported version).
- Left `Cargo.toml` package versions untouched (still `0.1.0`, informational only) — they aren't part of the truth chain here and touching all 7 files for a cosmetic-only field wasn't the smallest robust fix.

## Operator-gated

- **NPM_TOKEN**: create the `@canary-obs` npm org, mint an automation token with publish rights, add it as the `NPM_TOKEN` repo secret (see `docs/compatibility-policy.md`). Once set, push an `sdk-v*` tag or re-run `sdk-publish.yml` via `workflow_dispatch` — no further code changes needed.

## Test plan

- [x] `cargo test --workspace --locked` — 260+ tests, 0 failures, including two new tests pinning the version-stamping wiring (`openapi_response_stamps_canary_version_and_changes_nothing_else` in `canary-http`, `openapi_serves_the_checked_in_document_with_stamped_version` in `canary-server`)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `./bin/validate --fast` — pass (ran as pre-commit hook)
- [x] `./bin/validate --strict` — pass (ran as pre-push hook, ~4 min, includes the Docker image build + `/healthz` `/readyz` smoke)
- [x] Live Docker smoke: plain `docker build .` + run reports `info.version: "0.0.0-dev"`; `docker build --build-arg CANARY_VERSION=v0.15.6-1-gabc1234 .` + run reports `info.version: "v0.15.6-1-gabc1234"` from the running container's `/api/v1/openapi.json`
- [x] Live npm smoke: `npm pack` produced tarball installs and loads (`captureEvent`, `captureException`, etc. all resolve); `npm install file:.../clients/typescript` also verified working
- [x] Live link sweep: all 231 unique CHANGELOG.md links checked with `curl -o /dev/null -w '%{http_code}'`; only the 22 pre-reset 1.x compare links 404 (expected, tags retired), all others 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)