### PR TITLE
fix(auth): require explicit unbound read authority

### DIFF
--- a/crates/canary-core/src/redaction.rs
+++ b/crates/canary-core/src/redaction.rs
@@ -12,9 +12,56 @@ use serde_json::Value;
 /// Replacement used when a value is sensitive by field name.
 pub const REDACTED: &str = "[REDACTED]";
 
+/// Stable names advertised by responder context envelopes for this redaction floor.
+pub const REDACTION_RULE_NAMES: [&str; 9] = [
+    "bearer_token",
+    "canary_api_key",
+    "jwt",
+    "aws_access_key",
+    "private_key_block",
+    "provider_token",
+    "credential_database_uri",
+    "email",
+    "sensitive_key_value",
+];
+
 static REDACTION_RULES: LazyLock<std::result::Result<Vec<(Regex, &'static str)>, regex::Error>> =
     LazyLock::new(|| {
         Ok(vec![
+            (
+                Regex::new(
+                    r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+                )?,
+                "[PRIVATE_KEY]",
+            ),
+            (
+                Regex::new(
+                    r"(?i)\b(postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|rediss)://[^\s/@]+@",
+                )?,
+                "$1://[REDACTED]@",
+            ),
+            (
+                Regex::new(r"\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b")?,
+                "[JWT]",
+            ),
+            (
+                Regex::new(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")?,
+                "[AWS_ACCESS_KEY]",
+            ),
+            (
+                Regex::new(r"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")?,
+                "[PROVIDER_TOKEN]",
+            ),
+            (
+                Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")?,
+                "[PROVIDER_TOKEN]",
+            ),
+            (
+                Regex::new(
+                    r"\b(?:sk-(?:proj-|ant-(?:api\d+-)?|or-v1-)?[A-Za-z0-9_-]{16,}|AIza[0-9A-Za-z_-]{20,}|hf_[A-Za-z0-9]{20,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{20,})\b",
+                )?,
+                "[PROVIDER_TOKEN]",
+            ),
             (
                 Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")?,
                 "Bearer [REDACTED]",
@@ -123,5 +170,49 @@ mod tests {
         assert_eq!(scrubbed["authorization"], REDACTED);
         assert_eq!(scrubbed["nested"]["email"], "[EMAIL]");
         assert_eq!(scrubbed["nested"]["api_key"], REDACTED);
+    }
+
+    #[test]
+    fn scrub_string_redacts_supported_secret_corpus_without_passthrough() {
+        let secrets = [
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue",
+            "AKIAIOSFODNN7EXAMPLE",
+            "-----BEGIN PRIVATE KEY-----\nsecret-material\n-----END PRIVATE KEY-----",
+            "ghp_0123456789abcdefghijklmnopqrstuv",
+            "gho_0123456789abcdefghijklmnopqrstuv",
+            "ghu_0123456789abcdefghijklmnopqrstuv",
+            "ghs_0123456789abcdefghijklmnopqrstuv",
+            "ghr_0123456789abcdefghijklmnopqrstuv",
+            "github_pat_0123456789_abcdefghijklmnopqrstuv",
+            concat!("xox", "b-123456789012-abcdefghijklmnop"),
+            concat!("xox", "a-123456789012-abcdefghijklmnop"),
+            concat!("xox", "p-123456789012-abcdefghijklmnop"),
+            concat!("xox", "r-123456789012-abcdefghijklmnop"),
+            concat!("xox", "s-123456789012-abcdefghijklmnop"),
+            "sk-0123456789abcdefghijklmnop",
+            "sk-proj-0123456789abcdefghijklmnop",
+            "sk-ant-0123456789abcdefghijklmnop",
+            "sk-ant-api03-0123456789abcdefghijklmnop",
+            "sk-or-v1-0123456789abcdefghijklmnop",
+            "AIza0123456789abcdefghijklmnopqrst",
+            "hf_0123456789abcdefghijklmnopqrst",
+            "glpat-0123456789abcdefghijklmnopqrst",
+            "npm_0123456789abcdefghijklmnopqrst",
+            "postgresql://canary:hunter2@db.internal/canary",
+        ];
+
+        for secret in secrets {
+            let scrubbed = scrub_string(secret);
+            assert_ne!(scrubbed, secret, "secret shape passed through: {secret}");
+            assert!(
+                !scrubbed.contains(secret),
+                "secret shape remained in scrubbed output: {secret}"
+            );
+            assert_eq!(
+                scrub_string(&scrubbed),
+                scrubbed,
+                "redaction is not idempotent"
+            );
+        }
     }
 }

--- a/crates/canary-ingest/src/lib.rs
+++ b/crates/canary-ingest/src/lib.rs
@@ -160,11 +160,16 @@ fn prepare(
     context: IngestContext,
 ) -> Result<ErrorIngest> {
     let service = required_string(attrs, "service")?;
-    let error_class = required_string(attrs, "error_class")?;
+    let error_class = scrub_string(&required_string(attrs, "error_class")?);
     let message = scrub_string(&required_string(attrs, "message")?);
 
     validate_context(attrs)?;
-    let fingerprint = validate_fingerprint(attrs)?;
+    let fingerprint = validate_fingerprint(attrs)?.map(|items| {
+        items
+            .into_iter()
+            .map(|item| scrub_string(&item))
+            .collect::<Vec<_>>()
+    });
 
     let stack_trace = optional_string(attrs, "stack_trace").map(|value| scrub_string(&value));
     let grouping = compute(GroupingInput {
@@ -194,12 +199,15 @@ fn prepare(
             message_template: grouping.message_template,
             stack_trace: stack_trace.map(|value| truncate(&value, MAX_STACK_TRACE_LEN)),
             context_json: context_json(attrs),
-            severity: optional_string(attrs, "severity").unwrap_or_else(|| "error".to_owned()),
+            severity: optional_string(attrs, "severity")
+                .map(|value| scrub_string(&value))
+                .unwrap_or_else(|| "error".to_owned()),
             environment: optional_string(attrs, "environment")
+                .map(|value| scrub_string(&value))
                 .unwrap_or_else(|| "production".to_owned()),
             group_hash: grouping.group_hash,
             fingerprint_json: fingerprint_json(fingerprint.as_deref()),
-            region: optional_string(attrs, "region"),
+            region: optional_string(attrs, "region").map(|value| scrub_string(&value)),
             classification,
             created_at: context.now,
         },
@@ -576,16 +584,48 @@ mod tests {
     #[test]
     fn server_side_redaction_runs_before_persistence() -> Result<()> {
         let mut store = migrated_store()?;
+        let corpus = [
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue",
+            "AKIAIOSFODNN7EXAMPLE",
+            "-----BEGIN PRIVATE KEY-----\nsecret-material\n-----END PRIVATE KEY-----",
+            "ghp_0123456789abcdefghijklmnopqrstuv",
+            "gho_0123456789abcdefghijklmnopqrstuv",
+            "ghu_0123456789abcdefghijklmnopqrstuv",
+            "ghs_0123456789abcdefghijklmnopqrstuv",
+            "ghr_0123456789abcdefghijklmnopqrstuv",
+            "github_pat_0123456789_abcdefghijklmnopqrstuv",
+            concat!("xox", "b-123456789012-abcdefghijklmnop"),
+            concat!("xox", "a-123456789012-abcdefghijklmnop"),
+            concat!("xox", "p-123456789012-abcdefghijklmnop"),
+            concat!("xox", "r-123456789012-abcdefghijklmnop"),
+            concat!("xox", "s-123456789012-abcdefghijklmnop"),
+            "sk-0123456789abcdefghijklmnop",
+            "sk-proj-0123456789abcdefghijklmnop",
+            "sk-ant-0123456789abcdefghijklmnop",
+            "sk-ant-api03-0123456789abcdefghijklmnop",
+            "sk-or-v1-0123456789abcdefghijklmnop",
+            "AIza0123456789abcdefghijklmnopqrst",
+            "hf_0123456789abcdefghijklmnopqrst",
+            "glpat-0123456789abcdefghijklmnopqrst",
+            "npm_0123456789abcdefghijklmnopqrst",
+            "postgresql://canary:hunter2@db.internal/canary",
+        ];
         let attrs = json!({
             "service": "svc",
-            "error_class": "RuntimeError",
-            "message": "failed for alice@example.com with sk_live_secret123",
-            "stack_trace": "Authorization: Bearer abc.def.ghi\npassword = \"hunter2\"\ntoken='abc123'",
+            "error_class": format!("RuntimeError {}", corpus[0]),
+            "message": format!("failed for alice@example.com with sk_live_secret123 {}", corpus[1]),
+            "stack_trace": format!("Authorization: Bearer abc.def.ghi\npassword = \"hunter2\"\ntoken='abc123'\n{}", corpus[2]),
+            "severity": corpus[3],
+            "environment": corpus[4],
+            "fingerprint": [corpus[5]],
+            "region": corpus[6],
             "context": {
                 "authorization": "Bearer context-secret",
                 "nested": {
                     "email": "bob@example.com",
-                    "api_key": "sk_live_nested_secret"
+                    "api_key": "sk_live_nested_secret",
+                    "more_provider_tokens": corpus[7..23],
+                    "database": corpus[23]
                 }
             }
         });
@@ -614,12 +654,17 @@ mod tests {
             }
         };
 
-        assert_eq!(detail.message, "failed for [EMAIL] with [CANARY_API_KEY]");
-        assert_eq!(
-            detail.stack_trace.as_deref(),
-            Some("Authorization: Bearer [REDACTED]\npassword=[REDACTED]\ntoken=[REDACTED]")
+        assert!(
+            detail
+                .message
+                .starts_with("failed for [EMAIL] with [CANARY_API_KEY]")
         );
-        let Some(context) = detail.context else {
+        assert!(detail.stack_trace.as_deref().is_some_and(|value| {
+            value.starts_with(
+                "Authorization: Bearer [REDACTED]\npassword=[REDACTED]\ntoken=[REDACTED]",
+            )
+        }));
+        let Some(ref context) = detail.context else {
             return Err(IngestError::PayloadTooLarge(
                 "redacted context should be present".to_owned(),
             ));
@@ -627,6 +672,13 @@ mod tests {
         assert_eq!(context["authorization"], REDACTED);
         assert_eq!(context["nested"]["email"], "[EMAIL]");
         assert_eq!(context["nested"]["api_key"], REDACTED);
+        let persisted_read_model = format!("{detail:?}");
+        for secret in corpus {
+            assert!(
+                !persisted_read_model.contains(secret),
+                "secret corpus value survived persistence: {secret}"
+            );
+        }
 
         Ok(())
     }
@@ -662,6 +714,6 @@ mod tests {
     }
 
     const fn canary_store_schema_version() -> u32 {
-        2026071000
+        2026071300
     }
 }

--- a/crates/canary-server/src/admin_keys.rs
+++ b/crates/canary-server/src/admin_keys.rs
@@ -31,6 +31,7 @@ struct ApiKeyCreate {
     name: String,
     scope: String,
     service: Option<String>,
+    allow_unbound: bool,
 }
 
 pub(crate) async fn list_api_keys(
@@ -107,6 +108,7 @@ pub(crate) async fn create_api_key(
         tenant_id: authority.tenant_id,
         project_id: authority.project_id,
         service: request.service,
+        allow_unbound: request.allow_unbound,
     };
     let response_body = api_key_insert_response(&key, &raw_key);
 
@@ -163,6 +165,7 @@ fn api_key_response(key: ApiKeyRecord) -> Value {
         "tenant_id": key.tenant_id,
         "project_id": key.project_id,
         "service": key.service,
+        "allow_unbound": key.allow_unbound,
     })
 }
 
@@ -177,6 +180,7 @@ fn api_key_insert_response(key: &ApiKeyInsert, raw_key: &str) -> Value {
         "tenant_id": key.tenant_id,
         "project_id": key.project_id,
         "service": key.service,
+        "allow_unbound": key.allow_unbound,
         "warning": "Store this key securely. It will not be shown again.",
     })
 }
@@ -192,7 +196,10 @@ fn decode_optional_json_object(body: &Bytes) -> Result<Map<String, Value>, Box<P
 fn parse_api_key_create(attrs: Map<String, Value>) -> Result<ApiKeyCreate, Box<ProblemDetails>> {
     let mut errors: ValidationErrors = ValidationErrors::new();
     for field in attrs.keys() {
-        if !matches!(field.as_str(), "name" | "scope" | "service") {
+        if !matches!(
+            field.as_str(),
+            "name" | "scope" | "service" | "allow_unbound"
+        ) {
             errors.insert(field.clone(), vec!["is not permitted".to_owned()]);
         }
     }
@@ -235,6 +242,17 @@ fn parse_api_key_create(attrs: Map<String, Value>) -> Result<ApiKeyCreate, Box<P
             None
         }
     };
+    let allow_unbound = match attrs.get("allow_unbound") {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Null) | None => false,
+        Some(_) => {
+            errors.insert(
+                "allow_unbound".to_owned(),
+                vec!["must be a boolean".to_owned()],
+            );
+            false
+        }
+    };
     if service.is_some() && scope == "admin" {
         errors.insert(
             "service".to_owned(),
@@ -247,12 +265,31 @@ fn parse_api_key_create(attrs: Map<String, Value>) -> Result<ApiKeyCreate, Box<P
             vec!["is required for responder-write keys".to_owned()],
         );
     }
+    if scope == "read-only" && service.is_none() && !allow_unbound {
+        errors.insert(
+            "service".to_owned(),
+            vec!["is required unless allow_unbound is true".to_owned()],
+        );
+    }
+    if service.is_some() && allow_unbound {
+        errors.insert(
+            "allow_unbound".to_owned(),
+            vec!["cannot be combined with a service binding".to_owned()],
+        );
+    }
+    if allow_unbound && scope != "read-only" {
+        errors.insert(
+            "allow_unbound".to_owned(),
+            vec!["is only valid for read-only keys".to_owned()],
+        );
+    }
 
     if errors.is_empty() {
         Ok(ApiKeyCreate {
             name,
             scope,
             service,
+            allow_unbound,
         })
     } else {
         Err(Box::new(validation_problem(

--- a/crates/canary-server/src/auth_cache.rs
+++ b/crates/canary-server/src/auth_cache.rs
@@ -120,6 +120,7 @@ mod tests {
             tenant_id: "tenant".to_owned(),
             project_id: "project".to_owned(),
             service: None,
+            allow_unbound: true,
         }
     }
 

--- a/crates/canary-server/src/keygen.rs
+++ b/crates/canary-server/src/keygen.rs
@@ -56,6 +56,7 @@ pub fn mint_key(
     scope: &str,
     name: &str,
     service: Option<&str>,
+    allow_unbound: bool,
 ) -> Result<String, MintKeyError> {
     if !VALID_SCOPES.contains(&scope) {
         return Err(MintKeyError::InvalidScope(scope.to_owned()));
@@ -79,6 +80,21 @@ pub fn mint_key(
             "--service cannot be set on admin keys".to_owned(),
         ));
     }
+    if scope == "read-only" && service.is_none() && !allow_unbound {
+        return Err(MintKeyError::InvalidServiceBinding(
+            "--service is required for read-only keys unless --allow-unbound is set".to_owned(),
+        ));
+    }
+    if service.is_some() && allow_unbound {
+        return Err(MintKeyError::InvalidServiceBinding(
+            "--allow-unbound cannot be combined with --service".to_owned(),
+        ));
+    }
+    if allow_unbound && scope != "read-only" {
+        return Err(MintKeyError::InvalidServiceBinding(
+            "--allow-unbound is only valid for read-only keys".to_owned(),
+        ));
+    }
 
     let mut store = Store::open(db_path).map_err(MintKeyError::Store)?;
     store.migrate().map_err(MintKeyError::Store)?;
@@ -98,6 +114,7 @@ pub fn mint_key(
             tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
             service,
+            allow_unbound,
         })
         .map_err(MintKeyError::Store)?;
 
@@ -139,7 +156,7 @@ mod tests {
         let db_path = unique_db_path("roundtrip");
         let _guard = DbGuard(db_path.clone());
 
-        let raw_key = mint_key(&db_path, "admin", "recovery", None)?;
+        let raw_key = mint_key(&db_path, "admin", "recovery", None, false)?;
 
         let store = Store::open(&db_path)?;
         let verified = store
@@ -154,7 +171,7 @@ mod tests {
         let db_path = unique_db_path("badscope");
         let _guard = DbGuard(db_path.clone());
 
-        let result = mint_key(&db_path, "superuser", "x", None);
+        let result = mint_key(&db_path, "superuser", "x", None, false);
         assert!(
             matches!(&result, Err(MintKeyError::InvalidScope(scope)) if scope == "superuser"),
             "expected InvalidScope(\"superuser\"), got {result:?}"
@@ -166,19 +183,38 @@ mod tests {
         let db_path = unique_db_path("responder");
         let _guard = DbGuard(db_path.clone());
 
-        let missing = mint_key(&db_path, "responder-write", "bot", None);
+        let missing = mint_key(&db_path, "responder-write", "bot", None, false);
         assert!(
             matches!(&missing, Err(MintKeyError::InvalidServiceBinding(message)) if message.contains("--service is required")),
             "expected missing service binding, got {missing:?}"
         );
 
-        let raw_key = mint_key(&db_path, "responder-write", "bot", Some("billing"))?;
+        let raw_key = mint_key(&db_path, "responder-write", "bot", Some("billing"), false)?;
         let store = Store::open(&db_path)?;
         let verified = store
             .verify_api_key(&raw_key)?
             .ok_or("minted key should verify as active")?;
         assert_eq!(verified.scope, "responder-write");
         assert_eq!(verified.service.as_deref(), Some("billing"));
+        Ok(())
+    }
+
+    #[test]
+    fn read_key_requires_service_or_explicit_unbound_grant()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let db_path = unique_db_path("read-authority");
+        let _guard = DbGuard(db_path.clone());
+
+        let missing = mint_key(&db_path, "read-only", "reader", None, false);
+        assert!(matches!(
+            missing,
+            Err(MintKeyError::InvalidServiceBinding(_))
+        ));
+
+        let raw_key = mint_key(&db_path, "read-only", "fleet-reader", None, true)?;
+        let store = Store::open(&db_path)?;
+        let verified = store.verify_api_key(&raw_key)?.ok_or("key should verify")?;
+        assert!(verified.allow_unbound);
         Ok(())
     }
 }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -5004,7 +5004,7 @@ mod tests {
                 "POST",
                 "/api/v1/keys",
                 ADMIN_KEY,
-                r#"{"name":"deploy","scope":"read-only"}"#,
+                r#"{"name":"deploy","scope":"read-only","allow_unbound":true}"#,
             )?)
             .await?;
         assert_eq!(create_response.status(), StatusCode::CREATED);
@@ -5016,6 +5016,7 @@ mod tests {
         assert_eq!(created["name"], "deploy");
         assert_eq!(created["scope"], "read-only");
         assert_eq!(created["service"], Value::Null);
+        assert_eq!(created["allow_unbound"], true);
         assert_eq!(created["tenant_id"], canary_store::BOOTSTRAP_TENANT_ID);
         assert_eq!(created["project_id"], canary_store::BOOTSTRAP_PROJECT_ID);
         assert_eq!(
@@ -5043,6 +5044,7 @@ mod tests {
         assert_eq!(listed_key["name"], "deploy");
         assert_eq!(listed_key["scope"], "read-only");
         assert_eq!(listed_key["service"], Value::Null);
+        assert_eq!(listed_key["allow_unbound"], true);
         assert_eq!(listed_key["tenant_id"], canary_store::BOOTSTRAP_TENANT_ID);
         assert_eq!(listed_key["project_id"], canary_store::BOOTSTRAP_PROJECT_ID);
         assert_eq!(
@@ -5172,6 +5174,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn implicit_unbound_read_key_fails_closed_at_runtime() -> Result<(), Box<dyn Error>> {
+        let state = test_ingest_state()?;
+        let raw_key = "sk_live_legacy_unbound_read";
+        {
+            let mut store = state.lock_store().map_err(|_| "store lock poisoned")?;
+            store.insert_api_key(ApiKeyInsert {
+                id: "KEY-legacy-unbound-read".to_owned(),
+                name: "legacy fleet reader".to_owned(),
+                key_prefix: raw_key.chars().take(API_KEY_PREFIX_LEN).collect(),
+                key_hash: bcrypt::hash(raw_key, TEST_BCRYPT_COST)?,
+                created_at: "2026-05-28T20:00:00Z".to_owned(),
+                revoked_at: None,
+                scope: "read-only".to_owned(),
+                tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
+                project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
+                service: None,
+                allow_unbound: false,
+            })?;
+        }
+
+        let response = ingest_router(state)
+            .oneshot(read_request(raw_key, "/api/v1/incidents")?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = json_body(response).await?;
+        assert_eq!(body["code"], "insufficient_scope");
+        assert_eq!(body["scope"], "read-only");
+        assert_eq!(body["required_service_binding"], true);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn admin_api_key_create_defaults_and_rejects_invalid_scope() -> Result<(), Box<dyn Error>>
     {
         let router = ingest_router(test_ingest_state()?);
@@ -5216,6 +5251,24 @@ mod tests {
         assert_eq!(
             json_body(unbound_responder).await?["errors"]["service"],
             json!(["is required for responder-write keys"])
+        );
+
+        let implicit_unbound_read = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/keys",
+                ADMIN_KEY,
+                r#"{"name":"implicit-fleet-reader","scope":"read-only"}"#,
+            )?)
+            .await?;
+        assert_eq!(
+            implicit_unbound_read.status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(
+            json_body(implicit_unbound_read).await?["errors"]["service"],
+            json!(["is required unless allow_unbound is true"])
         );
 
         let forbidden_response = router
@@ -5435,6 +5488,7 @@ mod tests {
                 tenant_id: "TENANT-alpha".to_owned(),
                 project_id: "PROJECT-web".to_owned(),
                 service: Some("linejam".to_owned()),
+                allow_unbound: false,
             })?;
             store.commit_error_ingest(owned_error_ingest(
                 "TENANT-alpha",
@@ -6862,6 +6916,7 @@ mod tests {
                 tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
                 project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
                 service: Some("linejam".to_owned()),
+                allow_unbound: false,
             })?;
         }
         let router = ingest_router(state);
@@ -9016,6 +9071,7 @@ mod tests {
                 tenant_id: "TENANT-alpha".to_owned(),
                 project_id: "PROJECT-web".to_owned(),
                 service: Some("linejam".to_owned()),
+                allow_unbound: false,
             })?;
         }
 
@@ -9053,6 +9109,7 @@ mod tests {
             tenant_id: "TENANT-alpha".to_owned(),
             project_id: "PROJECT-web".to_owned(),
             service: Some("linejam".to_owned()),
+            allow_unbound: false,
         })?;
         let mut matching = webhook_subscription_insert(
             "WHK-linejam",
@@ -9131,6 +9188,7 @@ mod tests {
                 tenant_id: "TENANT-alpha".to_owned(),
                 project_id: "PROJECT-web".to_owned(),
                 service: Some("linejam".to_owned()),
+                allow_unbound: false,
             })?;
         }
 
@@ -10217,6 +10275,7 @@ mod tests {
             tenant_id: tenant_id.to_owned(),
             project_id: project_id.to_owned(),
             service: None,
+            allow_unbound: scope == "read-only",
         })?;
         Ok(())
     }
@@ -10238,6 +10297,7 @@ mod tests {
             tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
             service: Some(service.to_owned()),
+            allow_unbound: false,
         })?;
         Ok(())
     }
@@ -10259,6 +10319,7 @@ mod tests {
             tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
             service: Some(service.to_owned()),
+            allow_unbound: false,
         })?;
         Ok(())
     }
@@ -10280,6 +10341,7 @@ mod tests {
             tenant_id: canary_store::BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: canary_store::BOOTSTRAP_PROJECT_ID.to_owned(),
             service: Some(service.to_owned()),
+            allow_unbound: false,
         })?;
         Ok(())
     }

--- a/crates/canary-server/src/main.rs
+++ b/crates/canary-server/src/main.rs
@@ -45,6 +45,7 @@ fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
     let mut scope = "admin".to_owned();
     let mut name = "operator-minted".to_owned();
     let mut service: Option<String> = None;
+    let mut allow_unbound = false;
     let mut iter = args.iter();
     while let Some(flag) = iter.next() {
         match flag.as_str() {
@@ -57,6 +58,7 @@ fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
             "--service" => {
                 service = Some(iter.next().ok_or("--service requires a value")?.clone());
             }
+            "--allow-unbound" => allow_unbound = true,
             other => return Err(format!("unknown mint-key argument: {other}").into()),
         }
     }
@@ -65,7 +67,7 @@ fn run_mint_key(args: &[String]) -> Result<(), Box<dyn Error>> {
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_DB_PATH));
 
-    let raw_key = keygen::mint_key(&db_path, &scope, &name, service.as_deref())?;
+    let raw_key = keygen::mint_key(&db_path, &scope, &name, service.as_deref(), allow_unbound)?;
     // The raw key prints to stdout; everything else goes to stderr so the key
     // can be captured cleanly (e.g. `... mint-key | tail -1`).
     eprintln!(

--- a/crates/canary-server/src/read_audit.rs
+++ b/crates/canary-server/src/read_audit.rs
@@ -136,6 +136,7 @@ mod tests {
             tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
             service: service.map(|s| s.to_owned()),
+            allow_unbound: scope == "read-only" && service.is_none(),
         }
     }
 

--- a/crates/canary-server/src/responder_context.rs
+++ b/crates/canary-server/src/responder_context.rs
@@ -6,7 +6,7 @@
 
 use canary_core::{
     query::IncidentDetail,
-    redaction::{REDACTED, scrub_string, sensitive_key},
+    redaction::{REDACTED, REDACTION_RULE_NAMES, scrub_string, sensitive_key},
 };
 use canary_store::VerifiedApiKey;
 use serde_json::{Value, json};
@@ -59,12 +59,7 @@ pub(crate) fn incident_context_response(
                 },
                 "privacy_policy": {
                     "classification": "redacted",
-                    "redaction_rules": [
-                        "bearer_token",
-                        "canary_api_key",
-                        "email",
-                        "sensitive_key_value"
-                    ],
+                    "redaction_rules": REDACTION_RULE_NAMES,
                     "max_string_chars": MAX_CONTEXT_STRING_CHARS,
                     "max_metadata_bytes": MAX_METADATA_BYTES,
                     "max_evidence_link_chars": MAX_EVIDENCE_LINK_CHARS
@@ -180,6 +175,7 @@ mod tests {
             tenant_id: "TENANT-test".to_owned(),
             project_id: "PROJECT-test".to_owned(),
             service: Some("svc".to_owned()),
+            allow_unbound: false,
         }
     }
 
@@ -260,5 +256,9 @@ mod tests {
             "https://example.test?token=[REDACTED]"
         );
         assert_eq!(value["context_envelope"]["schema"], INCIDENT_CONTEXT_SCHEMA);
+        assert_eq!(
+            value["context_envelope"]["privacy_policy"]["redaction_rules"],
+            json!(REDACTION_RULE_NAMES)
+        );
     }
 }

--- a/crates/canary-server/src/server_auth.rs
+++ b/crates/canary-server/src/server_auth.rs
@@ -42,6 +42,12 @@ pub(crate) fn require_read_scope(
     {
         return Err(Box::new(responder_service_binding_problem()));
     }
+    if ApiKeyScope::parse(&key.scope) == Some(ApiKeyScope::ReadOnly)
+        && key.service.is_none()
+        && !key.allow_unbound
+    {
+        return Err(Box::new(read_service_binding_problem()));
+    }
     enforce_rate_limit(state, RateLimitKind::Query, &key.id)?;
     Ok(key)
 }
@@ -175,6 +181,17 @@ pub(crate) fn responder_service_binding_problem() -> ProblemDetails {
         None,
     )
     .with_extra("scope", json!("responder-write"))
+    .with_extra("required_service_binding", json!(true))
+}
+
+pub(crate) fn read_service_binding_problem() -> ProblemDetails {
+    ProblemDetails::new(
+        StatusCode::FORBIDDEN.as_u16(),
+        ProblemCode::InsufficientScope,
+        "API key scope `read-only` must be service-bound unless project-wide read authority was explicitly granted.",
+        None,
+    )
+    .with_extra("scope", json!("read-only"))
     .with_extra("required_service_binding", json!(true))
 }
 

