### PR TITLE
fix(api): complete onboarding key receipts

### DIFF
--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -3650,6 +3650,10 @@ mod tests {
         assert_eq!(created["service"], "billing api");
         assert_eq!(created["api_key"]["name"], "billing api-ingest");
         assert_eq!(created["api_key"]["scope"], "ingest-only");
+        assert_eq!(created["api_key"]["tenant_id"], "TENANT-bootstrap");
+        assert_eq!(created["api_key"]["project_id"], "PROJECT-bootstrap");
+        assert_eq!(created["api_key"]["service"], "billing api");
+        assert_eq!(created["api_key"]["allow_unbound"], false);
         assert!(raw_key.starts_with("sk_live_"));
         assert_eq!(
             created["api_key"]["key_prefix"],

--- a/crates/canary-server/src/service_onboarding_routes.rs
+++ b/crates/canary-server/src/service_onboarding_routes.rs
@@ -158,6 +158,10 @@ fn api_key_insert_response(key: &ApiKeyInsert, raw_key: &str) -> Value {
         "key": raw_key,
         "key_prefix": key.key_prefix,
         "created_at": key.created_at,
+        "tenant_id": key.tenant_id,
+        "project_id": key.project_id,
+        "service": key.service,
+        "allow_unbound": key.allow_unbound,
         "warning": "Store this key securely. It will not be shown again.",
     })
 }


### PR DESCRIPTION
## Summary

- return tenant_id, project_id, service, and allow_unbound in service-onboarding key receipts
- make the observable response conform to the shared ApiKeyCreateResponse contract
- add a response-level regression assertion for every previously omitted field

## Verification

- red: focused service-onboarding test failed on missing tenant_id
- green: cargo test -p canary-server service_onboarding_creates_target_ingest_key_and_snippets --locked
- ./bin/validate --fast — PASS in 1m06s
- pre-push ./bin/validate --strict — PASS in 5m25s

Follow-up to #266 and its late OpenAPI review thread.

Agent: orchestrator
Agent-Surface: Codex
Agent-Model: openai/gpt-5
Agent-Reasoning: high
Agent-Task: canary-936