### PR TITLE
Correlate bounded operational signals into incidents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time",
+ "url",
 ]
 
 [[package]]

--- a/clients/typescript/INTEGRATION.md
+++ b/clients/typescript/INTEGRATION.md
@@ -121,6 +121,11 @@ scoped server key. Operational events carry one stable caller-defined subject,
 an owner, an evidence link, and producer/server clocks; raw metrics and provider
 snapshots stay at the evidence link:
 
+The SDK exposes analytics and operational events as a discriminated union.
+Operational events cannot carry analytics attributes and always normalize to
+`audit` retention, `redacted` privacy, and `unsampled` delivery; conflicting
+values and unknown fields are rejected before transport.
+
 ```bash
 curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/events" \
   -H "Authorization: Bearer $CANARY_API_KEY" \

--- a/clients/typescript/INTEGRATION.md
+++ b/clients/typescript/INTEGRATION.md
@@ -117,7 +117,32 @@ curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/check-ins" \
 
 Use `alive` for TTL-style freshness and `in_progress`, `ok`, or `error` for
 scheduled runs. Send operational events to `/api/v1/events` with the same
-scoped server key.
+scoped server key. Operational events carry one stable caller-defined subject,
+an owner, an evidence link, and producer/server clocks; raw metrics and provider
+snapshots stay at the evidence link:
+
+```bash
+curl -fsS -X POST "$CANARY_ENDPOINT/api/v1/events" \
+  -H "Authorization: Bearer $CANARY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service":"my-control-plane",
+    "name":"capacity.saturation",
+    "summary":"Worker capacity crossed policy",
+    "severity":"warning",
+    "operational":{
+      "subject":{"type":"capacity","id":"worker-pool"},
+      "state":"active",
+      "owner":"platform-operator",
+      "evidence_url":"https://evidence.example/receipts/capacity",
+      "observed_at":"2026-07-14T14:01:00Z"
+    }
+  }'
+```
+
+Canary stores the bounded event, opens or updates the service incident, and
+uses the existing signed incident webhook as a responder wake-up hint. Replay
+the timeline or query the returned `incident_id` for correctness.
 
 ## 6. Verify live coverage
 

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -25,16 +25,29 @@ export interface CheckInPayload {
   context?: Record<string, unknown>;
 }
 
-export interface EventPayload {
+interface EventPayloadBase {
   name: string;
   summary: string;
   severity?: "info" | "warning" | "error";
+}
+
+export interface AnalyticsEventPayload extends EventPayloadBase {
   attributes?: Record<string, unknown>;
   retention_class?: "ephemeral" | "standard" | "audit";
   privacy_policy?: "redacted" | "public" | "sensitive";
   sampling_policy?: string;
-  operational?: OperationalSignal;
+  operational?: never;
 }
+
+export interface OperationalEventPayload extends EventPayloadBase {
+  operational: OperationalSignal;
+  attributes?: never;
+  retention_class?: "audit";
+  privacy_policy?: "redacted";
+  sampling_policy?: "unsampled";
+}
+
+export type EventPayload = AnalyticsEventPayload | OperationalEventPayload;
 
 export interface OperationalSignal {
   subject: {
@@ -146,15 +159,13 @@ export function createClient(opts: ClientOptions): CanaryClient {
 
   async function event(payload: EventPayload): Promise<EventResponse | null> {
     if (inflight >= maxQueue) return null;
+    const normalized = normalizeEventPayload(payload);
+    if (!normalized) return null;
     inflight++;
 
     const body = JSON.stringify({
       service: opts.service,
-      severity: "info",
-      retention_class: payload.operational ? "audit" : "standard",
-      privacy_policy: "redacted",
-      sampling_policy: "unsampled",
-      ...payload,
+      ...normalized,
     });
 
     try {
@@ -174,6 +185,81 @@ export function createClient(opts: ClientOptions): CanaryClient {
       return inflight;
     },
   };
+}
+
+function normalizeEventPayload(payload: EventPayload): Record<string, unknown> | null {
+  const object = payload as unknown as Record<string, unknown>;
+  const allowed = new Set([
+    "name",
+    "summary",
+    "severity",
+    "attributes",
+    "retention_class",
+    "privacy_policy",
+    "sampling_policy",
+    "operational",
+  ]);
+  if (Object.keys(object).some((field) => !allowed.has(field))) return null;
+
+  if (!Object.prototype.hasOwnProperty.call(object, "operational")) {
+    return {
+      severity: "info",
+      retention_class: "standard",
+      privacy_policy: "redacted",
+      sampling_policy: "unsampled",
+      ...payload,
+    };
+  }
+
+  if (
+    object.attributes !== undefined ||
+    (object.retention_class !== undefined && object.retention_class !== "audit") ||
+    (object.privacy_policy !== undefined && object.privacy_policy !== "redacted") ||
+    (object.sampling_policy !== undefined && object.sampling_policy !== "unsampled") ||
+    !validOperationalSignal(object.operational)
+  ) {
+    return null;
+  }
+
+  return {
+    severity: "info",
+    ...payload,
+    attributes: {},
+    retention_class: "audit",
+    privacy_policy: "redacted",
+    sampling_policy: "unsampled",
+  };
+}
+
+function validOperationalSignal(value: unknown): value is OperationalSignal {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const object = value as Record<string, unknown>;
+  if (
+    Object.keys(object).some(
+      (field) => !["subject", "state", "owner", "evidence_url", "observed_at"].includes(field)
+    )
+  ) return false;
+  if (!object.subject || typeof object.subject !== "object" || Array.isArray(object.subject)) {
+    return false;
+  }
+  const subject = object.subject as Record<string, unknown>;
+  if (Object.keys(subject).some((field) => !["type", "id"].includes(field))) return false;
+  if (typeof subject.type !== "string" || !/^[a-z0-9._-]{1,64}$/.test(subject.type)) return false;
+  if (typeof subject.id !== "string" || !/^[A-Za-z0-9._:-]{1,160}$/.test(subject.id)) return false;
+  if (object.state !== "active" && object.state !== "resolved") return false;
+  if (typeof object.owner !== "string" || object.owner.trim().length === 0 || [...object.owner].length > 128) return false;
+  if (typeof object.evidence_url !== "string" || [...object.evidence_url].length > 2048) return false;
+  try {
+    const evidence = new URL(object.evidence_url);
+    if (evidence.protocol !== "https:" || evidence.username || evidence.password || !evidence.hostname) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  return typeof object.observed_at === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+    object.observed_at
+  ) && !Number.isNaN(Date.parse(object.observed_at));
 }
 
 async function attempt<T>(

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -33,6 +33,29 @@ export interface EventPayload {
   retention_class?: "ephemeral" | "standard" | "audit";
   privacy_policy?: "redacted" | "public" | "sensitive";
   sampling_policy?: string;
+  operational?: OperationalSignal;
+}
+
+export interface OperationalSignal {
+  subject: {
+    type: string;
+    id: string;
+  };
+  state: "active" | "resolved";
+  owner: string;
+  evidence_url: string;
+  observed_at: string;
+}
+
+export interface OperationalSignalContext {
+  name: string;
+  subject_type: string;
+  subject_id: string;
+  state: "active" | "resolved";
+  owner: string;
+  evidence_url: string;
+  observed_at: string;
+  received_at: string;
 }
 
 export interface CanaryResponse {
@@ -61,6 +84,9 @@ export interface EventResponse {
   privacy_policy: "redacted" | "public" | "sensitive";
   sampling_policy: string;
   created_at: string;
+  operational?: OperationalSignalContext;
+  incident_event?: "incident.opened" | "incident.updated" | "incident.resolved";
+  incident_id?: string;
 }
 
 export interface CanaryClient {
@@ -125,7 +151,7 @@ export function createClient(opts: ClientOptions): CanaryClient {
     const body = JSON.stringify({
       service: opts.service,
       severity: "info",
-      retention_class: "standard",
+      retention_class: payload.operational ? "audit" : "standard",
       privacy_policy: "redacted",
       sampling_policy: "unsampled",
       ...payload,

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,8 +1,24 @@
 import { createClient, type CanaryClient, type CanaryResponse } from "./client";
-import type { CheckInPayload, CheckInResponse, EventPayload, EventResponse } from "./client";
+import type {
+  CheckInPayload,
+  CheckInResponse,
+  EventPayload,
+  EventResponse,
+  OperationalSignal,
+  OperationalSignalContext,
+} from "./client";
 import { scrub, scrubObject, type ScrubRule } from "./scrub";
 
-export type { CanaryResponse, CheckInPayload, CheckInResponse, EventPayload, EventResponse, ScrubRule };
+export type {
+  CanaryResponse,
+  CheckInPayload,
+  CheckInResponse,
+  EventPayload,
+  EventResponse,
+  OperationalSignal,
+  OperationalSignalContext,
+  ScrubRule,
+};
 
 export interface InitOptions {
   endpoint: string;

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -2,8 +2,10 @@ import { createClient, type CanaryClient, type CanaryResponse } from "./client";
 import type {
   CheckInPayload,
   CheckInResponse,
+  AnalyticsEventPayload,
   EventPayload,
   EventResponse,
+  OperationalEventPayload,
   OperationalSignal,
   OperationalSignalContext,
 } from "./client";
@@ -13,8 +15,10 @@ export type {
   CanaryResponse,
   CheckInPayload,
   CheckInResponse,
+  AnalyticsEventPayload,
   EventPayload,
   EventResponse,
+  OperationalEventPayload,
   OperationalSignal,
   OperationalSignalContext,
   ScrubRule,
@@ -94,6 +98,13 @@ export async function captureEvent(
   payload: EventPayload
 ): Promise<EventResponse | null> {
   if (!client) return null;
+
+  if (payload.operational) {
+    return client.event({
+      ...payload,
+      summary: scrubPii ? scrub(payload.summary, scrubRules)! : payload.summary,
+    });
+  }
 
   return client.event({
     ...payload,

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -289,4 +289,50 @@ describe("createClient", () => {
     expect(body.sampling_policy).toBe("unsampled");
     expect(result?.event).toBe("telemetry.event");
   });
+
+  it("sends operational events as bounded audit signals", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "EVT-operational01",
+          service: "test-app",
+          event: "telemetry.event",
+          name: "capacity.saturation",
+          severity: "warning",
+          summary: "Capacity saturated",
+          attributes: {},
+          retention_class: "audit",
+          privacy_policy: "redacted",
+          sampling_policy: "unsampled",
+          created_at: "2026-07-14T14:01:01Z",
+          incident_event: "incident.opened",
+          incident_id: "INC-operational01",
+        }),
+        { status: 201 }
+      )
+    );
+
+    const client = createClient(opts);
+    await client.event({
+      name: "capacity.saturation",
+      summary: "Capacity saturated",
+      severity: "warning",
+      operational: {
+        subject: { type: "capacity", id: "worker-pool" },
+        state: "active",
+        owner: "infrastructure-operator",
+        evidence_url: "https://evidence.example/receipts/capacity",
+        observed_at: "2026-07-14T14:01:00Z",
+      },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.retention_class).toBe("audit");
+    expect(body.attributes).toBeUndefined();
+    expect(body.operational.subject).toEqual({ type: "capacity", id: "worker-pool" });
+    expect(body.operational.evidence_url).toBe(
+      "https://evidence.example/receipts/capacity"
+    );
+  });
 });

--- a/clients/typescript/test/client.test.ts
+++ b/clients/typescript/test/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createClient, type CanaryClient } from "../src/client";
+import { createClient, type CanaryClient, type EventPayload } from "../src/client";
 
 describe("createClient", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -329,10 +329,86 @@ describe("createClient", () => {
     const [, init] = fetchSpy.mock.calls[0];
     const body = JSON.parse(init.body);
     expect(body.retention_class).toBe("audit");
-    expect(body.attributes).toBeUndefined();
+    expect(body.attributes).toEqual({});
     expect(body.operational.subject).toEqual({ type: "capacity", id: "worker-pool" });
     expect(body.operational.evidence_url).toBe(
       "https://evidence.example/receipts/capacity"
     );
+  });
+
+  it("rejects conflicting or unbounded operational payloads before transport", async () => {
+    const client = createClient(opts);
+    const base = {
+      name: "capacity.saturation",
+      summary: "Capacity saturated",
+      operational: {
+        subject: { type: "capacity", id: "worker-pool" },
+        state: "active",
+        owner: "infrastructure-operator",
+        evidence_url: "https://evidence.example/receipts/capacity",
+        observed_at: "2026-07-14T14:01:00Z",
+      },
+    };
+    for (const invalid of [
+      { ...base, attributes: { raw_metrics: [1, 2, 3] } },
+      { ...base, retention_class: "standard" },
+      { ...base, privacy_policy: "public" },
+      { ...base, sampling_policy: "sampled:0.5" },
+      { ...base, provider_snapshot: { droplets: [1, 2, 3] } },
+      { ...base, operational: null },
+      { ...base, operational: [] },
+      { ...base, operational: { ...base.operational, samples: [1, 2, 3] } },
+      { ...base, operational: { ...base.operational, subject: null } },
+      { ...base, operational: { ...base.operational, subject: [] } },
+      {
+        ...base,
+        operational: {
+          ...base.operational,
+          subject: { ...base.operational.subject, provider: "private" },
+        },
+      },
+      {
+        ...base,
+        operational: {
+          ...base.operational,
+          subject: { ...base.operational.subject, type: "Invalid" },
+        },
+      },
+      {
+        ...base,
+        operational: {
+          ...base.operational,
+          subject: { ...base.operational.subject, id: "invalid/id" },
+        },
+      },
+      { ...base, operational: { ...base.operational, state: "unknown" } },
+      { ...base, operational: { ...base.operational, owner: "" } },
+      { ...base, operational: { ...base.operational, owner: "x".repeat(129) } },
+      { ...base, operational: { ...base.operational, evidence_url: 42 } },
+      { ...base, operational: { ...base.operational, evidence_url: "x".repeat(2049) } },
+      { ...base, operational: { ...base.operational, evidence_url: "not a url" } },
+      { ...base, operational: { ...base.operational, evidence_url: "http://unsafe.test" } },
+      {
+        ...base,
+        operational: {
+          ...base.operational,
+          evidence_url: "https://user:password@evidence.example/receipt",
+        },
+      },
+      { ...base, operational: { ...base.operational, observed_at: 42 } },
+      { ...base, operational: { ...base.operational, observed_at: "not-a-clock" } },
+      {
+        ...base,
+        operational: {
+          ...base.operational,
+          observed_at: "2026-99-99T14:01:00Z",
+        },
+      },
+    ]) {
+      await expect(
+        client.event(invalid as unknown as EventPayload)
+      ).resolves.toBeNull();
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/clients/typescript/test/index.test.ts
+++ b/clients/typescript/test/index.test.ts
@@ -289,6 +289,34 @@ describe("captureEvent", () => {
     expect(body.summary).toBe("Signup completed for [EMAIL]");
     expect(body.attributes).toEqual({ email: "[EMAIL]", plan: "pro" });
   });
+
+  it("preserves the discriminated operational envelope without analytics attributes", async () => {
+    initCanary({
+      endpoint: "https://canary.test",
+      apiKey: "sk_test_abc",
+      service: "test-svc",
+    });
+
+    await captureEvent({
+      name: "drift.violation",
+      summary: "Drift detected",
+      operational: {
+        subject: { type: "deployment", id: "production" },
+        state: "active",
+        owner: "infrastructure-operator",
+        evidence_url: "https://evidence.example/receipts/drift",
+        observed_at: "2026-07-14T14:01:00Z",
+      },
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.attributes).toEqual({});
+    expect(body.retention_class).toBe("audit");
+    expect(body.operational.subject).toEqual({
+      type: "deployment",
+      id: "production",
+    });
+  });
 });
 
 describe("uninitialized capture helpers", () => {

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -4636,28 +4636,7 @@ impl McpToolContext {
             }
             "canary_event_capture" => {
                 let client = self.ingest_client()?;
-                let operational = optional_object(arguments, "operational")?;
-                let retention_class = optional_string(arguments, "retention_class")?
-                    .unwrap_or_else(|| {
-                        if operational.is_some() {
-                            "audit".to_owned()
-                        } else {
-                            "standard".to_owned()
-                        }
-                    });
-                let mut payload = json!({
-                    "service": required_string(arguments, "service")?,
-                    "name": required_string(arguments, "name")?,
-                    "summary": required_string(arguments, "summary")?,
-                    "severity": optional_string(arguments, "severity")?.unwrap_or_else(|| "info".to_owned()),
-                    "attributes": optional_object(arguments, "attributes")?.unwrap_or_default(),
-                    "retention_class": retention_class,
-                    "privacy_policy": optional_string(arguments, "privacy_policy")?.unwrap_or_else(|| "redacted".to_owned()),
-                    "sampling_policy": optional_string(arguments, "sampling_policy")?.unwrap_or_else(|| "unsampled".to_owned()),
-                });
-                if let Some(operational) = operational {
-                    payload["operational"] = Value::Object(operational);
-                }
+                let payload = normalize_event_payload(Value::Object(arguments.clone()))?;
                 let response = client.post_auth_json("/api/v1/events", &payload)?;
                 Ok(json_envelope(
                     "canary_event_capture",
@@ -4991,6 +4970,220 @@ fn optional_string_array(
     }
 }
 
+/// Normalize one event payload and reject operational contract conflicts before transport.
+pub fn normalize_event_payload(mut payload: Value) -> Result<Value> {
+    let object = payload
+        .as_object_mut()
+        .ok_or_else(|| CliError::Message("event payload must be an object".to_owned()))?;
+    let allowed = [
+        "service",
+        "name",
+        "summary",
+        "severity",
+        "attributes",
+        "retention_class",
+        "privacy_policy",
+        "sampling_policy",
+        "operational",
+    ];
+    if let Some(field) = object
+        .keys()
+        .find(|field| !allowed.contains(&field.as_str()))
+    {
+        return Err(CliError::Message(format!("unknown event field `{field}`")));
+    }
+    for field in ["service", "name", "summary"] {
+        let value = object
+            .get(field)
+            .and_then(Value::as_str)
+            .ok_or_else(|| CliError::Message(format!("event {field} must be a string")))?;
+        if value.trim().is_empty() {
+            return Err(CliError::Message(format!(
+                "event {field} must not be empty"
+            )));
+        }
+    }
+    if object
+        .get("name")
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.chars().count() > 128)
+    {
+        return Err(CliError::Message(
+            "event name must not exceed 128 characters".to_owned(),
+        ));
+    }
+    if object
+        .get("summary")
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.chars().count() > 512)
+    {
+        return Err(CliError::Message(
+            "event summary must not exceed 512 characters".to_owned(),
+        ));
+    }
+    object
+        .entry("severity")
+        .or_insert_with(|| Value::String("info".to_owned()));
+    object
+        .entry("attributes")
+        .or_insert_with(|| Value::Object(Default::default()));
+    object
+        .entry("privacy_policy")
+        .or_insert_with(|| Value::String("redacted".to_owned()));
+    object
+        .entry("sampling_policy")
+        .or_insert_with(|| Value::String("unsampled".to_owned()));
+
+    let Some(operational) = object.get("operational").cloned() else {
+        object
+            .entry("retention_class")
+            .or_insert_with(|| Value::String("standard".to_owned()));
+        return Ok(payload);
+    };
+    object
+        .entry("retention_class")
+        .or_insert_with(|| Value::String("audit".to_owned()));
+
+    let attributes = object
+        .get("attributes")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            CliError::Message("operational event attributes must be an object".to_owned())
+        })?;
+    if !attributes.is_empty() {
+        return Err(CliError::Message(
+            "operational event attributes must be empty; retain raw evidence outside Canary"
+                .to_owned(),
+        ));
+    }
+    require_event_setting(object, "retention_class", "audit")?;
+    require_event_setting(object, "privacy_policy", "redacted")?;
+    require_event_setting(object, "sampling_policy", "unsampled")?;
+    validate_operational_value(&operational)?;
+    Ok(payload)
+}
+
+fn require_event_setting(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+    expected: &str,
+) -> Result<()> {
+    match object.get(field).and_then(Value::as_str) {
+        Some(value) if value == expected => Ok(()),
+        _ => Err(CliError::Message(format!(
+            "operational event `{field}` must be `{expected}`"
+        ))),
+    }
+}
+
+fn validate_operational_value(value: &Value) -> Result<()> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| CliError::Message("operational must be an object".to_owned()))?;
+    let allowed = ["subject", "state", "owner", "evidence_url", "observed_at"];
+    if let Some(field) = object
+        .keys()
+        .find(|field| !allowed.contains(&field.as_str()))
+    {
+        return Err(CliError::Message(format!(
+            "unknown operational field `{field}`"
+        )));
+    }
+    let subject = object
+        .get("subject")
+        .and_then(Value::as_object)
+        .ok_or_else(|| CliError::Message("operational.subject must be an object".to_owned()))?;
+    if let Some(field) = subject
+        .keys()
+        .find(|field| !["type", "id"].contains(&field.as_str()))
+    {
+        return Err(CliError::Message(format!(
+            "unknown operational.subject field `{field}`"
+        )));
+    }
+    let subject_type = bounded_operational_string(subject, "type", 64)?;
+    if !subject_type.chars().all(|character| {
+        character.is_ascii_lowercase()
+            || character.is_ascii_digit()
+            || matches!(character, '.' | '_' | '-')
+    }) {
+        return Err(CliError::Message(
+            "operational.subject.type must use lowercase letters, digits, dots, underscores, or hyphens"
+                .to_owned(),
+        ));
+    }
+    let subject_id = bounded_operational_string(subject, "id", 160)?;
+    if !subject_id.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | ':' | '-')
+    }) {
+        return Err(CliError::Message(
+            "operational.subject.id contains an unsupported character".to_owned(),
+        ));
+    }
+    let state = required_nested_string(object, "state", "operational.state")?;
+    if !matches!(state, "active" | "resolved") {
+        return Err(CliError::Message(
+            "operational.state must be active or resolved".to_owned(),
+        ));
+    }
+    let owner = required_nested_string(object, "owner", "operational.owner")?;
+    if owner.trim().is_empty() || owner.chars().count() > 128 {
+        return Err(CliError::Message(
+            "operational.owner must contain 1-128 characters".to_owned(),
+        ));
+    }
+    let evidence_url = required_nested_string(object, "evidence_url", "operational.evidence_url")?;
+    let parsed = reqwest::Url::parse(evidence_url).map_err(|_| {
+        CliError::Message("operational.evidence_url must be a valid HTTPS URL".to_owned())
+    })?;
+    if evidence_url.chars().count() > 2048
+        || parsed.scheme() != "https"
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+    {
+        return Err(CliError::Message(
+            "operational.evidence_url must be a valid HTTPS URL no longer than 2048 characters"
+                .to_owned(),
+        ));
+    }
+    let observed_at = required_nested_string(object, "observed_at", "operational.observed_at")?;
+    if time::OffsetDateTime::parse(observed_at, &time::format_description::well_known::Rfc3339)
+        .is_err()
+    {
+        return Err(CliError::Message(
+            "operational.observed_at must be an RFC3339 timestamp".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn required_nested_string<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    field: &str,
+    path: &str,
+) -> Result<&'a str> {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| CliError::Message(format!("{path} must be a string")))
+}
+
+fn bounded_operational_string<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    field: &str,
+    max: usize,
+) -> Result<&'a str> {
+    let path = format!("operational.subject.{field}");
+    let value = required_nested_string(object, field, &path)?;
+    if value.is_empty() || value.chars().count() > max {
+        return Err(CliError::Message(format!(
+            "{path} must contain 1-{max} characters"
+        )));
+    }
+    Ok(value)
+}
+
 /// Return the CLI-backed tool manifest.
 pub fn tool_manifest() -> Vec<ToolSpec> {
     vec![
@@ -5072,7 +5265,53 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
         ToolSpec {
             name: "canary_event_capture",
             description: "Capture one bounded telemetry event; an optional operational envelope participates in deterministic incident correlation and keeps evidence out of Canary.",
-            input_schema: json!({"type":"object","required":["service","name","summary"],"properties":{"service":{"type":"string"},"name":{"type":"string"},"summary":{"type":"string"},"severity":{"type":"string","enum":["info","warning","error"]},"attributes":{"type":"object"},"retention_class":{"type":"string","enum":["ephemeral","standard","audit"]},"privacy_policy":{"type":"string","enum":["redacted","public","sensitive"]},"sampling_policy":{"type":"string"},"operational":{"type":"object","additionalProperties":false,"required":["subject","state","owner","evidence_url","observed_at"],"properties":{"subject":{"type":"object","additionalProperties":false,"required":["type","id"],"properties":{"type":{"type":"string"},"id":{"type":"string"}}},"state":{"type":"string","enum":["active","resolved"]},"owner":{"type":"string"},"evidence_url":{"type":"string","format":"uri"},"observed_at":{"type":"string","format":"date-time"}}}}}),
+            input_schema: json!({
+                "type":"object",
+                "additionalProperties":false,
+                "required":["service","name","summary"],
+                "properties":{
+                    "service":{"type":"string","minLength":1},
+                    "name":{"type":"string","minLength":1,"maxLength":128},
+                    "summary":{"type":"string","minLength":1,"maxLength":512},
+                    "severity":{"type":"string","enum":["info","warning","error"]},
+                    "attributes":{"type":"object"},
+                    "retention_class":{"type":"string","enum":["ephemeral","standard","audit"]},
+                    "privacy_policy":{"type":"string","enum":["redacted","public","sensitive"]},
+                    "sampling_policy":{"type":"string","minLength":1},
+                    "operational":{
+                        "type":"object",
+                        "additionalProperties":false,
+                        "required":["subject","state","owner","evidence_url","observed_at"],
+                        "properties":{
+                            "subject":{
+                                "type":"object",
+                                "additionalProperties":false,
+                                "required":["type","id"],
+                                "properties":{
+                                    "type":{"type":"string","minLength":1,"maxLength":64,"pattern":"^[a-z0-9._-]+$"},
+                                    "id":{"type":"string","minLength":1,"maxLength":160,"pattern":"^[A-Za-z0-9._:-]+$"}
+                                }
+                            },
+                            "state":{"type":"string","enum":["active","resolved"]},
+                            "owner":{"type":"string","minLength":1,"maxLength":128},
+                            "evidence_url":{"type":"string","format":"uri","maxLength":2048,"pattern":"^https://"},
+                            "observed_at":{"type":"string","format":"date-time"}
+                        }
+                    }
+                },
+                "oneOf":[
+                    {"not":{"required":["operational"]}},
+                    {
+                        "required":["operational"],
+                        "properties":{
+                            "attributes":{"type":"object","maxProperties":0},
+                            "retention_class":{"const":"audit"},
+                            "privacy_policy":{"const":"redacted"},
+                            "sampling_policy":{"const":"unsampled"}
+                        }
+                    }
+                ]
+            }),
         },
         ToolSpec {
             name: "canary_claims_list",
@@ -6402,6 +6641,20 @@ Vercel CLI completed
             json!(["service", "name", "summary"])
         );
         assert_eq!(
+            tool_by_name["canary_event_capture"].input_schema["additionalProperties"],
+            json!(false)
+        );
+        assert_eq!(
+            tool_by_name["canary_event_capture"].input_schema["properties"]["operational"]["properties"]
+                ["subject"]["properties"]["type"]["pattern"],
+            "^[a-z0-9._-]+$"
+        );
+        assert_eq!(
+            tool_by_name["canary_event_capture"].input_schema["properties"]["operational"]["properties"]
+                ["evidence_url"]["pattern"],
+            "^https://"
+        );
+        assert_eq!(
             tool_by_name["canary_claim_create"].input_schema["required"],
             json!([
                 "subject_type",
@@ -6441,6 +6694,45 @@ Vercel CLI completed
                 tool.name
             );
         }
+    }
+
+    #[test]
+    fn operational_event_normalization_is_discriminated_and_fail_closed()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let valid = json!({
+            "service":"infrastructure-control",
+            "name":"drift.violation",
+            "summary":"Drift detected",
+            "operational":{
+                "subject":{"type":"deployment","id":"production"},
+                "state":"active",
+                "owner":"infrastructure-operator",
+                "evidence_url":"https://evidence.example/receipts/drift",
+                "observed_at":"2026-07-14T14:00:00Z"
+            }
+        });
+        let normalized = normalize_event_payload(valid.clone())?;
+        assert_eq!(normalized["attributes"], json!({}));
+        assert_eq!(normalized["retention_class"], "audit");
+        assert_eq!(normalized["privacy_policy"], "redacted");
+        assert_eq!(normalized["sampling_policy"], "unsampled");
+
+        for (field, value) in [
+            ("attributes", json!({"raw_metrics":[1,2,3]})),
+            ("retention_class", json!("standard")),
+            ("privacy_policy", json!("public")),
+            ("sampling_policy", json!("sampled:0.5")),
+            ("provider_snapshot", json!({"droplets":[1,2,3]})),
+        ] {
+            let mut invalid = valid.clone();
+            invalid[field] = value;
+            assert!(normalize_event_payload(invalid).is_err(), "{field}");
+        }
+
+        let mut insecure = valid;
+        insecure["operational"]["evidence_url"] = json!("http://unsafe.example/receipt");
+        assert!(normalize_event_payload(insecure).is_err());
+        Ok(())
     }
 
     fn temp_project(name: &str) -> std::result::Result<PathBuf, Box<dyn std::error::Error>> {

--- a/crates/canary-cli/src/lib.rs
+++ b/crates/canary-cli/src/lib.rs
@@ -646,7 +646,7 @@ pub fn summarize_annotations(value: &Value) -> Vec<String> {
 
 /// Summarize a telemetry event write receipt.
 pub fn summarize_event(value: &Value) -> Vec<String> {
-    vec![
+    let mut lines = vec![
         format!("id: {}", string_field(value, "id")),
         format!("service: {}", string_field(value, "service")),
         format!("event: {}", string_field(value, "event")),
@@ -661,7 +661,22 @@ pub fn summarize_event(value: &Value) -> Vec<String> {
             "sampling_policy: {}",
             string_field(value, "sampling_policy")
         ),
-    ]
+    ];
+    if let Some(operational) = value.get("operational") {
+        lines.extend([
+            format!(
+                "subject: {} {}",
+                string_field(operational, "subject_type"),
+                string_field(operational, "subject_id")
+            ),
+            format!("owner: {}", string_field(operational, "owner")),
+            format!("observed_at: {}", string_field(operational, "observed_at")),
+            format!("received_at: {}", string_field(operational, "received_at")),
+            format!("incident_id: {}", string_field(value, "incident_id")),
+            format!("incident_event: {}", string_field(value, "incident_event")),
+        ]);
+    }
+    lines
 }
 
 /// Summarize timeline events.
@@ -4621,19 +4636,29 @@ impl McpToolContext {
             }
             "canary_event_capture" => {
                 let client = self.ingest_client()?;
-                let response = client.post_auth_json(
-                    "/api/v1/events",
-                    &json!({
-                        "service": required_string(arguments, "service")?,
-                        "name": required_string(arguments, "name")?,
-                        "summary": required_string(arguments, "summary")?,
-                        "severity": optional_string(arguments, "severity")?.unwrap_or_else(|| "info".to_owned()),
-                        "attributes": optional_object(arguments, "attributes")?.unwrap_or_default(),
-                        "retention_class": optional_string(arguments, "retention_class")?.unwrap_or_else(|| "standard".to_owned()),
-                        "privacy_policy": optional_string(arguments, "privacy_policy")?.unwrap_or_else(|| "redacted".to_owned()),
-                        "sampling_policy": optional_string(arguments, "sampling_policy")?.unwrap_or_else(|| "unsampled".to_owned()),
-                    }),
-                )?;
+                let operational = optional_object(arguments, "operational")?;
+                let retention_class = optional_string(arguments, "retention_class")?
+                    .unwrap_or_else(|| {
+                        if operational.is_some() {
+                            "audit".to_owned()
+                        } else {
+                            "standard".to_owned()
+                        }
+                    });
+                let mut payload = json!({
+                    "service": required_string(arguments, "service")?,
+                    "name": required_string(arguments, "name")?,
+                    "summary": required_string(arguments, "summary")?,
+                    "severity": optional_string(arguments, "severity")?.unwrap_or_else(|| "info".to_owned()),
+                    "attributes": optional_object(arguments, "attributes")?.unwrap_or_default(),
+                    "retention_class": retention_class,
+                    "privacy_policy": optional_string(arguments, "privacy_policy")?.unwrap_or_else(|| "redacted".to_owned()),
+                    "sampling_policy": optional_string(arguments, "sampling_policy")?.unwrap_or_else(|| "unsampled".to_owned()),
+                });
+                if let Some(operational) = operational {
+                    payload["operational"] = Value::Object(operational);
+                }
+                let response = client.post_auth_json("/api/v1/events", &payload)?;
                 Ok(json_envelope(
                     "canary_event_capture",
                     client.endpoint(),
@@ -5046,8 +5071,8 @@ pub fn tool_manifest() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "canary_event_capture",
-            description: "Capture one bounded analytics event as a telemetry.event timeline row.",
-            input_schema: json!({"type":"object","required":["service","name","summary"],"properties":{"service":{"type":"string"},"name":{"type":"string"},"summary":{"type":"string"},"severity":{"type":"string","enum":["info","warning","error"]},"attributes":{"type":"object"},"retention_class":{"type":"string","enum":["ephemeral","standard","audit"]},"privacy_policy":{"type":"string","enum":["redacted","public","sensitive"]},"sampling_policy":{"type":"string"}}}),
+            description: "Capture one bounded telemetry event; an optional operational envelope participates in deterministic incident correlation and keeps evidence out of Canary.",
+            input_schema: json!({"type":"object","required":["service","name","summary"],"properties":{"service":{"type":"string"},"name":{"type":"string"},"summary":{"type":"string"},"severity":{"type":"string","enum":["info","warning","error"]},"attributes":{"type":"object"},"retention_class":{"type":"string","enum":["ephemeral","standard","audit"]},"privacy_policy":{"type":"string","enum":["redacted","public","sensitive"]},"sampling_policy":{"type":"string"},"operational":{"type":"object","additionalProperties":false,"required":["subject","state","owner","evidence_url","observed_at"],"properties":{"subject":{"type":"object","additionalProperties":false,"required":["type","id"],"properties":{"type":{"type":"string"},"id":{"type":"string"}}},"state":{"type":"string","enum":["active","resolved"]},"owner":{"type":"string"},"evidence_url":{"type":"string","format":"uri"},"observed_at":{"type":"string","format":"date-time"}}}}}),
         },
         ToolSpec {
             name: "canary_claims_list",

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -60,7 +60,7 @@ enum Commands {
     Monitors,
     /// Inspect dogfood coverage.
     Dogfood(DogfoodArgs),
-    /// Capture bounded analytics events.
+    /// Capture bounded telemetry or operational events.
     Events(EventsArgs),
     /// Coordinate agentic remediation claims.
     Claims(ClaimsArgs),
@@ -234,7 +234,7 @@ struct EventsArgs {
 
 #[derive(Debug, Subcommand)]
 enum EventsCommand {
-    /// Capture one analytics event.
+    /// Capture one telemetry or operational event.
     Capture(EventCaptureArgs),
 }
 
@@ -250,12 +250,24 @@ struct EventCaptureArgs {
     severity: String,
     #[arg(long = "attribute")]
     attributes: Vec<String>,
-    #[arg(long, default_value = "standard")]
-    retention_class: String,
+    #[arg(long)]
+    retention_class: Option<String>,
     #[arg(long, default_value = "redacted")]
     privacy_policy: String,
     #[arg(long, default_value = "unsampled")]
     sampling_policy: String,
+    #[arg(long)]
+    operational_subject_type: Option<String>,
+    #[arg(long)]
+    operational_subject_id: Option<String>,
+    #[arg(long)]
+    operational_state: Option<String>,
+    #[arg(long)]
+    operational_owner: Option<String>,
+    #[arg(long)]
+    operational_evidence_url: Option<String>,
+    #[arg(long)]
+    operational_observed_at: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -903,19 +915,28 @@ fn jsonrpc_error(id: Value, code: i64, message: &str) -> Value {
 fn run_events_command(args: EventsArgs, client: &ApiClient, mode: RenderMode) -> Result<()> {
     match args.command {
         EventsCommand::Capture(args) => {
-            let response = client.post_auth_json(
-                "/api/v1/events",
-                &json!({
-                    "service": args.service,
-                    "name": args.name,
-                    "summary": args.summary,
-                    "severity": args.severity,
-                    "attributes": parse_attributes(&args.attributes)?,
-                    "retention_class": args.retention_class,
-                    "privacy_policy": args.privacy_policy,
-                    "sampling_policy": args.sampling_policy,
-                }),
-            )?;
+            let operational = operational_event_payload(&args)?;
+            let retention_class = args.retention_class.clone().unwrap_or_else(|| {
+                if operational.is_some() {
+                    "audit".to_owned()
+                } else {
+                    "standard".to_owned()
+                }
+            });
+            let mut payload = json!({
+                "service": args.service,
+                "name": args.name,
+                "summary": args.summary,
+                "severity": args.severity,
+                "attributes": parse_attributes(&args.attributes)?,
+                "retention_class": retention_class,
+                "privacy_policy": args.privacy_policy,
+                "sampling_policy": args.sampling_policy,
+            });
+            if let Some(operational) = operational {
+                payload["operational"] = operational;
+            }
+            let response = client.post_auth_json("/api/v1/events", &payload)?;
             render(
                 "events capture",
                 client.endpoint(),
@@ -925,6 +946,36 @@ fn run_events_command(args: EventsArgs, client: &ApiClient, mode: RenderMode) ->
             )
         }
     }
+}
+
+fn operational_event_payload(args: &EventCaptureArgs) -> Result<Option<Value>> {
+    let values = [
+        args.operational_subject_type.as_deref(),
+        args.operational_subject_id.as_deref(),
+        args.operational_state.as_deref(),
+        args.operational_owner.as_deref(),
+        args.operational_evidence_url.as_deref(),
+        args.operational_observed_at.as_deref(),
+    ];
+    if values.iter().all(Option::is_none) {
+        return Ok(None);
+    }
+    if values.iter().any(Option::is_none) {
+        return Err(CliError::Message(
+            "operational events require --operational-subject-type, --operational-subject-id, --operational-state, --operational-owner, --operational-evidence-url, and --operational-observed-at"
+                .to_owned(),
+        ));
+    }
+    Ok(Some(json!({
+        "subject": {
+            "type": args.operational_subject_type,
+            "id": args.operational_subject_id,
+        },
+        "state": args.operational_state,
+        "owner": args.operational_owner,
+        "evidence_url": args.operational_evidence_url,
+        "observed_at": args.operational_observed_at,
+    })))
 }
 
 fn parse_attributes(attributes: &[String]) -> Result<serde_json::Map<String, serde_json::Value>> {

--- a/crates/canary-cli/src/main.rs
+++ b/crates/canary-cli/src/main.rs
@@ -11,13 +11,14 @@ use canary_cli::{
     ApiClient, CliError, Config, IntegrationEnrollRequest, IntegrationInput, McpToolContext,
     RenderMode, Result, Window, doctor_report, dogfood_strict_failure_count, dogfood_value_report,
     encode, find_repo_root, integration_discover, integration_enroll, integration_patch,
-    integration_plan, integration_status, json_envelope, mcp_tool_manifest, print_json,
-    print_lines, resolve_endpoint_without_config, run_dogfood_inventory, summarize_annotations,
-    summarize_claims, summarize_doctor, summarize_dogfood, summarize_dogfood_value,
-    summarize_error_detail, summarize_event, summarize_incident_detail,
-    summarize_incident_escalation, summarize_incidents, summarize_integration, summarize_monitors,
-    summarize_query, summarize_report, summarize_services, summarize_targets, summarize_timeline,
-    summarize_webhook_delivery, tool_manifest,
+    integration_plan, integration_status, json_envelope, mcp_tool_manifest,
+    normalize_event_payload, print_json, print_lines, resolve_endpoint_without_config,
+    run_dogfood_inventory, summarize_annotations, summarize_claims, summarize_doctor,
+    summarize_dogfood, summarize_dogfood_value, summarize_error_detail, summarize_event,
+    summarize_incident_detail, summarize_incident_escalation, summarize_incidents,
+    summarize_integration, summarize_monitors, summarize_query, summarize_report,
+    summarize_services, summarize_targets, summarize_timeline, summarize_webhook_delivery,
+    tool_manifest,
 };
 use clap::{Args, Parser, Subcommand};
 use serde_json::{Value, json};
@@ -936,6 +937,7 @@ fn run_events_command(args: EventsArgs, client: &ApiClient, mode: RenderMode) ->
             if let Some(operational) = operational {
                 payload["operational"] = operational;
             }
+            let payload = normalize_event_payload(payload)?;
             let response = client.post_auth_json("/api/v1/events", &payload)?;
             render(
                 "events capture",

--- a/crates/canary-core/src/query.rs
+++ b/crates/canary-core/src/query.rs
@@ -144,9 +144,9 @@ pub struct GroupCursor {
 pub struct TimelineCursor {
     /// Last row timestamp from the previous page.
     pub created_at: String,
-    /// Causal rank within one timestamp; causes sort before incident effects.
-    #[serde(default)]
-    pub causal_rank: u8,
+    /// Causal rank within one timestamp; absent on cursors issued before causal ordering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causal_rank: Option<u8>,
     /// Last row id from the previous page.
     pub id: String,
 }
@@ -216,7 +216,7 @@ pub fn decode_timeline_cursor(cursor: &str) -> Option<TimelineCursor> {
     let cursor = serde_json::from_slice::<TimelineCursor>(&decoded).ok()?;
     if cursor.created_at.is_empty()
         || cursor.id.is_empty()
-        || cursor.causal_rank > 1
+        || cursor.causal_rank.is_some_and(|rank| rank > 1)
         || OffsetDateTime::parse(&cursor.created_at, &Rfc3339).is_err()
     {
         return None;
@@ -1603,7 +1603,7 @@ mod tests {
     {
         let cursor = TimelineCursor {
             created_at: "2026-05-28T20:59:50Z".to_owned(),
-            causal_rank: 0,
+            causal_rank: Some(0),
             id: "EVT-b".to_owned(),
         };
         let Some(encoded) = encode_timeline_cursor(&cursor) else {
@@ -1615,6 +1615,23 @@ mod tests {
 
         let malformed = BASE64_URL_SAFE_NO_PAD.encode(r#"{"created_at":1,"id":2}"#);
         assert_eq!(decode_timeline_cursor(&malformed), None);
+        Ok(())
+    }
+
+    #[test]
+    fn timeline_cursor_decoder_preserves_missing_causal_rank_as_legacy()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let encoded =
+            BASE64_URL_SAFE_NO_PAD.encode(r#"{"created_at":"2026-05-28T20:59:50Z","id":"EVT-b"}"#);
+
+        assert_eq!(
+            decode_timeline_cursor(&encoded),
+            Some(TimelineCursor {
+                created_at: "2026-05-28T20:59:50Z".to_owned(),
+                causal_rank: None,
+                id: "EVT-b".to_owned(),
+            })
+        );
         Ok(())
     }
 

--- a/crates/canary-core/src/query.rs
+++ b/crates/canary-core/src/query.rs
@@ -663,6 +663,30 @@ pub struct IncidentDetailSignal {
     /// Current active remediation claim for the signal's underlying subject.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_claim: Option<RemediationClaimSummary>,
+    /// Bounded producer context for caller-defined operational signals.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operational: Option<OperationalSignalContext>,
+}
+
+/// Caller-owned operational signal context returned to incident responders.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OperationalSignalContext {
+    /// Caller-defined signal name.
+    pub name: String,
+    /// Stable caller-defined subject type.
+    pub subject_type: String,
+    /// Stable caller-defined subject id.
+    pub subject_id: String,
+    /// Current producer-declared state.
+    pub state: String,
+    /// Owner responsible for the signal.
+    pub owner: String,
+    /// Link to bounded evidence retained by the producer.
+    pub evidence_url: String,
+    /// Producer observation clock.
+    pub observed_at: String,
+    /// Canary receipt clock.
+    pub received_at: String,
 }
 
 /// Incident annotation view embedded in incident detail.
@@ -884,6 +908,15 @@ pub struct TelemetryEvent {
     pub sampling_policy: String,
     /// Creation timestamp.
     pub created_at: String,
+    /// Bounded operational signal receipt when this event participates in incidents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operational: Option<OperationalSignalContext>,
+    /// Incident event emitted by deterministic correlation, when any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub incident_event: Option<String>,
+    /// Incident id produced or updated by deterministic correlation, when any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub incident_id: Option<String>,
 }
 
 /// Response for `GET /api/v1/timeline`.

--- a/crates/canary-core/src/query.rs
+++ b/crates/canary-core/src/query.rs
@@ -144,6 +144,9 @@ pub struct GroupCursor {
 pub struct TimelineCursor {
     /// Last row timestamp from the previous page.
     pub created_at: String,
+    /// Causal rank within one timestamp; causes sort before incident effects.
+    #[serde(default)]
+    pub causal_rank: u8,
     /// Last row id from the previous page.
     pub id: String,
 }
@@ -213,6 +216,7 @@ pub fn decode_timeline_cursor(cursor: &str) -> Option<TimelineCursor> {
     let cursor = serde_json::from_slice::<TimelineCursor>(&decoded).ok()?;
     if cursor.created_at.is_empty()
         || cursor.id.is_empty()
+        || cursor.causal_rank > 1
         || OffsetDateTime::parse(&cursor.created_at, &Rfc3339).is_err()
     {
         return None;
@@ -1599,6 +1603,7 @@ mod tests {
     {
         let cursor = TimelineCursor {
             created_at: "2026-05-28T20:59:50Z".to_owned(),
+            causal_rank: 0,
             id: "EVT-b".to_owned(),
         };
         let Some(encoded) = encode_timeline_cursor(&cursor) else {

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -1478,6 +1478,200 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn operational_event_opens_updates_signs_and_replays_incident()
+    -> Result<(), Box<dyn Error>> {
+        let path = temp_db_path("operational-incident");
+        let (url, http_server) = spawn_webhook_server(204, &[])?;
+        {
+            let mut store = Store::open(&path)?;
+            store.migrate()?;
+            let _ = store.apply_initial_seed("2026-07-14T14:00:00Z")?;
+            seed_api_key(&mut store, "KEY-ingest", INGEST_KEY, "ingest-only", None)?;
+            seed_api_key(&mut store, "KEY-read", READ_KEY, "read-only", None)?;
+            store.insert_webhook_subscription(webhook_subscription_insert(
+                "WHK-operational-incident",
+                &url,
+                vec!["incident.opened".to_owned()],
+                "test-webhook-secret",
+                true,
+                "2026-07-14T14:00:00Z",
+            ))?;
+        }
+
+        let server = CanaryServer::boot(ServerConfig {
+            webhook_drain_interval: StdDuration::from_millis(10),
+            webhook_transport_builder: local_webhook_transport_builder,
+            ..ServerConfig::new(path.clone())
+        })?;
+        let router = server.router();
+        let first = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/events",
+                INGEST_KEY,
+                r#"{
+                    "service":"infrastructure-control",
+                    "name":"capacity.saturation",
+                    "summary":"Capacity policy crossed its bounded threshold",
+                    "severity":"warning",
+                    "operational":{
+                        "subject":{"type":"capacity","id":"worker-pool-primary"},
+                        "state":"active",
+                        "owner":"infrastructure-operator",
+                        "evidence_url":"https://evidence.example/receipts/capacity-001",
+                        "observed_at":"2026-07-14T14:01:00Z"
+                    }
+                }"#,
+            )?)
+            .await?;
+        assert_eq!(first.status(), StatusCode::CREATED);
+        let first = json_body(first).await?;
+        let incident_id = first["incident_id"]
+            .as_str()
+            .ok_or("operational receipt omitted incident_id")?
+            .to_owned();
+        assert_eq!(first["incident_event"], "incident.opened");
+        assert_eq!(first["operational"]["owner"], "infrastructure-operator");
+        assert_eq!(first["operational"]["observed_at"], "2026-07-14T14:01:00Z");
+        assert!(first["operational"]["received_at"].as_str().is_some());
+        assert_ne!(
+            first["operational"]["observed_at"],
+            first["operational"]["received_at"]
+        );
+
+        let update = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/events",
+                INGEST_KEY,
+                r#"{
+                    "service":"infrastructure-control",
+                    "name":"capacity.saturation",
+                    "summary":"Capacity remains saturated; evidence refreshed",
+                    "severity":"error",
+                    "operational":{
+                        "subject":{"type":"capacity","id":"worker-pool-primary"},
+                        "state":"active",
+                        "owner":"infrastructure-operator",
+                        "evidence_url":"https://evidence.example/receipts/capacity-002",
+                        "observed_at":"2026-07-14T14:02:00Z"
+                    }
+                }"#,
+            )?)
+            .await?;
+        assert_eq!(update.status(), StatusCode::CREATED);
+        let update = json_body(update).await?;
+        assert_eq!(update["incident_event"], "incident.updated");
+        assert_eq!(update["incident_id"], incident_id);
+
+        let active = router
+            .clone()
+            .oneshot(read_request(READ_KEY, "/api/v1/incidents")?)
+            .await?;
+        assert_eq!(active.status(), StatusCode::OK);
+        let active = json_body(active).await?;
+        assert_eq!(active["incidents"][0]["id"], incident_id);
+        assert_eq!(
+            active["incidents"][0]["signals"][0]["signal_type"],
+            "operational_event"
+        );
+
+        let resolved = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/events",
+                INGEST_KEY,
+                r#"{
+                    "service":"infrastructure-control",
+                    "name":"capacity.saturation",
+                    "summary":"Capacity returned within policy",
+                    "severity":"info",
+                    "operational":{
+                        "subject":{"type":"capacity","id":"worker-pool-primary"},
+                        "state":"resolved",
+                        "owner":"infrastructure-operator",
+                        "evidence_url":"https://evidence.example/receipts/capacity-003",
+                        "observed_at":"2026-07-14T14:03:00Z"
+                    }
+                }"#,
+            )?)
+            .await?;
+        assert_eq!(resolved.status(), StatusCode::CREATED);
+        let resolved = json_body(resolved).await?;
+        assert_eq!(resolved["incident_event"], "incident.resolved");
+        assert_eq!(resolved["incident_id"], incident_id);
+
+        let detail = router
+            .clone()
+            .oneshot(read_request(
+                READ_KEY,
+                &format!("/api/v1/incidents/{incident_id}"),
+            )?)
+            .await?;
+        assert_eq!(detail.status(), StatusCode::OK);
+        let detail = json_body(detail).await?;
+        assert_eq!(detail["signals"][0]["type"], "operational_event");
+        assert_eq!(
+            detail["signals"][0]["operational"]["evidence_url"],
+            "https://evidence.example/receipts/capacity-003"
+        );
+        assert_eq!(
+            detail["signals"][0]["operational"]["subject_id"],
+            "worker-pool-primary"
+        );
+
+        let timeline = router
+            .clone()
+            .oneshot(read_request(
+                READ_KEY,
+                "/api/v1/timeline?service=infrastructure-control&limit=10",
+            )?)
+            .await?;
+        assert_eq!(timeline.status(), StatusCode::OK);
+        let timeline = json_body(timeline).await?;
+        let events = timeline["events"]
+            .as_array()
+            .ok_or("missing timeline events")?;
+        assert!(
+            events
+                .iter()
+                .any(|event| event["event"] == "telemetry.event")
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event["event"] == "incident.opened")
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event["event"] == "incident.updated")
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event["event"] == "incident.resolved")
+        );
+
+        wait_for_delivered_webhook(&path)?;
+        let captured = join_http_server(http_server)?;
+        assert_eq!(
+            header_value(&captured.head, "x-event").as_deref(),
+            Some("incident.opened")
+        );
+        assert!(header_value(&captured.head, "x-canary-signature").is_some());
+        assert!(header_value(&captured.head, "x-delivery-id").is_some());
+        assert!(captured.body.contains(&incident_id));
+
+        drop_server(server).await?;
+        fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn canary_server_boot_wires_retention_prune_worker() -> Result<(), Box<dyn Error>> {
         let path = temp_db_path("retention-prune");
         let now = server_time::current_utc();
@@ -5788,6 +5982,103 @@ mod tests {
             invalid_body["errors"]["attributes"],
             json!(["must be an object"])
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn operational_event_names_are_caller_defined_and_payloads_stay_bounded()
+    -> Result<(), Box<dyn Error>> {
+        let router = ingest_router(test_ingest_state()?);
+        for (index, name) in [
+            "cost.anomaly",
+            "drift.violation",
+            "capacity.saturation",
+            "balance.low",
+            "recovery-proof.stale",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let body = serde_json::json!({
+                "service": format!("infrastructure-{index}"),
+                "name": name,
+                "summary": format!("Bounded operational signal {index}"),
+                "severity": "warning",
+                "operational": {
+                    "subject": {"type": "policy", "id": format!("subject-{index}")},
+                    "state": "active",
+                    "owner": "infrastructure-operator",
+                    "evidence_url": format!("https://evidence.example/receipts/{index}"),
+                    "observed_at": "2026-07-14T14:00:00Z"
+                }
+            });
+            let response = router
+                .clone()
+                .oneshot(json_request(
+                    "POST",
+                    "/api/v1/events",
+                    INGEST_KEY,
+                    &body.to_string(),
+                )?)
+                .await?;
+            assert_eq!(response.status(), StatusCode::CREATED, "{name}");
+            let receipt = json_body(response).await?;
+            assert_eq!(receipt["name"], *name);
+            assert_eq!(receipt["incident_event"], "incident.opened");
+        }
+
+        let raw_snapshot = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/events",
+                INGEST_KEY,
+                r#"{
+                    "service":"infrastructure-control",
+                    "name":"drift.violation",
+                    "summary":"raw snapshot must not be warehoused",
+                    "attributes":{"provider_snapshot":{"droplets":[1,2,3]}},
+                    "operational":{
+                        "subject":{"type":"drift","id":"fleet"},
+                        "state":"active",
+                        "owner":"infrastructure-operator",
+                        "evidence_url":"https://evidence.example/receipts/drift",
+                        "observed_at":"2026-07-14T14:00:00Z"
+                    }
+                }"#,
+            )?)
+            .await?;
+        assert_eq!(raw_snapshot.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let problem = json_body(raw_snapshot).await?;
+        assert!(
+            problem["errors"]["attributes"][0]
+                .as_str()
+                .is_some_and(|message| message.contains("must be empty"))
+        );
+
+        let unknown = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/events",
+                INGEST_KEY,
+                r#"{
+                    "service":"infrastructure-control",
+                    "name":"balance.low",
+                    "summary":"unknown high-cardinality field must fail closed",
+                    "operational":{
+                        "subject":{"type":"balance","id":"account"},
+                        "state":"active",
+                        "owner":"infrastructure-operator",
+                        "evidence_url":"https://evidence.example/receipts/balance",
+                        "observed_at":"2026-07-14T14:00:00Z",
+                        "samples":[1,2,3]
+                    }
+                }"#,
+            )?)
+            .await?;
+        assert_eq!(unknown.status(), StatusCode::UNPROCESSABLE_ENTITY);
 
         Ok(())
     }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -2052,6 +2052,19 @@ mod tests {
                 .any(|entity_type| entity_type.as_str() == Some("telemetry_event")),
             "TimelineEvent.entity_type must include telemetry_event"
         );
+        let request = document
+            .pointer("/components/schemas/TelemetryEventRequest")
+            .ok_or("missing TelemetryEventRequest")?;
+        assert_eq!(request["additionalProperties"], json!(false));
+        assert_eq!(request["oneOf"].as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            request["oneOf"][1]["properties"]["retention_class"]["const"],
+            "audit"
+        );
+        assert_eq!(
+            request["oneOf"][1]["properties"]["attributes"]["maxProperties"],
+            0
+        );
 
         Ok(())
     }
@@ -6079,6 +6092,72 @@ mod tests {
             )?)
             .await?;
         assert_eq!(unknown.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        for field in ["raw_metrics", "provider_snapshot", "raw_logs", "raw_traces"] {
+            let mut body = serde_json::json!({
+                "service":"infrastructure-control",
+                "name":"drift.violation",
+                "summary":"unknown top-level payload must fail closed",
+                "operational":{
+                    "subject":{"type":"drift","id":"fleet"},
+                    "state":"active",
+                    "owner":"infrastructure-operator",
+                    "evidence_url":"https://evidence.example/receipts/drift",
+                    "observed_at":"2026-07-14T14:00:00Z"
+                }
+            });
+            body[field] = json!({"samples":[1,2,3]});
+            let response = router
+                .clone()
+                .oneshot(json_request(
+                    "POST",
+                    "/api/v1/events",
+                    INGEST_KEY,
+                    &body.to_string(),
+                )?)
+                .await?;
+            assert_eq!(
+                response.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{field}"
+            );
+            let problem = json_body(response).await?;
+            assert_eq!(problem["errors"][field], json!(["is not allowed"]));
+        }
+
+        for (field, invalid) in [
+            ("retention_class", json!("standard")),
+            ("privacy_policy", json!("public")),
+            ("sampling_policy", json!("sampled:0.5")),
+        ] {
+            let mut body = serde_json::json!({
+                "service":"infrastructure-control",
+                "name":"drift.violation",
+                "summary":"operational settings are invariant",
+                "operational":{
+                    "subject":{"type":"drift","id":"fleet"},
+                    "state":"active",
+                    "owner":"infrastructure-operator",
+                    "evidence_url":"https://evidence.example/receipts/drift",
+                    "observed_at":"2026-07-14T14:00:00Z"
+                }
+            });
+            body[field] = invalid;
+            let response = router
+                .clone()
+                .oneshot(json_request(
+                    "POST",
+                    "/api/v1/events",
+                    INGEST_KEY,
+                    &body.to_string(),
+                )?)
+                .await?;
+            assert_eq!(
+                response.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{field}"
+            );
+        }
 
         Ok(())
     }

--- a/crates/canary-server/src/read_audit.rs
+++ b/crates/canary-server/src/read_audit.rs
@@ -52,6 +52,7 @@ pub(crate) fn record_read_audit(store: &mut Store, key: &VerifiedApiKey, route: 
         privacy_policy: "redacted".to_owned(),
         sampling_policy: "unsampled".to_owned(),
         created_at: now,
+        operational: None,
     };
 
     let _ = store.insert_telemetry_event(event);
@@ -110,6 +111,7 @@ pub(crate) fn record_context_read_audit(
         privacy_policy: "redacted".to_owned(),
         sampling_policy: "unsampled".to_owned(),
         created_at: now,
+        operational: None,
     };
 
     store.insert_telemetry_event(event)?;

--- a/crates/canary-server/src/telemetry_routes.rs
+++ b/crates/canary-server/src/telemetry_routes.rs
@@ -115,6 +115,22 @@ fn parse_event(
     received_at: String,
 ) -> Result<TelemetryEventInsert, ValidationErrors> {
     let mut errors = ValidationErrors::new();
+    reject_unknown_fields(
+        &attrs,
+        "",
+        &[
+            "service",
+            "name",
+            "summary",
+            "severity",
+            "attributes",
+            "retention_class",
+            "privacy_policy",
+            "sampling_policy",
+            "operational",
+        ],
+        &mut errors,
+    );
     let service = required_string(&attrs, "service", &mut errors);
     let name = required_string(&attrs, "name", &mut errors);
     let summary = required_string(&attrs, "summary", &mut errors);
@@ -229,9 +245,11 @@ fn reject_unknown_fields(
         .keys()
         .filter(|field| !allowed.contains(&field.as_str()))
     {
-        errors.insert(
-            format!("{prefix}.{field}"),
-            vec!["is not allowed".to_owned()],
-        );
+        let key = if prefix.is_empty() {
+            field.to_owned()
+        } else {
+            format!("{prefix}.{field}")
+        };
+        errors.insert(key, vec!["is not allowed".to_owned()]);
     }
 }

--- a/crates/canary-server/src/telemetry_routes.rs
+++ b/crates/canary-server/src/telemetry_routes.rs
@@ -10,7 +10,7 @@ use canary_http::{
     request::{MAX_JSON_BODY_BYTES, decode_json_object},
 };
 use canary_ingest::{IngestEffect, ValidationErrors};
-use canary_store::{TelemetryEventError, TelemetryEventInsert};
+use canary_store::{OperationalSignalInsert, TelemetryEventError, TelemetryEventInsert};
 use serde_json::{Map, Value};
 
 use crate::{
@@ -27,6 +27,7 @@ pub(crate) async fn create_event(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response<Body> {
+    let received_at = current_rfc3339();
     if let Err(problem) = check_content_length(&headers) {
         return problem_response(*problem);
     }
@@ -44,7 +45,7 @@ pub(crate) async fn create_event(
         Ok(attrs) => attrs,
         Err(problem) => return problem_response(*problem),
     };
-    let insert = match parse_event(attrs, &key.tenant_id, &key.project_id) {
+    let insert = match parse_event(attrs, &key.tenant_id, &key.project_id, received_at) {
         Ok(insert) => insert,
         Err(errors) => {
             return problem_response(validation_problem("Invalid event payload.", errors));
@@ -60,17 +61,23 @@ pub(crate) async fn create_event(
         Ok(store) => store,
         Err(_) => return problem_response(internal_problem()),
     };
-    let result = store.insert_telemetry_event(insert);
+    let result = store.commit_telemetry_event(insert);
     drop(store);
 
     match result {
-        Ok(event) => {
-            let payload_json = webhook_payload(&event, &tenant_id, &project_id);
+        Ok(commit) => {
+            let payload_json = webhook_payload(&commit.event, &tenant_id, &project_id);
             let _ = state.handle_effects(&[IngestEffect::EnqueueWebhook {
-                event: event.event.clone(),
+                event: commit.event.event.clone(),
                 payload_json,
             }]);
-            json_status_response(StatusCode::CREATED.as_u16(), event)
+            if let Some(incident) = commit.incident_event.as_ref() {
+                let _ = state.handle_effects(&[IngestEffect::EnqueueWebhook {
+                    event: incident.event.clone(),
+                    payload_json: incident.payload_json.clone(),
+                }]);
+            }
+            json_status_response(StatusCode::CREATED.as_u16(), commit.event)
         }
         Err(TelemetryEventError::Validation(errors)) => {
             let mut validation = ValidationErrors::new();
@@ -79,7 +86,9 @@ pub(crate) async fn create_event(
             }
             problem_response(validation_problem("Invalid event payload.", validation))
         }
-        Err(TelemetryEventError::Sqlite(_)) => problem_response(internal_problem()),
+        Err(TelemetryEventError::Sqlite(_) | TelemetryEventError::Store(_)) => {
+            problem_response(internal_problem())
+        }
     }
 }
 
@@ -103,18 +112,13 @@ fn parse_event(
     attrs: Map<String, Value>,
     tenant_id: &str,
     project_id: &str,
+    received_at: String,
 ) -> Result<TelemetryEventInsert, ValidationErrors> {
     let mut errors = ValidationErrors::new();
     let service = required_string(&attrs, "service", &mut errors);
     let name = required_string(&attrs, "name", &mut errors);
     let summary = required_string(&attrs, "summary", &mut errors);
     let severity = optional_string(attrs.get("severity")).unwrap_or_else(|| "info".to_owned());
-    let retention_class =
-        optional_string(attrs.get("retention_class")).unwrap_or_else(|| "standard".to_owned());
-    let privacy_policy =
-        optional_string(attrs.get("privacy_policy")).unwrap_or_else(|| "redacted".to_owned());
-    let sampling_policy =
-        optional_string(attrs.get("sampling_policy")).unwrap_or_else(|| "unsampled".to_owned());
     let attributes = attrs
         .get("attributes")
         .cloned()
@@ -125,6 +129,18 @@ fn parse_event(
             vec!["must be an object".to_owned()],
         );
     }
+    let operational = parse_operational(attrs.get("operational"), &mut errors);
+    let retention_class = optional_string(attrs.get("retention_class")).unwrap_or_else(|| {
+        if operational.is_some() {
+            "audit".to_owned()
+        } else {
+            "standard".to_owned()
+        }
+    });
+    let privacy_policy =
+        optional_string(attrs.get("privacy_policy")).unwrap_or_else(|| "redacted".to_owned());
+    let sampling_policy =
+        optional_string(attrs.get("sampling_policy")).unwrap_or_else(|| "unsampled".to_owned());
     if !errors.is_empty() {
         return Err(errors);
     }
@@ -141,6 +157,81 @@ fn parse_event(
         retention_class,
         privacy_policy,
         sampling_policy,
-        created_at: current_rfc3339(),
+        created_at: received_at,
+        operational,
     })
+}
+
+fn parse_operational(
+    value: Option<&Value>,
+    errors: &mut ValidationErrors,
+) -> Option<OperationalSignalInsert> {
+    let value = value?;
+    let Some(object) = value.as_object() else {
+        errors.insert(
+            "operational".to_owned(),
+            vec!["must be an object".to_owned()],
+        );
+        return None;
+    };
+    reject_unknown_fields(
+        object,
+        "operational",
+        &["subject", "state", "owner", "evidence_url", "observed_at"],
+        errors,
+    );
+    let subject = match object.get("subject").and_then(Value::as_object) {
+        Some(subject) => subject,
+        None => {
+            errors.insert(
+                "operational.subject".to_owned(),
+                vec!["must be an object".to_owned()],
+            );
+            return None;
+        }
+    };
+    reject_unknown_fields(subject, "operational.subject", &["type", "id"], errors);
+    let subject_type = required_string(subject, "type", errors);
+    let subject_id = required_string(subject, "id", errors);
+    let state = required_string(object, "state", errors);
+    let owner = required_string(object, "owner", errors);
+    let evidence_url = required_string(object, "evidence_url", errors);
+    let observed_at = required_string(object, "observed_at", errors);
+    if subject_type.is_none()
+        || subject_id.is_none()
+        || state.is_none()
+        || owner.is_none()
+        || evidence_url.is_none()
+        || observed_at.is_none()
+    {
+        return None;
+    }
+
+    Some(OperationalSignalInsert {
+        subject_type: subject_type.unwrap_or_default(),
+        subject_id: subject_id.unwrap_or_default(),
+        state: state.unwrap_or_default(),
+        owner: owner.unwrap_or_default(),
+        evidence_url: evidence_url.unwrap_or_default(),
+        observed_at: observed_at.unwrap_or_default(),
+        incident_id: canary_core::ids::IncidentId::generate(),
+        incident_event_id: canary_core::ids::EventId::generate(),
+    })
+}
+
+fn reject_unknown_fields(
+    object: &Map<String, Value>,
+    prefix: &str,
+    allowed: &[&str],
+    errors: &mut ValidationErrors,
+) {
+    for field in object
+        .keys()
+        .filter(|field| !allowed.contains(&field.as_str()))
+    {
+        errors.insert(
+            format!("{prefix}.{field}"),
+            vec!["is not allowed".to_owned()],
+        );
+    }
 }

--- a/crates/canary-store/Cargo.toml
+++ b/crates/canary-store/Cargo.toml
@@ -13,6 +13,7 @@ rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1.0"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting", "parsing"] }
+url = "2.5"
 
 [lints]
 workspace = true

--- a/crates/canary-store/src/incidents.rs
+++ b/crates/canary-store/src/incidents.rs
@@ -51,6 +51,8 @@ pub struct IncidentCorrelationEvent {
     pub id: String,
     /// JSON payload sent to responders.
     pub payload_json: String,
+    /// Incident subject opened or updated by the correlation.
+    pub incident_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +101,7 @@ pub(crate) fn correlate_in_transaction(
         &command.signal_ref,
         &command.tenant_id,
         &command.project_id,
+        &command.service,
         &command.now,
     )?;
     match open_incident(
@@ -158,6 +161,7 @@ fn update_incident(
         &incident.id,
         &incident.tenant_id,
         &incident.project_id,
+        &incident.service,
         &command.now,
     )?;
     let mut incident =
@@ -214,6 +218,15 @@ fn sync_signal(
             )?;
             Ok((true, false))
         }
+        (Some(signal), true) if command.signal_type == "operational_event" => {
+            transaction.execute(
+                "UPDATE incident_signals
+                 SET attached_at = ?1
+                 WHERE id = ?2",
+                params![command.now, signal.id],
+            )?;
+            Ok((true, false))
+        }
         (Some(signal), false) if signal.resolved_at.is_none() => {
             transaction.execute(
                 "UPDATE incident_signals
@@ -232,6 +245,7 @@ fn normalize_signals(
     incident_id: &str,
     tenant_id: &str,
     project_id: &str,
+    service: &str,
     now: &str,
 ) -> Result<bool> {
     let mut changed = false;
@@ -242,6 +256,7 @@ fn normalize_signals(
             &signal.signal_ref,
             tenant_id,
             project_id,
+            service,
             now,
         )?;
         if active && signal.resolved_at.is_some() {
@@ -344,7 +359,10 @@ fn desired_severity(active_signals: &[&SignalRow], now: &str) -> String {
 
 fn signal_counts_for_severity(signal: &SignalRow, now: &str) -> bool {
     // Intentional divergence: health-transition signals are active state, not attached_at recency.
-    signal.signal_type == "health_transition" || within_active_window(&signal.attached_at, now)
+    matches!(
+        signal.signal_type.as_str(),
+        "health_transition" | "operational_event"
+    ) || within_active_window(&signal.attached_at, now)
 }
 
 fn signal_active(
@@ -353,6 +371,7 @@ fn signal_active(
     signal_ref: &str,
     tenant_id: &str,
     project_id: &str,
+    service: &str,
     now: &str,
 ) -> Result<bool> {
     match signal_type {
@@ -376,6 +395,22 @@ fn signal_active(
             Ok(target
                 .or(monitor)
                 .is_some_and(|state| HealthState::persisted_incident_signal_active(&state)))
+        }
+        "operational_event" => {
+            let state = transaction
+                .query_row(
+                    "SELECT json_extract(payload, '$.operational.state')
+                     FROM service_events
+                     WHERE tenant_id = ?1 AND project_id = ?2 AND service = ?3
+                       AND entity_type = 'operational_signal' AND entity_ref = ?4
+                     ORDER BY created_at DESC, rowid DESC
+                     LIMIT 1",
+                    params![tenant_id, project_id, service, signal_ref],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()?
+                .flatten();
+            Ok(state.as_deref() == Some("active"))
         }
         _ => Ok(false),
     }
@@ -543,6 +578,7 @@ fn insert_incident_event(
         event: event.to_owned(),
         id: command.event_id.to_string(),
         payload_json,
+        incident_id: incident.id.clone(),
     })
 }
 

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -5160,6 +5160,74 @@ mod tests {
     }
 
     #[test]
+    fn operational_timeline_pages_keep_cause_before_incident_effect()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        let created_at = "2026-05-28T20:59:50Z";
+        let commit = store.commit_telemetry_event(TelemetryEventInsert {
+            id: EventId::from_str("EVT-aaaaaaaaaaaa")?,
+            tenant_id: BOOTSTRAP_TENANT_ID.to_owned(),
+            project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
+            service: "infrastructure-control".to_owned(),
+            name: "drift.violation".to_owned(),
+            severity: "warning".to_owned(),
+            summary: "Declared state differs from observed state".to_owned(),
+            attributes_json: "{}".to_owned(),
+            retention_class: "audit".to_owned(),
+            privacy_policy: "redacted".to_owned(),
+            sampling_policy: "unsampled".to_owned(),
+            created_at: created_at.to_owned(),
+            operational: Some(OperationalSignalInsert {
+                subject_type: "deployment".to_owned(),
+                subject_id: "production".to_owned(),
+                state: "active".to_owned(),
+                owner: "infrastructure-operator".to_owned(),
+                evidence_url: "https://evidence.example/receipts/drift".to_owned(),
+                observed_at: created_at.to_owned(),
+                incident_id: IncidentId::from_str("INC-cccccccccccc")?,
+                incident_event_id: EventId::from_str("EVT-zzzzzzzzzzzz")?,
+            }),
+        })?;
+        assert_eq!(
+            commit
+                .incident_event
+                .as_ref()
+                .map(|event| event.event.as_str()),
+            Some("incident.opened")
+        );
+
+        let now = OffsetDateTime::parse("2026-05-28T21:00:00Z", &Rfc3339)?;
+        let first = query::timeline_at(
+            &store.connection,
+            "1h",
+            TimelineQueryOptions {
+                service: Some("infrastructure-control".to_owned()),
+                limit: Some("1".to_owned()),
+                ..TimelineQueryOptions::default()
+            },
+            now,
+        )?;
+        assert_eq!(first.events[0].event, "telemetry.event");
+        assert!(first.cursor.is_some());
+
+        let second = query::timeline_at(
+            &store.connection,
+            "1h",
+            TimelineQueryOptions {
+                service: Some("infrastructure-control".to_owned()),
+                limit: Some("1".to_owned()),
+                cursor: first.cursor,
+                ..TimelineQueryOptions::default()
+            },
+            now,
+        )?;
+        assert_eq!(second.events[0].event, "incident.opened");
+        assert!(second.cursor.is_none());
+
+        Ok(())
+    }
+
+    #[test]
     fn active_incidents_filters_inactive_signals_and_annotation_actions()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut store = migrated_store()?;

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -1317,6 +1317,7 @@ mod tests {
         health::state_machine::HealthState,
         ids::{ClaimId, ErrorId, EventId, IncidentId},
         ingest::classification::{Category, Classification, Component, Persistence},
+        query::{TimelineCursor, decode_timeline_cursor, encode_timeline_cursor},
     };
     use rusqlite::params;
     use serde_json::{Value, json};
@@ -5223,6 +5224,68 @@ mod tests {
         )?;
         assert_eq!(second.events[0].event, "incident.opened");
         assert!(second.cursor.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_timeline_cursors_continue_without_duplicate_or_skip_for_either_anchor_class()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let store = migrated_store()?;
+        let created_at = "2026-05-28T20:59:50Z";
+        for (id, event) in [
+            ("EVT-z", "telemetry.event"),
+            ("EVT-y", "incident.opened"),
+            ("EVT-x", "telemetry.event"),
+            ("EVT-w", "incident.updated"),
+        ] {
+            store.connection.execute(
+                "INSERT INTO service_events (
+                    id, service, event, entity_type, entity_ref, severity, summary, payload, created_at
+                 ) VALUES (?1, 'legacy-cursor', ?2, 'deployment', 'production', 'warning',
+                    'summary', '{}', ?3)",
+                params![id, event, created_at],
+            )?;
+        }
+        let now = OffsetDateTime::parse("2026-05-28T21:00:00Z", &Rfc3339)?;
+
+        for (anchor, expected) in [
+            ("EVT-z", vec!["EVT-y", "EVT-x", "EVT-w"]),
+            ("EVT-y", vec!["EVT-x", "EVT-w"]),
+        ] {
+            let mut cursor = encode_timeline_cursor(&TimelineCursor {
+                created_at: created_at.to_owned(),
+                causal_rank: None,
+                id: anchor.to_owned(),
+            });
+            let mut actual = Vec::new();
+
+            loop {
+                let page = query::timeline_at(
+                    &store.connection,
+                    "1h",
+                    TimelineQueryOptions {
+                        service: Some("legacy-cursor".to_owned()),
+                        limit: Some("1".to_owned()),
+                        cursor,
+                        ..TimelineQueryOptions::default()
+                    },
+                    now,
+                )?;
+                actual.extend(page.events.into_iter().map(|event| event.id));
+                let Some(next_cursor) = page.cursor else {
+                    break;
+                };
+                assert_eq!(
+                    decode_timeline_cursor(&next_cursor).and_then(|cursor| cursor.causal_rank),
+                    None,
+                    "legacy continuation must not guess the anchor event class"
+                );
+                cursor = Some(next_cursor);
+            }
+
+            assert_eq!(actual, expected, "legacy anchor {anchor}");
+        }
 
         Ok(())
     }

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -78,7 +78,10 @@ pub use retention::{
 pub use service_sli::{
     MIN_TRAJECTORY_SAMPLES, ServiceSliSummary, ServiceSliTrajectory, TrajectoryStatus,
 };
-pub use telemetry::{TelemetryEventError, TelemetryEventInsert, TelemetryEventResult};
+pub use telemetry::{
+    OperationalSignalInsert, TelemetryEventCommit, TelemetryEventError, TelemetryEventInsert,
+    TelemetryEventResult,
+};
 pub use webhook_deliveries::{
     WebhookDeliveryInsert, WebhookDeliveryListOptions, WebhookDeliveryPageError,
     WebhookDeliveryPageOptions, WebhookDeliveryPageResult, WebhookDeliveryRow,
@@ -163,7 +166,15 @@ impl Store {
         &mut self,
         event: TelemetryEventInsert,
     ) -> TelemetryEventResult<canary_core::query::TelemetryEvent> {
-        telemetry::insert_event(&self.connection, event)
+        telemetry::insert_event(&mut self.connection, event).map(|commit| commit.event)
+    }
+
+    /// Persist one bounded event and return its atomic incident-correlation outcome.
+    pub fn commit_telemetry_event(
+        &mut self,
+        event: TelemetryEventInsert,
+    ) -> TelemetryEventResult<TelemetryEventCommit> {
+        telemetry::insert_event(&mut self.connection, event)
     }
 
     /// Correlate one post-commit signal into Canary's incident graph.
@@ -5098,6 +5109,7 @@ mod tests {
             privacy_policy: "redacted".to_owned(),
             sampling_policy: "sampled:0.25".to_owned(),
             created_at: "2026-05-28T20:59:50Z".to_owned(),
+            operational: None,
         })?;
 
         assert_eq!(event.event, "telemetry.event");
@@ -5140,6 +5152,7 @@ mod tests {
             privacy_policy: "unknown".to_owned(),
             sampling_policy: "".to_owned(),
             created_at: "2026-05-28T20:59:51Z".to_owned(),
+            operational: None,
         });
         assert!(matches!(invalid, Err(TelemetryEventError::Validation(_))));
 

--- a/crates/canary-store/src/query.rs
+++ b/crates/canary-store/src/query.rs
@@ -761,13 +761,24 @@ pub(crate) fn timeline_at(
         filters.extend(event_types.iter().cloned());
     }
     if let Some(cursor) = cursor.as_ref() {
-        sql.push_str(" AND (created_at < ? OR (created_at = ? AND id < ?))");
+        sql.push_str(
+            " AND (created_at < ? OR (created_at = ? AND (
+                CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END > ?
+                OR (CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END = ? AND id < ?)
+            )))",
+        );
         filters.push(cursor.created_at.clone());
         filters.push(cursor.created_at.clone());
+        filters.push(cursor.causal_rank.to_string());
+        filters.push(cursor.causal_rank.to_string());
         filters.push(cursor.id.clone());
     }
 
-    sql.push_str(" ORDER BY created_at DESC, id DESC LIMIT ?");
+    sql.push_str(
+        " ORDER BY created_at DESC,
+          CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END ASC,
+          id DESC LIMIT ?",
+    );
     filters.push((limit + 1).to_string());
 
     let mut statement = connection.prepare(&sql)?;
@@ -799,6 +810,7 @@ pub(crate) fn timeline_at(
         rows.last().and_then(|event| {
             encode_timeline_cursor(&TimelineCursor {
                 created_at: event.created_at.clone(),
+                causal_rank: timeline_causal_rank(&event.event),
                 id: event.id.clone(),
             })
         })
@@ -807,6 +819,10 @@ pub(crate) fn timeline_at(
     };
 
     Ok(timeline_response(rows, service, window, cursor))
+}
+
+fn timeline_causal_rank(event: &str) -> u8 {
+    u8::from(event.starts_with("incident."))
 }
 
 pub(crate) fn error_detail(

--- a/crates/canary-store/src/query.rs
+++ b/crates/canary-store/src/query.rs
@@ -760,25 +760,42 @@ pub(crate) fn timeline_at(
         sql.push(')');
         filters.extend(event_types.iter().cloned());
     }
+    let legacy_cursor = cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.causal_rank.is_none());
     if let Some(cursor) = cursor.as_ref() {
-        sql.push_str(
-            " AND (created_at < ? OR (created_at = ? AND (
-                CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END > ?
-                OR (CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END = ? AND id < ?)
-            )))",
-        );
-        filters.push(cursor.created_at.clone());
-        filters.push(cursor.created_at.clone());
-        filters.push(cursor.causal_rank.to_string());
-        filters.push(cursor.causal_rank.to_string());
-        filters.push(cursor.id.clone());
+        match cursor.causal_rank {
+            Some(causal_rank) => {
+                sql.push_str(
+                    " AND (created_at < ? OR (created_at = ? AND (
+                        CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END > ?
+                        OR (CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END = ? AND id < ?)
+                    )))",
+                );
+                filters.push(cursor.created_at.clone());
+                filters.push(cursor.created_at.clone());
+                filters.push(causal_rank.to_string());
+                filters.push(causal_rank.to_string());
+                filters.push(cursor.id.clone());
+            }
+            None => {
+                sql.push_str(" AND (created_at < ? OR (created_at = ? AND id < ?))");
+                filters.push(cursor.created_at.clone());
+                filters.push(cursor.created_at.clone());
+                filters.push(cursor.id.clone());
+            }
+        }
     }
 
-    sql.push_str(
-        " ORDER BY created_at DESC,
-          CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END ASC,
-          id DESC LIMIT ?",
-    );
+    if legacy_cursor {
+        sql.push_str(" ORDER BY created_at DESC, id DESC LIMIT ?");
+    } else {
+        sql.push_str(
+            " ORDER BY created_at DESC,
+              CASE WHEN event LIKE 'incident.%' THEN '1' ELSE '0' END ASC,
+              id DESC LIMIT ?",
+        );
+    }
     filters.push((limit + 1).to_string());
 
     let mut statement = connection.prepare(&sql)?;
@@ -810,7 +827,7 @@ pub(crate) fn timeline_at(
         rows.last().and_then(|event| {
             encode_timeline_cursor(&TimelineCursor {
                 created_at: event.created_at.clone(),
-                causal_rank: timeline_causal_rank(&event.event),
+                causal_rank: (!legacy_cursor).then(|| timeline_causal_rank(&event.event)),
                 id: event.id.clone(),
             })
         })

--- a/crates/canary-store/src/query.rs
+++ b/crates/canary-store/src/query.rs
@@ -4,12 +4,12 @@ use canary_core::{
         ActiveIncident, ActiveIncidentSignal, ActiveIncidents, ErrorClassAggregate,
         ErrorClassification, ErrorDetail, ErrorDetailGroup, ErrorGroupSummary, ErrorsByClass,
         ErrorsByErrorClass, ErrorsByService, IncidentAnnotation, IncidentDetail,
-        IncidentDetailIncident, IncidentDetailSignal, IncidentTimelineEvent, QueryCursor,
-        QueryWindow, RemediationClaim, RemediationClaimSummary, TimelineCursor, TimelineEvent,
-        TimelineResponse, active_incidents_response, decode_cursor, decode_timeline_cursor,
-        encode_timeline_cursor, error_detail_response, errors_by_class_response,
-        errors_by_error_class_response, errors_by_service_response, incident_detail_response,
-        timeline_response,
+        IncidentDetailIncident, IncidentDetailSignal, IncidentTimelineEvent,
+        OperationalSignalContext, QueryCursor, QueryWindow, RemediationClaim,
+        RemediationClaimSummary, TimelineCursor, TimelineEvent, TimelineResponse,
+        active_incidents_response, decode_cursor, decode_timeline_cursor, encode_timeline_cursor,
+        error_detail_response, errors_by_class_response, errors_by_error_class_response,
+        errors_by_service_response, incident_detail_response, timeline_response,
     },
     webhook_events,
 };
@@ -896,7 +896,7 @@ pub(crate) fn active_incidents_at(
 
         let signals = incident_signals(connection, &row.id)?;
         let signal_owner = row.owner();
-        let active_signals = active_signals(connection, signals, signal_owner, now)?;
+        let active_signals = active_signals(connection, signals, signal_owner, &row.service, now)?;
 
         if active_signals.is_empty() {
             continue;
@@ -969,8 +969,13 @@ fn incident_detail_for_owner(
     let now_string = now
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
-    let signal_context =
-        load_incident_signal_context(connection, &signal_rows, signal_owner, &now_string)?;
+    let signal_context = load_incident_signal_context(
+        connection,
+        &signal_rows,
+        signal_owner,
+        &incident.service,
+        &now_string,
+    )?;
     let signals = signal_rows
         .iter()
         .map(|signal| format_incident_signal(signal, &signal_context))
@@ -1168,6 +1173,7 @@ struct IncidentSignalContext {
     error_groups: std::collections::HashMap<String, ErrorGroupSignalContext>,
     targets: std::collections::HashMap<String, TargetSignalContext>,
     monitors: std::collections::HashMap<String, MonitorSignalContext>,
+    operational: std::collections::HashMap<String, OperationalSignalContext>,
     annotation_counts: std::collections::HashMap<(String, String), u64>,
     claim_summaries: std::collections::HashMap<(String, String), RemediationClaimSummary>,
 }
@@ -1347,10 +1353,12 @@ fn load_incident_signal_context(
     connection: &Connection,
     signals: &[IncidentDetailSignalRow],
     owner: Option<(&str, &str)>,
+    service: &str,
     now: &str,
 ) -> QueryResult<IncidentSignalContext> {
     let error_refs = signal_refs_for_detail(signals, "error_group");
     let health_refs = signal_refs_for_detail(signals, "health_transition");
+    let operational_refs = signal_refs_for_detail(signals, "operational_event");
     let target_refs = health_refs
         .iter()
         .filter(|reference| reference.starts_with("TGT-"))
@@ -1366,9 +1374,62 @@ fn load_incident_signal_context(
         error_groups: load_error_group_signal_context(connection, &error_refs, owner)?,
         targets: load_target_signal_context(connection, &target_refs)?,
         monitors: load_monitor_signal_context(connection, &monitor_refs)?,
+        operational: load_operational_signal_context(
+            connection,
+            &operational_refs,
+            owner,
+            service,
+        )?,
         annotation_counts: load_signal_annotation_counts(connection, signals, owner)?,
         claim_summaries: load_signal_claim_summaries(connection, signals, owner, now)?,
     })
+}
+
+fn load_operational_signal_context(
+    connection: &Connection,
+    refs: &[String],
+    owner: Option<(&str, &str)>,
+    service: &str,
+) -> QueryResult<std::collections::HashMap<String, OperationalSignalContext>> {
+    let Some((tenant_id, project_id)) = owner else {
+        return Ok(std::collections::HashMap::new());
+    };
+    let mut statement = connection.prepare(
+        "SELECT signal_name,
+                json_extract(payload, '$.operational.subject_type'),
+                json_extract(payload, '$.operational.subject_id'),
+                json_extract(payload, '$.operational.state'),
+                json_extract(payload, '$.operational.owner'),
+                json_extract(payload, '$.operational.evidence_url'),
+                json_extract(payload, '$.operational.observed_at'),
+                json_extract(payload, '$.operational.received_at')
+         FROM service_events
+         WHERE tenant_id = ?1 AND project_id = ?2 AND service = ?3
+           AND entity_type = 'operational_signal' AND entity_ref = ?4
+         ORDER BY created_at DESC, rowid DESC
+         LIMIT 1",
+    )?;
+    let mut context = std::collections::HashMap::new();
+    for signal_ref in refs {
+        let value = statement
+            .query_row(params![tenant_id, project_id, service, signal_ref], |row| {
+                Ok(OperationalSignalContext {
+                    name: row.get(0)?,
+                    subject_type: row.get(1)?,
+                    subject_id: row.get(2)?,
+                    state: row.get(3)?,
+                    owner: row.get(4)?,
+                    evidence_url: row.get(5)?,
+                    observed_at: row.get(6)?,
+                    received_at: row.get(7)?,
+                })
+            })
+            .optional()?;
+        if let Some(value) = value {
+            context.insert(signal_ref.clone(), value);
+        }
+    }
+    Ok(context)
 }
 
 fn signal_refs_for_detail(signals: &[IncidentDetailSignalRow], signal_type: &str) -> Vec<String> {
@@ -1742,6 +1803,44 @@ fn format_incident_signal(
         "health_transition" if signal.signal_ref.starts_with("MON-") => {
             format_monitor_signal(signal, context)
         }
+        "operational_event" => {
+            let operational = context.operational.get(&signal.signal_ref).cloned();
+            IncidentDetailSignal {
+                signal_type: "operational_event".to_owned(),
+                summary: operational.as_ref().map_or_else(
+                    || {
+                        format!(
+                            "Operational signal {} (detail unavailable).",
+                            signal.signal_ref
+                        )
+                    },
+                    |value| {
+                        format!(
+                            "{} {} is {} (owner {}).",
+                            value.subject_type, value.subject_id, value.state, value.owner
+                        )
+                    },
+                ),
+                group_hash: None,
+                error_class: None,
+                total_count: None,
+                first_seen_at: None,
+                last_seen_at: None,
+                classification: None,
+                target_id: None,
+                target_name: None,
+                monitor_id: None,
+                monitor_name: None,
+                current_state: operational.as_ref().map(|value| value.state.clone()),
+                consecutive_failures: None,
+                signal_ref: Some(signal.signal_ref.clone()),
+                attached_at: signal.attached_at.clone(),
+                resolved_at: signal.resolved_at.clone(),
+                annotation_count: 0,
+                current_claim: None,
+                operational,
+            }
+        }
         "health_transition" => IncidentDetailSignal {
             signal_type: "health_transition".to_owned(),
             summary: format!(
@@ -1765,6 +1864,7 @@ fn format_incident_signal(
             resolved_at: signal.resolved_at.clone(),
             annotation_count: 0,
             current_claim: claim_summary(context, &signal.signal_type, &signal.signal_ref),
+            operational: None,
         },
         _ => IncidentDetailSignal {
             signal_type: signal.signal_type.clone(),
@@ -1789,6 +1889,7 @@ fn format_incident_signal(
             resolved_at: signal.resolved_at.clone(),
             annotation_count: annotation_count(context, &signal.signal_type, &signal.signal_ref),
             current_claim: claim_summary(context, &signal.signal_type, &signal.signal_ref),
+            operational: None,
         },
     }
 }
@@ -1838,6 +1939,7 @@ fn format_error_group_signal(
         resolved_at: signal.resolved_at.clone(),
         annotation_count: annotation_count(context, &signal.signal_type, &signal.signal_ref),
         current_claim: claim_summary(context, &signal.signal_type, &signal.signal_ref),
+        operational: None,
     }
 }
 
@@ -1884,6 +1986,7 @@ fn format_target_signal(
         resolved_at: signal.resolved_at.clone(),
         annotation_count: annotation_count(context, &signal.signal_type, &signal.signal_ref),
         current_claim: claim_summary(context, &signal.signal_type, &signal.signal_ref),
+        operational: None,
     }
 }
 
@@ -1924,6 +2027,7 @@ fn format_monitor_signal(
         resolved_at: signal.resolved_at.clone(),
         annotation_count: annotation_count(context, &signal.signal_type, &signal.signal_ref),
         current_claim: claim_summary(context, &signal.signal_type, &signal.signal_ref),
+        operational: None,
     }
 }
 
@@ -2018,6 +2122,7 @@ fn active_signals(
     connection: &Connection,
     signals: Vec<IncidentSignalRow>,
     owner: Option<(&str, &str)>,
+    service: &str,
     now: OffsetDateTime,
 ) -> QueryResult<Vec<ActiveIncidentSignal>> {
     let mut active = Vec::new();
@@ -2027,7 +2132,7 @@ fn active_signals(
             continue;
         }
 
-        if signal_active_for_report(connection, &signal, owner, now)? {
+        if signal_active_for_report(connection, &signal, owner, service, now)? {
             active.push(ActiveIncidentSignal {
                 signal_type: signal.signal_type,
                 signal_ref: signal.signal_ref,
@@ -2044,13 +2149,42 @@ fn signal_active_for_report(
     connection: &Connection,
     signal: &IncidentSignalRow,
     owner: Option<(&str, &str)>,
+    service: &str,
     now: OffsetDateTime,
 ) -> QueryResult<bool> {
     match signal.signal_type.as_str() {
         "health_transition" => health_signal_active(connection, &signal.signal_ref),
         "error_group" => error_group_signal_active(connection, &signal.signal_ref, owner, now),
+        "operational_event" => {
+            operational_signal_active(connection, &signal.signal_ref, owner, service)
+        }
         _ => Ok(false),
     }
+}
+
+fn operational_signal_active(
+    connection: &Connection,
+    signal_ref: &str,
+    owner: Option<(&str, &str)>,
+    service: &str,
+) -> QueryResult<bool> {
+    let Some((tenant_id, project_id)) = owner else {
+        return Ok(false);
+    };
+    let state = connection
+        .query_row(
+            "SELECT json_extract(payload, '$.operational.state')
+             FROM service_events
+             WHERE tenant_id = ?1 AND project_id = ?2 AND service = ?3
+               AND entity_type = 'operational_signal' AND entity_ref = ?4
+             ORDER BY created_at DESC, rowid DESC
+             LIMIT 1",
+            params![tenant_id, project_id, service, signal_ref],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    Ok(state.as_deref() == Some("active"))
 }
 
 fn health_signal_active(connection: &Connection, signal_ref: &str) -> QueryResult<bool> {
@@ -2157,8 +2291,11 @@ fn incident_severity(signals: &[ActiveIncidentSignal], now: OffsetDateTime) -> S
 }
 
 fn signal_counts_for_severity(signal: &ActiveIncidentSignal, now: OffsetDateTime) -> bool {
-    // Intentional divergence: health-transition signals are active state, not attached_at recency.
-    signal.signal_type == "health_transition" || within_incident_window(&signal.attached_at, now)
+    // Health and operational signals are active state, not attached_at recency.
+    matches!(
+        signal.signal_type.as_str(),
+        "health_transition" | "operational_event"
+    ) || within_incident_window(&signal.attached_at, now)
 }
 
 fn within_incident_window(timestamp: &str, now: OffsetDateTime) -> bool {

--- a/crates/canary-store/src/telemetry.rs
+++ b/crates/canary-store/src/telemetry.rs
@@ -1,6 +1,9 @@
 //! Bounded consumer telemetry events backed by the service timeline.
 
-use canary_core::{ids::EventId, query::TelemetryEvent};
+use canary_core::{
+    ids::{EventId, IncidentId},
+    query::{OperationalSignalContext, TelemetryEvent},
+};
 use rusqlite::{Connection, params, types::Type};
 use serde_json::Value;
 
@@ -36,6 +39,29 @@ pub struct TelemetryEventInsert {
     pub sampling_policy: String,
     /// Creation timestamp.
     pub created_at: String,
+    /// Optional bounded operational signal that participates in incident correlation.
+    pub operational: Option<OperationalSignalInsert>,
+}
+
+/// Bounded caller-defined operational signal carried by one telemetry event.
+#[derive(Debug, Clone)]
+pub struct OperationalSignalInsert {
+    /// Stable caller-defined subject type.
+    pub subject_type: String,
+    /// Stable caller-defined subject id.
+    pub subject_id: String,
+    /// Producer-declared current state (`active` or `resolved`).
+    pub state: String,
+    /// Responsible owner.
+    pub owner: String,
+    /// Link to evidence retained outside Canary.
+    pub evidence_url: String,
+    /// Producer observation clock.
+    pub observed_at: String,
+    /// Incident id reserved for a possible open.
+    pub incident_id: IncidentId,
+    /// Incident event id reserved for a possible open or update.
+    pub incident_event_id: EventId,
 }
 
 /// Telemetry persistence failure.
@@ -47,17 +73,42 @@ pub enum TelemetryEventError {
     /// SQLite rejected the write.
     #[error("sqlite error: {0}")]
     Sqlite(#[from] rusqlite::Error),
+    /// Incident correlation rejected the atomic write.
+    #[error("store error: {0}")]
+    Store(#[from] crate::StoreError),
 }
 
 /// Result returned by telemetry persistence.
 pub type TelemetryEventResult<T> = std::result::Result<T, TelemetryEventError>;
 
+/// Atomically persisted telemetry row and any incident responder event it emitted.
+#[derive(Debug, Clone)]
+pub struct TelemetryEventCommit {
+    /// Stored event receipt.
+    pub event: TelemetryEvent,
+    /// Incident webhook event produced by correlation, when state changed or refreshed.
+    pub incident_event: Option<crate::IncidentCorrelationEvent>,
+}
+
 pub(crate) fn insert_event(
-    connection: &Connection,
+    connection: &mut Connection,
     event: TelemetryEventInsert,
-) -> TelemetryEventResult<TelemetryEvent> {
+) -> TelemetryEventResult<TelemetryEventCommit> {
     validate(&event)?;
     let attributes = decode_attributes(&event.attributes_json)?;
+    let operational = event
+        .operational
+        .as_ref()
+        .map(|signal| OperationalSignalContext {
+            name: event.name.clone(),
+            subject_type: signal.subject_type.clone(),
+            subject_id: signal.subject_id.clone(),
+            state: signal.state.clone(),
+            owner: signal.owner.clone(),
+            evidence_url: signal.evidence_url.clone(),
+            observed_at: signal.observed_at.clone(),
+            received_at: event.created_at.clone(),
+        });
     let payload = serde_json::json!({
         "event": TELEMETRY_EVENT,
         "signal_kind": "analytics_event",
@@ -69,23 +120,37 @@ pub(crate) fn insert_event(
         "retention_class": event.retention_class,
         "privacy_policy": event.privacy_policy,
         "sampling_policy": event.sampling_policy,
+        "operational": operational,
     });
     let payload_json = payload.to_string();
 
-    connection.execute(
+    let transaction = connection.transaction()?;
+    let (entity_type, entity_ref, signal_kind) = match event.operational.as_ref() {
+        Some(signal) => (
+            "operational_signal",
+            operational_signal_ref(&signal.subject_type, &signal.subject_id),
+            "operational",
+        ),
+        None => ("telemetry_event", event.id.to_string(), "analytics_event"),
+    };
+
+    transaction.execute(
         "INSERT INTO service_events (
             id, tenant_id, project_id, service, event, signal_kind, signal_name,
             entity_type, entity_ref, severity, summary, attributes, retention_class,
             privacy_policy, sampling_policy, payload, created_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, 'analytics_event', ?6, 'telemetry_event', ?1,
-                   ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9,
+                   ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         params![
             event.id.as_str(),
             event.tenant_id,
             event.project_id,
             event.service,
             TELEMETRY_EVENT,
+            signal_kind,
             event.name,
+            entity_type,
+            entity_ref,
             event.severity,
             event.summary,
             event.attributes_json,
@@ -97,19 +162,53 @@ pub(crate) fn insert_event(
         ],
     )?;
 
-    Ok(TelemetryEvent {
-        id: event.id.into_string(),
-        service: event.service,
-        event: TELEMETRY_EVENT.to_owned(),
-        name: event.name,
-        severity: event.severity,
-        summary: event.summary,
-        attributes,
-        retention_class: event.retention_class,
-        privacy_policy: event.privacy_policy,
-        sampling_policy: event.sampling_policy,
-        created_at: event.created_at,
+    let incident_event = match event.operational.as_ref() {
+        Some(signal) => crate::incidents::correlate_in_transaction(
+            &transaction,
+            crate::IncidentCorrelation {
+                tenant_id: event.tenant_id.clone(),
+                project_id: event.project_id.clone(),
+                signal_type: "operational_event".to_owned(),
+                signal_ref: operational_signal_ref(&signal.subject_type, &signal.subject_id),
+                service: event.service.clone(),
+                incident_id: signal.incident_id.clone(),
+                event_id: signal.incident_event_id.clone(),
+                now: event.created_at.clone(),
+            },
+        )?,
+        None => None,
+    };
+    let incident_event_name = incident_event
+        .as_ref()
+        .map(|incident| incident.event.clone());
+    let incident_id = incident_event
+        .as_ref()
+        .map(|incident| incident.incident_id.clone());
+    transaction.commit()?;
+
+    Ok(TelemetryEventCommit {
+        event: TelemetryEvent {
+            id: event.id.into_string(),
+            service: event.service,
+            event: TELEMETRY_EVENT.to_owned(),
+            name: event.name,
+            severity: event.severity,
+            summary: event.summary,
+            attributes,
+            retention_class: event.retention_class,
+            privacy_policy: event.privacy_policy,
+            sampling_policy: event.sampling_policy,
+            created_at: event.created_at,
+            operational,
+            incident_event: incident_event_name,
+            incident_id,
+        },
+        incident_event,
     })
+}
+
+pub(crate) fn operational_signal_ref(subject_type: &str, subject_id: &str) -> String {
+    format!("{subject_type}/{subject_id}")
 }
 
 fn validate(event: &TelemetryEventInsert) -> TelemetryEventResult<()> {
@@ -159,11 +258,88 @@ fn validate(event: &TelemetryEventInsert) -> TelemetryEventResult<()> {
     if event.sampling_policy.trim().is_empty() {
         errors.push(("sampling_policy", "must be a non-empty string"));
     }
+    if let Some(signal) = event.operational.as_ref() {
+        validate_operational_signal(signal, &event.attributes_json, &mut errors);
+        if event.retention_class != "audit" {
+            errors.push(("retention_class", "must be audit for operational signals"));
+        }
+        if event.privacy_policy != "redacted" {
+            errors.push(("privacy_policy", "must be redacted for operational signals"));
+        }
+        if event.sampling_policy != "unsampled" {
+            errors.push((
+                "sampling_policy",
+                "must be unsampled for operational signals",
+            ));
+        }
+    }
     if !errors.is_empty() {
         return Err(TelemetryEventError::Validation(errors));
     }
     let _ = decode_attributes(&event.attributes_json)?;
     Ok(())
+}
+
+fn validate_operational_signal(
+    signal: &OperationalSignalInsert,
+    attributes_json: &str,
+    errors: &mut Vec<(&'static str, &'static str)>,
+) {
+    if !bounded_subject_component(&signal.subject_type, 64)
+        || signal
+            .subject_type
+            .chars()
+            .any(|character| character.is_ascii_uppercase())
+    {
+        errors.push((
+            "operational.subject.type",
+            "must use 1-64 lowercase letters, digits, dots, underscores, or hyphens",
+        ));
+    }
+    if !bounded_subject_component(&signal.subject_id, 160) {
+        errors.push((
+            "operational.subject.id",
+            "must use 1-160 letters, digits, dots, underscores, colons, or hyphens",
+        ));
+    }
+    if !matches!(signal.state.as_str(), "active" | "resolved") {
+        errors.push(("operational.state", "must be one of: active, resolved"));
+    }
+    if signal.owner.trim().is_empty() || signal.owner.chars().count() > 128 {
+        errors.push((
+            "operational.owner",
+            "must be a non-empty string no longer than 128 characters",
+        ));
+    }
+    if signal.evidence_url.chars().count() > 2048 || !signal.evidence_url.starts_with("https://") {
+        errors.push((
+            "operational.evidence_url",
+            "must be an https URL no longer than 2048 characters",
+        ));
+    }
+    if time::OffsetDateTime::parse(
+        &signal.observed_at,
+        &time::format_description::well_known::Rfc3339,
+    )
+    .is_err()
+    {
+        errors.push(("operational.observed_at", "must be an RFC3339 timestamp"));
+    }
+    if attributes_json != "{}" {
+        errors.push((
+            "attributes",
+            "must be empty for operational signals; retain metrics and snapshots at the evidence URL",
+        ));
+    }
+}
+
+fn bounded_subject_component(value: &str, max: usize) -> bool {
+    let len = value.chars().count();
+    len > 0
+        && len <= max
+        && value.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | ':' | '-')
+        })
 }
 
 fn decode_attributes(attributes_json: &str) -> TelemetryEventResult<Value> {

--- a/crates/canary-store/src/telemetry.rs
+++ b/crates/canary-store/src/telemetry.rs
@@ -311,7 +311,13 @@ fn validate_operational_signal(
             "must be a non-empty string no longer than 128 characters",
         ));
     }
-    if signal.evidence_url.chars().count() > 2048 || !signal.evidence_url.starts_with("https://") {
+    let valid_evidence_url = url::Url::parse(&signal.evidence_url).is_ok_and(|url| {
+        url.scheme() == "https"
+            && url.host_str().is_some()
+            && url.username().is_empty()
+            && url.password().is_none()
+    });
+    if signal.evidence_url.chars().count() > 2048 || !valid_evidence_url {
         errors.push((
             "operational.evidence_url",
             "must be an https URL no longer than 2048 characters",

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -243,7 +243,7 @@
       "name": "canary_dogfood_value"
     },
     {
-      "description": "Capture one bounded analytics event as a telemetry.event timeline row.",
+      "description": "Capture one bounded telemetry event; an optional operational envelope participates in deterministic incident correlation and keeps evidence out of Canary.",
       "input_schema": {
         "properties": {
           "attributes": {
@@ -251,6 +251,53 @@
           },
           "name": {
             "type": "string"
+          },
+          "operational": {
+            "additionalProperties": false,
+            "properties": {
+              "evidence_url": {
+                "format": "uri",
+                "type": "string"
+              },
+              "observed_at": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "active",
+                  "resolved"
+                ],
+                "type": "string"
+              },
+              "subject": {
+                "additionalProperties": false,
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "id"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "subject",
+              "state",
+              "owner",
+              "evidence_url",
+              "observed_at"
+            ],
+            "type": "object"
           },
           "privacy_policy": {
             "enum": [

--- a/priv/mcp/canary-cli-tools.json
+++ b/priv/mcp/canary-cli-tools.json
@@ -245,11 +245,43 @@
     {
       "description": "Capture one bounded telemetry event; an optional operational envelope participates in deterministic incident correlation and keeps evidence out of Canary.",
       "input_schema": {
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "not": {
+              "required": [
+                "operational"
+              ]
+            }
+          },
+          {
+            "properties": {
+              "attributes": {
+                "maxProperties": 0,
+                "type": "object"
+              },
+              "privacy_policy": {
+                "const": "redacted"
+              },
+              "retention_class": {
+                "const": "audit"
+              },
+              "sampling_policy": {
+                "const": "unsampled"
+              }
+            },
+            "required": [
+              "operational"
+            ]
+          }
+        ],
         "properties": {
           "attributes": {
             "type": "object"
           },
           "name": {
+            "maxLength": 128,
+            "minLength": 1,
             "type": "string"
           },
           "operational": {
@@ -257,6 +289,8 @@
             "properties": {
               "evidence_url": {
                 "format": "uri",
+                "maxLength": 2048,
+                "pattern": "^https://",
                 "type": "string"
               },
               "observed_at": {
@@ -264,6 +298,8 @@
                 "type": "string"
               },
               "owner": {
+                "maxLength": 128,
+                "minLength": 1,
                 "type": "string"
               },
               "state": {
@@ -277,9 +313,15 @@
                 "additionalProperties": false,
                 "properties": {
                   "id": {
+                    "maxLength": 160,
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z0-9._:-]+$",
                     "type": "string"
                   },
                   "type": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9._-]+$",
                     "type": "string"
                   }
                 },
@@ -316,9 +358,11 @@
             "type": "string"
           },
           "sampling_policy": {
+            "minLength": 1,
             "type": "string"
           },
           "service": {
+            "minLength": 1,
             "type": "string"
           },
           "severity": {
@@ -330,6 +374,8 @@
             "type": "string"
           },
           "summary": {
+            "maxLength": 512,
+            "minLength": 1,
             "type": "string"
           }
         },

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -2436,12 +2436,12 @@
         "tags": [
           "Telemetry"
         ],
-        "summary": "Ingest a bounded analytics event",
-        "description": "Stores a typed analytics event as a telemetry.event timeline row. Use this for low-volume operational/product signals that help agents triage; do not send logs, metrics, traces, or raw PII.",
+        "summary": "Ingest a bounded telemetry or operational event",
+        "description": "Stores one low-volume telemetry.event timeline row. An optional operational envelope deterministically opens, updates, or resolves an incident for a caller-defined bounded subject. Canary retains the signal and incident timeline, not raw metrics, provider snapshots, logs, traces, or high-cardinality evidence.",
         "x-agent-guidance": {
-          "when_to_call": "Call when a consuming app or agent needs to record a low-volume typed event that helps correlate user flows, deploys, or agent work with errors, health, and incidents.",
-          "trust": "The caller owns redaction before ingest. Canary enforces size, shape, scoped API keys, and service authority, but retention_class and privacy_policy are policy labels until downstream retention/privacy automation consumes them.",
-          "next": "Read /api/v1/report for recent_events or replay /api/v1/timeline?event_type=telemetry.event with a cursor to verify the event and correlate it with incidents, errors, health, claims, and annotations."
+          "when_to_call": "Call when a producer needs to record a low-volume typed event. Include operational only when a stable caller-defined subject should participate in deterministic incident correlation.",
+          "trust": "The caller owns redaction before ingest. Canary enforces size, exact operational shape, scoped API keys, service authority, and empty attributes for operational signals. Evidence remains at evidence_url; only the bounded envelope is retained.",
+          "next": "Read /api/v1/report or replay /api/v1/timeline?event_type=telemetry.event. When incident_id is present, query that incident; its opened/updated/resolved webhook is the signed responder wake-up hint."
         },
         "requestBody": {
           "required": true,
@@ -3990,6 +3990,9 @@
           },
           {
             "$ref": "#/components/schemas/IncidentDetailSignalHealthTransition"
+          },
+          {
+            "$ref": "#/components/schemas/IncidentDetailSignalOperational"
           }
         ]
       },
@@ -4121,6 +4124,60 @@
           },
           "current_claim": {
             "$ref": "#/components/schemas/RemediationClaimSummary"
+          }
+        }
+      },
+      "IncidentDetailSignalOperational": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "summary",
+          "signal_ref",
+          "current_state",
+          "attached_at",
+          "resolved_at",
+          "annotation_count",
+          "operational"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "operational_event"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "signal_ref": {
+            "type": "string"
+          },
+          "current_state": {
+            "type": "string",
+            "enum": [
+              "active",
+              "resolved"
+            ]
+          },
+          "attached_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolved_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "annotation_count": {
+            "type": "integer",
+            "enum": [
+              0
+            ]
+          },
+          "operational": {
+            "$ref": "#/components/schemas/OperationalSignalContext"
           }
         }
       },
@@ -6760,20 +6817,27 @@
           "attributes": {
             "type": "object",
             "additionalProperties": true,
-            "default": {}
+            "default": {},
+            "description": "Must be empty when operational is present; raw metrics, provider snapshots, logs and traces remain outside Canary."
           },
           "retention_class": {
             "$ref": "#/components/schemas/TelemetryRetentionClass",
-            "default": "standard"
+            "default": "standard",
+            "description": "Defaults to audit and must remain audit when operational is present."
           },
           "privacy_policy": {
             "$ref": "#/components/schemas/TelemetryPrivacyPolicy",
-            "default": "redacted"
+            "default": "redacted",
+            "description": "Must be redacted when operational is present."
           },
           "sampling_policy": {
             "type": "string",
             "minLength": 1,
-            "default": "unsampled"
+            "default": "unsampled",
+            "description": "Must be unsampled when operational is present."
+          },
+          "operational": {
+            "$ref": "#/components/schemas/OperationalSignalRequest"
           }
         }
       },
@@ -6834,7 +6898,102 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "operational": {
+            "$ref": "#/components/schemas/OperationalSignalContext"
+          },
+          "incident_event": {
+            "type": "string",
+            "enum": [
+              "incident.opened",
+              "incident.updated",
+              "incident.resolved"
+            ]
+          },
+          "incident_id": {
+            "type": "string"
           }
+        }
+      },
+      "OperationalSignalRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "subject",
+          "state",
+          "owner",
+          "evidence_url",
+          "observed_at"
+        ],
+        "properties": {
+          "subject": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "id"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64,
+                "pattern": "^[a-z0-9._-]+$"
+              },
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160,
+                "pattern": "^[A-Za-z0-9._:-]+$"
+              }
+            }
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "active",
+              "resolved"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "evidence_url": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "pattern": "^https://"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OperationalSignalContext": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "subject_type",
+          "subject_id",
+          "state",
+          "owner",
+          "evidence_url",
+          "observed_at",
+          "received_at"
+        ],
+        "properties": {
+          "name": { "type": "string" },
+          "subject_type": { "type": "string" },
+          "subject_id": { "type": "string" },
+          "state": { "type": "string", "enum": ["active", "resolved"] },
+          "owner": { "type": "string" },
+          "evidence_url": { "type": "string", "format": "uri" },
+          "observed_at": { "type": "string", "format": "date-time" },
+          "received_at": { "type": "string", "format": "date-time" }
         }
       }
     }

--- a/priv/openapi/openapi.json
+++ b/priv/openapi/openapi.json
@@ -6822,8 +6822,7 @@
           },
           "retention_class": {
             "$ref": "#/components/schemas/TelemetryRetentionClass",
-            "default": "standard",
-            "description": "Defaults to audit and must remain audit when operational is present."
+            "description": "Defaults to standard for analytics events and audit for operational events."
           },
           "privacy_policy": {
             "$ref": "#/components/schemas/TelemetryPrivacyPolicy",
@@ -6839,7 +6838,38 @@
           "operational": {
             "$ref": "#/components/schemas/OperationalSignalRequest"
           }
-        }
+        },
+        "oneOf": [
+          {
+            "title": "Analytics event",
+            "not": {
+              "required": ["operational"]
+            }
+          },
+          {
+            "title": "Operational event",
+            "required": ["operational"],
+            "properties": {
+              "attributes": {
+                "type": "object",
+                "maxProperties": 0,
+                "default": {}
+              },
+              "retention_class": {
+                "const": "audit",
+                "default": "audit"
+              },
+              "privacy_policy": {
+                "const": "redacted",
+                "default": "redacted"
+              },
+              "sampling_policy": {
+                "const": "unsampled",
+                "default": "unsampled"
+              }
+            }
+          }
+        ]
       },
       "TelemetryEvent": {
         "type": "object",


### PR DESCRIPTION
## Summary
- accept a generic, caller-defined bounded operational event envelope on the existing scoped event API
- atomically open/update/resolve one correlated incident and use existing signed responder webhooks as wake hints
- keep authoritative timeline replay causal for new cursors and migration-safe for legacy cursors
- align CLI, MCP, TypeScript, and OpenAPI contracts while rejecting raw metrics, snapshots, logs, traces, and unknown fields

## Proof
- `NO_COLOR=1 ./bin/validate`
- disposable fresh-DB open/update/resolve + signed loopback webhook + replay drill
- legacy no-duplicate/no-skip pagination for telemetry and incident anchors
- fresh critic APPROVE at `38c053e3`

No Misty Step topology, provider policy, external send, or provider mutation was introduced.