--- a/crates/canary-server/src/service_onboarding_routes.rs
+++ b/crates/canary-server/src/service_onboarding_routes.rs
@@ -84,6 +84,7 @@ pub(crate) async fn create_service_onboarding(
         tenant_id: authority.tenant_id.clone(),
         project_id: authority.project_id.clone(),
         service: Some(request.service.clone()),
+        allow_unbound: false,
     };
     let response_body =
         service_onboarding_response(&request, &target, &api_key, &raw_key, &base_url(&headers));

--- a/crates/canary-store/src/api_keys.rs
+++ b/crates/canary-store/src/api_keys.rs
@@ -35,6 +35,8 @@ pub struct ApiKeyInsert {
     pub project_id: String,
     /// Optional service this key is bound to for constrained ingest/read use.
     pub service: Option<String>,
+    /// Explicit grant for a read-only key to read every service in its project.
+    pub allow_unbound: bool,
 }
 
 /// Active API key whose bcrypt hash matched the supplied raw bearer token.
@@ -52,6 +54,8 @@ pub struct VerifiedApiKey {
     pub project_id: String,
     /// Optional service this key is bound to for constrained ingest/read use.
     pub service: Option<String>,
+    /// Whether this read-only key was deliberately granted project-wide reads.
+    pub allow_unbound: bool,
 }
 
 /// Admin-visible API key metadata. The raw key and hash are never exposed here.
@@ -75,14 +79,16 @@ pub struct ApiKeyRecord {
     pub project_id: String,
     /// Optional service this key is bound to for constrained ingest/read use.
     pub service: Option<String>,
+    /// Whether this read-only key was deliberately granted project-wide reads.
+    pub allow_unbound: bool,
 }
 
 pub(crate) fn insert(connection: &Connection, key: ApiKeyInsert) -> Result<()> {
     connection.execute(
         "INSERT INTO api_keys (
             id, name, key_prefix, key_hash, created_at, revoked_at, scope,
-            tenant_id, project_id, service
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            tenant_id, project_id, service, allow_unbound
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         params![
             key.id,
             key.name,
@@ -93,7 +99,8 @@ pub(crate) fn insert(connection: &Connection, key: ApiKeyInsert) -> Result<()> {
             key.scope,
             key.tenant_id,
             key.project_id,
-            key.service
+            key.service,
+            key.allow_unbound
         ],
     )?;
     Ok(())
@@ -102,7 +109,7 @@ pub(crate) fn insert(connection: &Connection, key: ApiKeyInsert) -> Result<()> {
 pub(crate) fn list(connection: &Connection) -> Result<Vec<ApiKeyRecord>> {
     let mut statement = connection.prepare(
         "SELECT id, name, scope, key_prefix, created_at, revoked_at,
-                tenant_id, project_id, service
+                tenant_id, project_id, service, allow_unbound
          FROM api_keys
          ORDER BY created_at DESC",
     )?;
@@ -118,6 +125,7 @@ pub(crate) fn list(connection: &Connection) -> Result<Vec<ApiKeyRecord>> {
                 tenant_id: row.get(6)?,
                 project_id: row.get(7)?,
                 service: row.get(8)?,
+                allow_unbound: row.get(9)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -132,7 +140,7 @@ pub(crate) fn list_scoped(
 ) -> Result<Vec<ApiKeyRecord>> {
     let mut statement = connection.prepare(
         "SELECT id, name, scope, key_prefix, created_at, revoked_at,
-                tenant_id, project_id, service
+                tenant_id, project_id, service, allow_unbound
          FROM api_keys
          WHERE tenant_id = ?1 AND project_id = ?2
          ORDER BY created_at DESC",
@@ -149,6 +157,7 @@ pub(crate) fn list_scoped(
                 tenant_id: row.get(6)?,
                 project_id: row.get(7)?,
                 service: row.get(8)?,
+                allow_unbound: row.get(9)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -212,6 +221,7 @@ pub fn verify_key_candidates(
                 tenant_id: candidate.tenant_id,
                 project_id: candidate.project_id,
                 service: candidate.service,
+                allow_unbound: candidate.allow_unbound,
             });
         }
     }
@@ -241,7 +251,7 @@ pub(crate) fn active_candidates(
     key_prefix: &str,
 ) -> Result<Vec<ApiKeyVerifyCandidate>> {
     let mut statement = connection.prepare(
-        "SELECT id, name, scope, key_hash, tenant_id, project_id, service
+        "SELECT id, name, scope, key_hash, tenant_id, project_id, service, allow_unbound
          FROM api_keys
          WHERE key_prefix = ?1 AND revoked_at IS NULL
          ORDER BY created_at ASC, id ASC",
@@ -256,6 +266,7 @@ pub(crate) fn active_candidates(
                 tenant_id: row.get(4)?,
                 project_id: row.get(5)?,
                 service: row.get(6)?,
+                allow_unbound: row.get(7)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -275,4 +286,5 @@ pub struct ApiKeyVerifyCandidate {
     tenant_id: String,
     project_id: String,
     service: Option<String>,
+    allow_unbound: bool,
 }

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -1669,6 +1669,7 @@ mod tests {
                 tenant_id: "TENANT-wrong".to_owned(),
                 project_id: "PROJECT-wrong".to_owned(),
                 service: Some("onboard".to_owned()),
+                allow_unbound: false,
             },
             "TENANT-right",
             "PROJECT-right",
@@ -1739,6 +1740,7 @@ mod tests {
             tenant_id: "TENANT-alpha".to_owned(),
             project_id: "PROJECT-api".to_owned(),
             service: Some("linejam".to_owned()),
+            allow_unbound: false,
         })?;
 
         let verified = store
@@ -4039,6 +4041,7 @@ mod tests {
             tenant_id: api_keys::BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: api_keys::BOOTSTRAP_PROJECT_ID.to_owned(),
             service: None,
+            allow_unbound: false,
         })?;
 
         let keys = store.list_api_keys()?;
@@ -7607,6 +7610,7 @@ mod tests {
             tenant_id: api_keys::BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: api_keys::BOOTSTRAP_PROJECT_ID.to_owned(),
             service: None,
+            allow_unbound: scope == "read-only",
         })?;
         Ok(())
     }

--- a/crates/canary-store/src/schema.rs
+++ b/crates/canary-store/src/schema.rs
@@ -5,12 +5,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use rusqlite::Connection;
 
 /// Current Rust schema version.
-pub const SCHEMA_VERSION: u32 = 2026071000;
+pub const SCHEMA_VERSION: u32 = 2026071300;
 
 pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
     let transaction = connection.transaction()?;
     transaction.execute_batch(SCHEMA_SQL)?;
     add_bootstrap_ownership_columns(&transaction)?;
+    add_api_key_unbound_grant_column(&transaction)?;
     scope_error_group_identity(&transaction)?;
     backfill_service_scope_columns(&transaction)?;
     add_service_event_telemetry_columns(&transaction)?;
@@ -192,6 +193,17 @@ fn add_bootstrap_ownership_columns(connection: &Connection) -> rusqlite::Result<
         add_text_column_if_missing(connection, table, "service", "TEXT")?;
     }
 
+    Ok(())
+}
+
+fn add_api_key_unbound_grant_column(connection: &Connection) -> rusqlite::Result<()> {
+    if table_column_names(connection, "api_keys")?.contains("allow_unbound") {
+        return Ok(());
+    }
+    connection.execute(
+        "ALTER TABLE api_keys ADD COLUMN allow_unbound INTEGER NOT NULL DEFAULT 0",
+        [],
+    )?;
     Ok(())
 }
 
@@ -472,7 +484,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
   scope TEXT NOT NULL DEFAULT 'admin',
   tenant_id TEXT NOT NULL DEFAULT 'TENANT-bootstrap',
   project_id TEXT NOT NULL DEFAULT 'PROJECT-bootstrap',
-  service TEXT
+  service TEXT,
+  allow_unbound INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS rate_limit_buckets (

--- a/crates/canary-store/src/seeds.rs
+++ b/crates/canary-store/src/seeds.rs
@@ -43,6 +43,7 @@ pub(crate) fn apply_initial_seed(
             tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
             project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
             service: None,
+            allow_unbound: false,
         },
     )?;
     transaction.execute(

--- a/crates/canary-store/tests/legacy_fixture_compat.rs
+++ b/crates/canary-store/tests/legacy_fixture_compat.rs
@@ -24,7 +24,7 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 const LEGACY_FIXTURE: &str = "tests/fixtures/legacy_schema.db";
 const POPULATED_LEGACY_FIXTURE: &str = "tests/fixtures/legacy_read_models.db";
-const RUST_SCHEMA_VERSION: u32 = 2026071000;
+const RUST_SCHEMA_VERSION: u32 = 2026071300;
 
 const LEGACY_MIGRATIONS: &[&str] = &[
     "20260314000001",

--- a/docs/api-key-rotation.md
+++ b/docs/api-key-rotation.md
@@ -3,7 +3,8 @@
 Canary API keys are scoped. Use the narrowest key that matches the caller:
 
 - `ingest-only`: `POST /api/v1/errors`
-- `read-only`: query, report, timeline, incidents, and read-only health endpoints
+- `read-only`: query, report, timeline, incidents, and read-only health endpoints;
+  service-bound by default
 - `responder-write`: service-bound read access plus remediation claim and annotation writeback
 - `admin`: target, webhook, onboarding, metrics, key management, and break-glass responder writes
 
@@ -42,14 +43,27 @@ curl -X POST $CANARY_ENDPOINT/api/v1/keys/KEY-old/revoke \
 
 ## Rotate A Read Or Admin Key
 
-1. Create the replacement with the same scope:
+1. Create the replacement with the same scope and service binding:
 
 ```bash
 curl -X POST $CANARY_ENDPOINT/api/v1/keys \
   -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"name": "ops-read-2026-04", "scope": "read-only"}'
+  -d '{"name": "billing-read-2026-04", "scope": "read-only", "service": "billing"}'
 ```
+
+An intentionally project-wide reader is an exceptional administrative grant:
+
+```bash
+curl -X POST $CANARY_ENDPOINT/api/v1/keys \
+  -H "Authorization: Bearer $CANARY_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "fleet-read-2026-04", "scope": "read-only", "allow_unbound": true}'
+```
+
+Omitting both `service` and `allow_unbound: true` is rejected. Existing
+unbound read keys created before this contract have no explicit grant and fail
+closed after migration; issue and verify a replacement before revoking them.
 
 2. Update dashboards, scripts, or operator tooling to use the new key.
 3. Verify the expected access level:

--- a/docs/architecture/service-bound-read-authority-2026-07-13.md
+++ b/docs/architecture/service-bound-read-authority-2026-07-13.md
@@ -1,0 +1,56 @@
+# Service-Bound Read Authority
+
+Status: accepted  
+Date: 2026-07-13  
+Decision: canary-936
+
+## Context
+
+Canary previously treated `api_keys.service IS NULL` as project-wide read
+authority. That made the most powerful read credential the default result of
+omitting a field, and the stored row could not distinguish an intentional
+fleet reader from a legacy or malformed key. Rich incident and error context
+then amplified the blast radius of one leaked read key.
+
+Canary is self-hosted and infrastructure-agnostic. This decision therefore
+belongs to the product authorization contract, not Misty Step deployment
+configuration: every operator needs the same safe default regardless of where
+Canary runs.
+
+## Decision
+
+New `read-only` keys must choose exactly one authority shape:
+
+- `service=<name>` grants reads for one service; this is the default path.
+- `allow_unbound=true` explicitly grants project-wide reads and cannot be
+  combined with `service` or another key scope.
+
+The explicit grant is persisted as `api_keys.allow_unbound`, returned in admin
+key metadata, and enforced after authentication. The migration defaults the
+column to false, so legacy unbound read keys fail closed and must be rotated.
+Admin authority remains project-wide; responder-write remains service-bound.
+
+The HTTP key API and the `mint-key` recovery command share this policy.
+`mint-key` uses `--allow-unbound` for the exceptional project-wide reader.
+
+## Redaction Boundary
+
+The existing shared deterministic redaction engine remains the single
+vocabulary. It now recognizes JWTs, AWS access-key IDs, private-key blocks,
+GitHub and Slack tokens, common provider tokens, and credential-bearing
+database URIs in addition to the existing Bearer, Canary-key, assignment, and
+email rules. Ingest scrubs every persisted free-form error field before
+grouping and storage; service remains an authorization identity and is not
+silently rewritten.
+
+This is a bounded secret-pattern floor, not a claim of general DLP. New
+credential families extend the shared corpus and persistence/readback test.
+
+## Consequences
+
+- Operators must rotate legacy unbound read keys after upgrade.
+- Deliberate fleet readers remain possible but are visible and auditable.
+- Bound-key route behavior is unchanged: cross-service detail is hidden or
+  forbidden according to each existing public route contract.
+- False positives are limited to declared credential shapes; Canary does not
+  redact generic high-entropy strings.

--- a/docs/responder-context-safety.md
+++ b/docs/responder-context-safety.md
@@ -16,7 +16,9 @@ Canary, and leaves durable audit evidence.
 | `responder-write` with `service=<name>` | May read incident context for the bound service. |
 | `responder-write` without a service binding | Rejected with RFC 9457 `insufficient_scope`. |
 | `responder-write` bound to a different service | Rejected with RFC 9457 `insufficient_scope`; response includes `bound_service` and `requested_service`. |
-| `read-only` | May read incident detail across the key owner scope. |
+| `read-only` with `service=<name>` | May read incident detail only for the bound service. |
+| `read-only` with explicit `allow_unbound=true` grant | May read incident detail across the key owner scope. |
+| legacy unbound `read-only` without an explicit grant | Rejected with RFC 9457 `insufficient_scope`; rotate the key. |
 | `admin` | Break-glass read; context response is still redacted, but no responder read-audit event is written. |
 
 Responder keys are not tenant-wide read keys. They are service-bound automation
@@ -45,6 +47,11 @@ Every incident detail response includes `context_envelope`:
     "redaction_rules": [
       "bearer_token",
       "canary_api_key",
+      "jwt",
+      "aws_access_key",
+      "private_key_block",
+      "provider_token",
+      "credential_database_uri",
       "email",
       "sensitive_key_value"
     ],
@@ -87,6 +94,11 @@ read model: `summary`, `incident`, `signals`, `signals_truncated`,
 | --- | --- | --- |
 | `bearer_token` | `Bearer <token-like-value>` | `Bearer [REDACTED]` |
 | `canary_api_key` | `sk_live_*` or `sk_test_*` | `[CANARY_API_KEY]` |
+| `jwt` | Three base64url-like segments beginning with `eyJ` | `[JWT]` |
+| `aws_access_key` | `AKIA*` or `ASIA*` access-key ID | `[AWS_ACCESS_KEY]` |
+| `private_key_block` | PEM private-key block | `[PRIVATE_KEY]` |
+| `provider_token` | Declared GitHub, Slack, OpenAI, Anthropic, OpenRouter, Google, Hugging Face, GitLab, or npm token shape | `[PROVIDER_TOKEN]` |
+| `credential_database_uri` | PostgreSQL, MySQL, MongoDB, or Redis URI with user info | Scheme plus `[REDACTED]@` |
 | `email` | Email-shaped strings | `[EMAIL]` |
 | `sensitive_key_value` | Object keys or assignment names such as `authorization`, `cookie`, `password`, `secret`, `token`, `api_key`, `access_token`, or `refresh_token` | `[REDACTED]` or `name=[REDACTED]` |
 | `max_string_chars` | Any string longer than 1024 characters | First 1024 characters plus ` [TRUNCATED]` |

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -23,7 +23,7 @@
       "responder_context_safety": {
         "incident_schema": "canary.responder_context.incident.v1",
         "authority": "Service-bound responder-write keys may read responder incident context only for their bound service; cross-service reads return RFC 9457 insufficient_scope and unbound responder-write keys are rejected.",
-        "redaction": "Incident context applies bearer_token, canary_api_key, email, and sensitive_key_value redaction plus field allowlists and size bounds before serialization.",
+        "redaction": "Incident context applies bearer_token, canary_api_key, jwt, aws_access_key, private_key_block, provider_token, credential_database_uri, email, and sensitive_key_value redaction plus field allowlists and size bounds before serialization.",
         "audit": "Successful non-admin incident context reads emit telemetry.event signal responder.context_read with retention_class audit, privacy_policy redacted, and reader/subject/context envelope metadata only."
       },
       "cold_start": {
@@ -4425,6 +4425,11 @@
                   "enum": [
                     "bearer_token",
                     "canary_api_key",
+                    "jwt",
+                    "aws_access_key",
+                    "private_key_block",
+                    "provider_token",
+                    "credential_database_uri",
                     "email",
                     "sensitive_key_value"
                   ]
@@ -6053,7 +6058,8 @@
           "revoked_at",
           "tenant_id",
           "project_id",
-          "service"
+          "service",
+          "allow_unbound"
         ],
         "properties": {
           "id": {
@@ -6091,6 +6097,10 @@
               "null"
             ]
           },
+          "allow_unbound": {
+            "type": "boolean",
+            "description": "True only when a read-only key was explicitly granted project-wide read authority."
+          },
           "scope": {
             "$ref": "#/components/schemas/ApiKeyScope"
           }
@@ -6124,7 +6134,12 @@
           },
           "service": {
             "type": "string",
-            "description": "Optional service binding for non-admin ingest/read keys. Service-bound keys cannot access or ingest for other services."
+            "description": "Service binding for non-admin ingest/read keys. Read-only keys require this unless allow_unbound is explicitly true."
+          },
+          "allow_unbound": {
+            "type": "boolean",
+            "default": false,
+            "description": "Explicitly grant a read-only key project-wide reads. Cannot be combined with service or used by another scope."
           }
         }
       },
@@ -6141,6 +6156,7 @@
           "tenant_id",
           "project_id",
           "service",
+          "allow_unbound",
           "warning"
         ],
         "properties": {
@@ -6171,6 +6187,9 @@
               "string",
               "null"
             ]
+          },
+          "allow_unbound": {
+            "type": "boolean"
           },
           "warning": {
             "type": "string"


### PR DESCRIPTION
## Summary

- make service binding the default authority for read-only API keys
- require an explicit admin-issued allow_unbound grant for project-wide reads
- fail legacy implicit wildcard read keys closed and document rotation
- expand Canary's shared server-side redaction floor and persist only scrubbed ingest fields
- record the authority decision in an ADR and the OpenAPI contract

## Acceptance proof

- Cross-service isolation: live Axum QA returned 403 insufficient_scope for a bound alpha key querying beta, 404 for beta detail, and an alpha report with no beta data.
- Explicit authority: implicit read-key creation returned 422; service-bound and explicit-unbound creation returned 201; explicit unbound beta query returned 200.
- Redaction: live persisted detail contained AWS_ACCESS_KEY marker and no synthetic AKIA sentinel; unit and ingest persistence corpora cover JWT, AWS, PEM, provider tokens, and credential database URIs.
- Scope decision: docs/architecture/service-bound-read-authority-2026-07-13.md.

## Verification

- ./bin/validate — PASS (deterministic full gate, production image and write/read rehearsals, 6m06s)
- pre-push ./bin/validate --strict — PASS (full gate plus advisories and git-history secret scan, 5m50s)
- focused canary-core, canary-ingest, canary-server, canary-store, and legacy-fixture tests — PASS
- fresh-context critic — PASS, no blockers

## Migration note

Existing read-only keys without a service binding now fail closed. Rotate them to a service-bound key, or explicitly issue allow_unbound only when project-wide authority is intended.

Agent: orchestrator
Agent-Surface: Codex
Agent-Model: openai/gpt-5
Agent-Reasoning: high
Agent-Task: canary-936