### PR TITLE
fix(egress): unify the public-destination oracle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,8 +170,20 @@ original cannot be re-shown.
   `Mutex<Store>` makes every subsequent authenticated request 500 until
   restart. Contain panics or use a non-poisoning lock.
 - **One egress oracle.** There is exactly one public-destination filter for
-  outbound HTTP; probe and webhook paths must share it. Hand-maintained copies
-  drift (the IPv4-mapped-address rejection landed in the probe copy only).
+  outbound HTTP — `canary-server::egress::is_global_ip` — and probe and
+  webhook paths must share it. Hand-maintained copies drift (the
+  IPv4-mapped-address rejection landed in the probe copy only, leaving
+  `http://[::ffff:169.254.169.254]/` past the webhook filter until the
+  2026-07-14 unification). Related trap: URL host extraction returns IPv6
+  literals in brackets, which `to_socket_addrs` cannot parse — IP literals
+  must be judged directly by the filter
+  (`egress::resolve_destination_addrs`), never left to fail as DNS errors. The
+  oracle must fail closed over IANA's currently allocated global-unicast space,
+  the current special-purpose registries, and translator prefixes; policy
+  changes update the shared table oracle and its explicitly allowed
+  boundary/exception rows together. Validated probe plans remain opaque to
+  callers, and the concrete transport rechecks public plans before connecting;
+  otherwise a forged pinned address bypasses the shared resolver.
 
 This list is load-bearing — every remediation in the Known-debt map above must cite it and extend it when new failure modes appear.
 </content>

--- a/crates/canary-server/src/egress.rs
+++ b/crates/canary-server/src/egress.rs
@@ -3,6 +3,18 @@
 //! Target probes and webhook delivery both initiate server-side HTTP requests.
 //! This module keeps the network safety boundary separate from route parsing
 //! and transport execution.
+//!
+//! `is_global_ip` is the single public-destination oracle for all outbound
+//! paths. Do not fork per-path copies — the pre-unification probe and webhook
+//! copies drifted (the IPv4-mapped rejection existed on the probe side only,
+//! leaving `http://[::ffff:169.254.169.254]/` reachable through webhooks).
+//!
+//! Any IPv6 form that embeds an IPv4 destination — mapped `::ffff:0:0/96`,
+//! compatible `::/96`, Teredo `2001::/32`, 6to4 `2002::/16`, and the NAT64
+//! prefixes — is rejected wholesale rather than judged by its embedded
+//! address. A translator or transition mechanism sits between the address the
+//! filter reads and the host that is actually reached, so the embedded value
+//! is not something this filter can hold to the IPv4 rules.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 
@@ -41,13 +53,7 @@ pub(crate) fn validate_public_http_destination(
         return Err(format!("{surface} URL resolves to localhost"));
     }
 
-    let addrs = (host.as_str(), port)
-        .to_socket_addrs()
-        .map_err(|error| format!("{surface} DNS resolution failed: {error}"))?
-        .collect::<Vec<_>>();
-    if addrs.is_empty() {
-        return Err(format!("{surface} DNS resolution returned no addresses"));
-    }
+    let addrs = resolve_destination_addrs(&host, port, surface)?;
     for addr in &addrs {
         if !is_global_ip(addr.ip()) {
             return Err(format!(
@@ -59,7 +65,40 @@ pub(crate) fn validate_public_http_destination(
     Ok(ValidatedHttpDestination { url, host, addrs })
 }
 
-fn is_global_ip(ip: IpAddr) -> bool {
+/// Resolve a destination host to socket addresses. IP literals (including
+/// bracketed IPv6 literals as produced by URL host extraction) are answered
+/// directly so the egress filter judges them instead of a DNS lookup error.
+pub(crate) fn resolve_destination_addrs(
+    host: &str,
+    port: u16,
+    surface: &str,
+) -> Result<Vec<SocketAddr>, String> {
+    let literal = host_without_ipv6_brackets(host);
+    if let Ok(ip) = literal.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+    let addrs = (host, port)
+        .to_socket_addrs()
+        .map_err(|error| format!("{surface} DNS resolution failed: {error}"))?
+        .collect::<Vec<_>>();
+    if addrs.is_empty() {
+        return Err(format!("{surface} DNS resolution returned no addresses"));
+    }
+    Ok(addrs)
+}
+
+/// URL host extraction retains brackets around IPv6 literals. Network APIs
+/// that parse an IP or TLS server name require the inner literal instead.
+pub(crate) fn host_without_ipv6_brackets(host: &str) -> &str {
+    host.strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(host)
+}
+
+/// The one public-destination filter for outbound HTTP. Every server-side
+/// egress path (target probes, webhook delivery, and any future outbound
+/// surface) must route through this predicate rather than keeping a copy.
+pub(crate) fn is_global_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(ip) => is_global_ipv4(ip),
         IpAddr::V6(ip) => is_global_ipv6(ip),
@@ -74,34 +113,265 @@ fn is_global_ipv4(ip: Ipv4Addr) -> bool {
         || ip.is_unspecified()
         || ip.is_broadcast()
         || ip.is_multicast()
-        || (a == 100 && (64..=127).contains(&b))
         || a == 0
         || a >= 224
-        || (a == 169 && b == 254)
-        || (a == 192 && b == 0)
+        || (a == 100 && (64..=127).contains(&b))
+        || is_non_global_ietf_protocol_assignment_ipv4(ip)
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 192 && b == 88 && c == 99)
         || (a == 198 && (18..=19).contains(&b))
         || (a == 198 && b == 51 && c == 100)
-        || (a == 203 && b == 0 && c == 113)
-        || (a == 255 && b == 255))
+        || (a == 203 && b == 0 && c == 113))
+}
+
+/// `192.0.0.0/24` is reserved for IETF protocol assignments. IANA marks only
+/// the PCP and TURN anycast addresses as globally reachable, so keep those two
+/// exact exceptions visible and fail closed for the rest of the block.
+fn is_non_global_ietf_protocol_assignment_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, d] = ip.octets();
+    a == 192 && b == 0 && c == 0 && d != 9 && d != 10
 }
 
 fn is_global_ipv6(ip: Ipv6Addr) -> bool {
-    !(ip.is_loopback()
-        || ip.is_unspecified()
-        || ip.is_multicast()
-        || is_unique_local_ipv6(ip)
-        || is_unicast_link_local_ipv6(ip)
-        || is_documentation_ipv6(ip))
+    is_allocated_global_unicast_ipv6(ip)
+        && !(ip.is_loopback()
+            || ip.is_unspecified()
+            || ip.is_multicast()
+            || is_discard_or_dummy_ipv6(ip)
+            || is_non_global_ietf_protocol_assignment_ipv6(ip)
+            || is_unique_local_ipv6(ip)
+            || is_unicast_link_local_ipv6(ip)
+            || is_deprecated_site_local_ipv6(ip)
+            || is_documentation_ipv6(ip)
+            || ip.segments()[0] == 0x5f00
+            || ip.to_ipv4().is_some()
+            || is_6to4_ipv6(ip)
+            || is_nat64_ipv6(ip))
+}
+
+/// IANA currently allocates global IPv6 unicast addresses only from
+/// `2000::/3`. Everything outside that allocation fails closed even when it is
+/// not yet named in the special-purpose registry; a locally routed reserved
+/// prefix is not a public destination.
+fn is_allocated_global_unicast_ipv6(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xe000) == 0x2000
+}
+
+/// 6to4 (RFC 3056, 2002::/16) embeds an IPv4 destination in bits 16..48 in
+/// cleartext. The filter cannot judge that embedded address as a v4 rule, so
+/// the whole prefix is non-global here — same rationale as NAT64 and the
+/// `::/96` embedded forms rejected by `to_ipv4`.
+fn is_6to4_ipv6(ip: Ipv6Addr) -> bool {
+    ip.segments()[0] == 0x2002
 }
 
 fn is_unique_local_ipv6(ip: Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xfe00) == 0xfc00
 }
 
+/// IANA's discard-only and dummy prefixes are both /64s under `100::/32`.
+fn is_discard_or_dummy_ipv6(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[..4] == [0x0100, 0, 0, 0] || segments[..4] == [0x0100, 0, 0, 1]
+}
+
+/// `2001::/23` is reserved for IETF protocol assignments and is non-global
+/// unless IANA has made a narrower globally reachable assignment. Keep the
+/// small exception list explicit so new assignments fail closed until policy
+/// and its table-driven oracle are reviewed together.
+fn is_non_global_ietf_protocol_assignment_ipv6(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    let in_protocol_space = segments[0] == 0x2001 && segments[1] <= 0x01ff;
+    in_protocol_space && !is_global_ietf_protocol_assignment_ipv6(segments)
+}
+
+fn is_global_ietf_protocol_assignment_ipv6(segments: [u16; 8]) -> bool {
+    matches!(segments, [0x2001, 0x0001, 0, 0, 0, 0, 0, 1..=3])
+        || (segments[0] == 0x2001 && segments[1] == 0x0003)
+        || segments[..3] == [0x2001, 0x0004, 0x0112]
+        || (segments[0] == 0x2001 && matches!(segments[1] & 0xfff0, 0x0020 | 0x0030))
+}
+
 fn is_unicast_link_local_ipv6(ip: Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfe80
 }
 
+fn is_deprecated_site_local_ipv6(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfec0
+}
+
 fn is_documentation_ipv6(ip: Ipv6Addr) -> bool {
-    ip.segments()[0] == 0x2001 && ip.segments()[1] == 0x0db8
+    let segments = ip.segments();
+    (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        || (segments[0] == 0x3fff && (segments[1] & 0xf000) == 0)
+}
+
+/// NAT64 translation prefixes: the well-known 64:ff9b::/96 (RFC 6052) and the
+/// local-use 64:ff9b:1::/48 (RFC 8215). Both embed an IPv4 destination the
+/// filter cannot see through a translator, so the whole prefixes are
+/// non-global here.
+fn is_nat64_ipv6(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x0064
+        && segments[1] == 0xff9b
+        && (segments[2..6] == [0, 0, 0, 0] || segments[2] == 0x0001)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One row per address class from the IANA special-purpose registries.
+    /// Every outbound path shares `is_global_ip`, so this table is the
+    /// egress contract for probes and webhooks alike.
+    const BLOCKED: &[(&str, &str)] = &[
+        ("127.0.0.1", "IPv4 loopback"),
+        ("10.0.0.1", "RFC1918 10/8"),
+        ("172.16.0.1", "RFC1918 172.16/12"),
+        ("192.168.1.1", "RFC1918 192.168/16"),
+        ("169.254.169.254", "IPv4 link-local / metadata"),
+        ("100.64.0.1", "CGNAT 100.64/10"),
+        ("100.127.255.255", "CGNAT upper bound"),
+        ("0.0.0.0", "unspecified"),
+        ("0.1.2.3", "this-network 0/8"),
+        (
+            "192.0.0.8",
+            "IANA special 192.0.0/24 below anycast exceptions",
+        ),
+        ("192.0.0.170", "IANA special 192.0.0/24"),
+        ("192.0.2.10", "TEST-NET-1"),
+        ("192.88.99.1", "deprecated 6to4 relay anycast"),
+        ("198.18.0.1", "benchmarking 198.18/15"),
+        ("198.19.255.255", "benchmarking upper bound"),
+        ("198.51.100.7", "TEST-NET-2"),
+        ("203.0.113.9", "TEST-NET-3"),
+        ("224.0.0.1", "IPv4 multicast"),
+        ("240.0.0.1", "reserved 240/4"),
+        ("255.255.255.255", "broadcast"),
+        ("::1", "IPv6 loopback"),
+        ("::", "IPv6 unspecified"),
+        ("fc00::1", "unique-local fc00::/7"),
+        ("fd12:3456::1", "unique-local fd00::/8"),
+        ("fe80::1", "IPv6 link-local"),
+        ("ff02::1", "IPv6 multicast"),
+        ("100::1", "IPv6 discard-only 100::/64"),
+        ("100:0:0:1::1", "IPv6 dummy prefix 100:0:0:1::/64"),
+        ("2001::1", "Teredo 2001::/32"),
+        ("2001:100::1", "unassigned IETF protocol space 2001::/23"),
+        ("2001:2::1", "IPv6 benchmarking 2001:2::/48"),
+        ("2001:10::1", "deprecated ORCHID 2001:10::/28"),
+        ("2001:db8::1", "IPv6 documentation"),
+        ("3fff::1", "IPv6 documentation 3fff::/20"),
+        ("5f00::1", "SRv6 SID 5f00::/16"),
+        ("fec0::1", "deprecated IPv6 site-local fec0::/10"),
+        ("::ffff:169.254.169.254", "IPv4-mapped metadata endpoint"),
+        ("::ffff:127.0.0.1", "IPv4-mapped loopback"),
+        ("::ffff:10.0.0.1", "IPv4-mapped RFC1918"),
+        (
+            "::ffff:8.8.8.8",
+            "IPv4-mapped global (embedded forms rejected wholesale)",
+        ),
+        ("::169.254.169.254", "IPv4-compatible metadata endpoint"),
+        ("::127.0.0.1", "IPv4-compatible loopback"),
+        ("::10.0.0.1", "IPv4-compatible RFC1918"),
+        (
+            "::8.8.8.8",
+            "IPv4-compatible global (embedded forms rejected wholesale)",
+        ),
+        ("2002:7f00:1::", "6to4 embedding loopback"),
+        ("2002:a9fe:a9fe::", "6to4 embedding the metadata endpoint"),
+        ("2002:808:808::", "6to4 embedding a global address"),
+        ("64:ff9b::a00:1", "NAT64 well-known 64:ff9b::/96"),
+        ("64:ff9b::808:808", "NAT64 well-known prefix, global embed"),
+        ("64:ff9b:1::a00:1", "NAT64 local-use 64:ff9b:1::/48"),
+        (
+            "64:ff9b:2::1",
+            "unallocated IPv6 adjacent to NAT64 local-use",
+        ),
+        (
+            "65:ff9b::1",
+            "unallocated IPv6 adjacent to NAT64 well-known",
+        ),
+        ("4000::1", "unallocated IPv6 above global-unicast 2000::/3"),
+    ];
+
+    const ALLOWED: &[(&str, &str)] = &[
+        ("93.184.216.34", "public IPv4"),
+        ("8.8.8.8", "public IPv4 resolver"),
+        ("192.0.0.9", "PCP anycast exception in IANA special space"),
+        ("192.0.0.10", "TURN anycast exception in IANA special space"),
+        ("192.0.1.1", "global space adjacent to IANA 192.0.0/24"),
+        ("198.51.99.1", "global space adjacent to TEST-NET-2"),
+        ("203.0.112.1", "global space adjacent to TEST-NET-3"),
+        ("100.63.255.255", "global space below CGNAT range"),
+        ("100.128.0.0", "global space above CGNAT range"),
+        ("2606:4700:4700::1111", "public IPv6 resolver"),
+        ("2001:1::1", "PCP anycast in IETF protocol space"),
+        ("2001:1::2", "TURN anycast in IETF protocol space"),
+        ("2001:1::3", "DNS-SD anycast in IETF protocol space"),
+        ("2001:3::1", "AMT in IETF protocol space"),
+        ("2001:4:112::1", "AS112-v6 in IETF protocol space"),
+        ("2001:20::1", "ORCHIDv2 in IETF protocol space"),
+        ("2001:30::1", "Drone Remote ID in IETF protocol space"),
+        ("2003::1", "global space adjacent to the 6to4 prefix"),
+        (
+            "2001:db9::1",
+            "global space adjacent to documentation prefix",
+        ),
+    ];
+
+    #[test]
+    fn egress_oracle_blocks_every_non_global_class_and_admits_global_space()
+    -> Result<(), std::net::AddrParseError> {
+        for (address, class) in BLOCKED {
+            let ip: IpAddr = address.parse()?;
+            assert!(!is_global_ip(ip), "{class} ({address}) must be blocked");
+        }
+        for (address, class) in ALLOWED {
+            let ip: IpAddr = address.parse()?;
+            assert!(is_global_ip(ip), "{class} ({address}) must be allowed");
+        }
+        Ok(())
+    }
+
+    fn assert_rejected_as_non_global(raw_url: &str, surface: &str) -> Result<(), String> {
+        match validate_public_http_destination(raw_url, surface) {
+            Ok(_) => Err(format!("{raw_url} must be rejected on the {surface} path")),
+            Err(error) => {
+                assert!(
+                    error.contains("non-global address"),
+                    "{raw_url}: unexpected rejection reason: {error}"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn webhook_destination_validation_rejects_ipv4_mapped_metadata_literal() -> Result<(), String> {
+        assert_rejected_as_non_global("http://[::ffff:169.254.169.254]/", "webhook")
+    }
+
+    #[test]
+    fn webhook_destination_validation_rejects_nat64_literal() -> Result<(), String> {
+        assert_rejected_as_non_global("https://[64:ff9b::a00:1]/hook", "webhook")
+    }
+
+    #[test]
+    fn destination_validation_accepts_and_pins_global_ipv6_literal() -> Result<(), String> {
+        let destination =
+            validate_public_http_destination("https://[2606:4700:4700::1111]/hook", "webhook")?;
+
+        assert_eq!(destination.host, "[2606:4700:4700::1111]");
+        assert_eq!(
+            destination.addrs,
+            [SocketAddr::new(
+                "2606:4700:4700::1111"
+                    .parse()
+                    .map_err(|error| format!("test address must parse: {error}"))?,
+                443,
+            )]
+        );
+        Ok(())
+    }
 }

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -2785,12 +2785,12 @@ mod tests {
     }
 
     #[test]
-    fn http_webhook_transport_rejects_private_destination_before_request()
+    fn http_webhook_transport_rejects_mapped_destinations_before_request()
     -> Result<(), Box<dyn Error>> {
         let listener = TcpListener::bind("127.0.0.1:0")?;
         let addr = listener.local_addr()?;
-        let request = WebhookRequest {
-            url: format!("http://{addr}/hook"),
+        let mut request = WebhookRequest {
+            url: format!("http://[::ffff:127.0.0.1]:{}/hook", addr.port()),
             body: "{}".to_owned(),
             headers: canary_http::webhooks::headers_for_body(
                 "{}",
@@ -2805,9 +2805,16 @@ mod tests {
         let transport = HttpWebhookTransport::with_timeout(StdDuration::from_millis(200))?;
 
         let TransportResult::RequestError(reason) = transport.send(&request) else {
-            return Err("private destination should be rejected before HTTP request".into());
+            return Err("mapped loopback should be rejected before HTTP request".into());
         };
-        assert!(reason.contains("non-global") || reason.contains("localhost"));
+        assert!(reason.contains("non-global"));
+
+        request.url = "http://[::ffff:169.254.169.254]/hook".to_owned();
+        let TransportResult::RequestError(reason) = transport.send(&request) else {
+            return Err("mapped metadata should be rejected before HTTP request".into());
+        };
+        assert!(reason.contains("non-global"));
+
         listener.set_nonblocking(true)?;
         match listener.accept() {
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -4668,7 +4675,7 @@ mod tests {
                 "POST",
                 "/api/v1/targets",
                 ADMIN_KEY,
-                r#"{"url":"http://127.0.0.1:9/health","name":"Local API","allow_private":true}"#,
+                r#"{"url":"http://[::ffff:169.254.169.254]/health","name":"Metadata","allow_private":true}"#,
             )?)
             .await?;
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
@@ -5105,22 +5112,25 @@ mod tests {
             "Invalid webhook configuration."
         );
 
-        let local_webhook_response = router
+        let non_global_webhook_response = router
             .clone()
             .oneshot(json_request(
                 "POST",
                 "/api/v1/webhooks",
                 ADMIN_KEY,
-                r#"{"url":"http://127.0.0.1:9/hook","events":["error.new_class"]}"#,
+                r#"{"url":"http://[::ffff:169.254.169.254]/hook","events":["error.new_class"]}"#,
             )?)
             .await?;
         assert_eq!(
-            local_webhook_response.status(),
+            non_global_webhook_response.status(),
             StatusCode::UNPROCESSABLE_ENTITY
         );
-        let local_webhook = json_body(local_webhook_response).await?;
-        assert_eq!(local_webhook["code"], "validation_error");
-        assert_eq!(local_webhook["detail"], "Invalid webhook configuration.");
+        let non_global_webhook = json_body(non_global_webhook_response).await?;
+        assert_eq!(non_global_webhook["code"], "validation_error");
+        assert_eq!(
+            non_global_webhook["detail"],
+            "Invalid webhook configuration."
+        );
 
         Ok(())
     }

--- a/crates/canary-server/src/target_probes.rs
+++ b/crates/canary-server/src/target_probes.rs
@@ -8,7 +8,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::Read,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs},
+    net::{IpAddr, SocketAddr, TcpStream},
     panic::{AssertUnwindSafe, catch_unwind},
     sync::{
         Arc, Condvar, Mutex,
@@ -19,6 +19,7 @@ use std::{
     time::{Duration as StdDuration, Instant},
 };
 
+use crate::egress::{host_without_ipv6_brackets, is_global_ip, resolve_destination_addrs};
 use crate::route_state::SharedStore;
 use canary_core::health::state_machine::{Counters, HealthState, Thresholds};
 use canary_store::{ActiveTargetProbeSchedule, TargetProbeSnapshot};
@@ -127,18 +128,51 @@ pub trait ProbeTransport: Send + Sync {
 pub struct ReqwestProbeTransport;
 
 /// Validated HTTP request passed to the transport.
+///
+/// Fields stay private so this value is an unforgeable policy capability:
+/// callers may inspect an approved plan through getters but cannot substitute
+/// an address or private-target grant before invoking a concrete transport.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProbeRequest {
     /// HTTP method.
-    pub method: String,
+    method: String,
     /// Original URL, preserving host for Host/SNI.
-    pub url: String,
+    url: String,
     /// Parsed request headers.
-    pub headers: BTreeMap<String, String>,
+    headers: BTreeMap<String, String>,
     /// Timeout in milliseconds.
-    pub timeout_ms: i64,
+    timeout_ms: i64,
     /// Resolved and approved socket addresses for this probe.
-    pub resolved_addrs: Vec<SocketAddr>,
+    resolved_addrs: Vec<SocketAddr>,
+    /// Whether the internal planner explicitly approved private destinations.
+    allow_private_targets: bool,
+}
+
+impl ProbeRequest {
+    /// Validated HTTP method.
+    pub fn method(&self) -> &str {
+        &self.method
+    }
+
+    /// Original validated URL, preserving its Host/SNI authority.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Validated request headers.
+    pub fn headers(&self) -> &BTreeMap<String, String> {
+        &self.headers
+    }
+
+    /// Request timeout in milliseconds.
+    pub fn timeout_ms(&self) -> i64 {
+        self.timeout_ms
+    }
+
+    /// Resolved and policy-approved socket addresses pinned to this request.
+    pub fn resolved_addrs(&self) -> &[SocketAddr] {
+        &self.resolved_addrs
+    }
 }
 
 /// Runtime boundary for executing target probes.
@@ -887,6 +921,7 @@ impl ProbeTransport for ReqwestProbeTransport {
         let timeout = timeout(request.timeout_ms);
         let url = Url::parse(&request.url)
             .map_err(|error| ProbeTransportError::Connection(error.to_string()))?;
+        validate_transport_destination(&url, &request)?;
         let host = url
             .host_str()
             .ok_or_else(|| ProbeTransportError::Connection("missing URL host".to_owned()))?;
@@ -923,6 +958,48 @@ impl ProbeTransport for ReqwestProbeTransport {
             tls_expires_at: None,
         })
     }
+}
+
+fn validate_transport_destination(
+    url: &Url,
+    request: &ProbeRequest,
+) -> Result<(), ProbeTransportError> {
+    if request.allow_private_targets {
+        return Ok(());
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| ProbeTransportError::Connection("missing URL host".to_owned()))?;
+    if host.eq_ignore_ascii_case("localhost") || host.ends_with(".localhost") {
+        return Err(ProbeTransportError::Connection(
+            "target host resolves to localhost".to_owned(),
+        ));
+    }
+    if request.resolved_addrs.is_empty() {
+        return Err(ProbeTransportError::Connection(
+            "target DNS resolution returned no addresses".to_owned(),
+        ));
+    }
+    for addr in &request.resolved_addrs {
+        if !is_global_ip(addr.ip()) {
+            return Err(ProbeTransportError::Connection(format!(
+                "target resolved to non-global address {}",
+                addr.ip()
+            )));
+        }
+    }
+    if let Ok(literal) = host_without_ipv6_brackets(host).parse::<IpAddr>()
+        && (request
+            .resolved_addrs
+            .iter()
+            .any(|addr| addr.ip() != literal)
+            || !is_global_ip(literal))
+    {
+        return Err(ProbeTransportError::Connection(format!(
+            "target URL contains non-global or unpinned address {literal}"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -982,13 +1059,17 @@ fn extract_tls_expiry(
     if scheme != "https" {
         return None;
     }
-    let server_name = ServerName::try_from(host.to_owned()).ok()?;
+    let server_name = tls_server_name(host)?;
     for addr in resolved_addrs {
         if let Some(expiry) = extract_tls_expiry_from_addr(*addr, server_name.clone(), timeout) {
             return Some(expiry);
         }
     }
     None
+}
+
+fn tls_server_name(host: &str) -> Option<ServerName<'static>> {
+    ServerName::try_from(host_without_ipv6_brackets(host).to_owned()).ok()
 }
 
 fn extract_tls_expiry_from_addr(
@@ -1118,6 +1199,7 @@ fn probe_request(
         headers: parse_headers(snapshot.headers.as_deref())?,
         timeout_ms: snapshot.timeout_ms,
         resolved_addrs,
+        allow_private_targets,
     })
 }
 
@@ -1131,13 +1213,7 @@ fn resolve_and_validate(
     {
         return Err("target host resolves to localhost".to_owned());
     }
-    let addrs = (host, port)
-        .to_socket_addrs()
-        .map_err(|error| format!("target DNS resolution failed: {error}"))?
-        .collect::<Vec<_>>();
-    if addrs.is_empty() {
-        return Err("target DNS resolution returned no addresses".to_owned());
-    }
+    let addrs = resolve_destination_addrs(host, port, "target")?;
     if !allow_private_targets {
         for addr in &addrs {
             if !is_global_ip(addr.ip()) {
@@ -1302,53 +1378,6 @@ fn deterministic_jitter(target_id: &str, jitter_range: i64) -> i64 {
         hash = hash.wrapping_mul(31).wrapping_add(i64::from(byte));
     }
     hash.rem_euclid(span) - jitter_range
-}
-
-fn is_global_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ip) => is_global_ipv4(ip),
-        IpAddr::V6(ip) => is_global_ipv6(ip),
-    }
-}
-
-fn is_global_ipv4(ip: Ipv4Addr) -> bool {
-    let [a, b, _, d] = ip.octets();
-    !(ip.is_private()
-        || ip.is_loopback()
-        || ip.is_link_local()
-        || ip.is_unspecified()
-        || ip.is_broadcast()
-        || ip.is_multicast()
-        || (a == 100 && (64..=127).contains(&b))
-        || a == 0
-        || a >= 224
-        || (a == 169 && b == 254)
-        || (a == 192 && b == 0)
-        || (a == 192 && b == 0 && d == 8)
-        || (a == 192 && b == 0 && d == 9)
-        || (a == 192 && b == 0 && d == 10)
-        || (a == 192 && b == 0 && d == 170)
-        || (a == 192 && b == 0 && d == 171)
-        || (a == 192 && b == 0 && d == 2)
-        || (a == 198 && b == 18)
-        || (a == 198 && b == 19)
-        || (a == 198 && b == 51)
-        || (a == 203 && b == 0))
-}
-
-fn is_global_ipv6(ip: Ipv6Addr) -> bool {
-    let segments = ip.segments();
-    let first = segments[0];
-    !(ip.is_loopback()
-        || ip.is_unspecified()
-        || ip.is_multicast()
-        || (first & 0xfe00) == 0xfc00
-        || (first & 0xffc0) == 0xfe80
-        || (first == 0x2001 && segments[1] == 0x0db8)
-        || (segments[0..5] == [0, 0, 0, 0, 0] && segments[5] == 0xffff)
-        || ip
-            .to_ipv4_mapped()
-            .is_some_and(|mapped| !is_global_ipv4(mapped)))
 }
 
 #[cfg(test)]
@@ -1647,19 +1676,36 @@ mod tests {
     }
 
     #[test]
-    fn ssrf_classification_blocks_non_global_addresses_by_default() {
-        for ip in [
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254)),
-            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
-            IpAddr::V6(Ipv6Addr::LOCALHOST),
-            IpAddr::V6("fc00::1".parse().unwrap_or(Ipv6Addr::LOCALHOST)),
-            IpAddr::V6("::ffff:127.0.0.1".parse().unwrap_or(Ipv6Addr::LOCALHOST)),
+    fn probe_resolution_consults_the_shared_egress_oracle() -> Result<(), String> {
+        for host in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "169.254.169.254",
+            "192.0.2.10",
+            "fc00::1",
+            "::ffff:169.254.169.254",
+            "[::ffff:169.254.169.254]",
+            "::169.254.169.254",
+            "2002:a9fe:a9fe::",
+            "64:ff9b::a00:1",
         ] {
-            assert!(!is_global_ip(ip), "{ip} should be blocked");
+            match resolve_and_validate(host, 80, false) {
+                Ok(_) => return Err(format!("{host} must be rejected on the probe path")),
+                Err(error) => assert!(
+                    error.contains("non-global address"),
+                    "{host}: unexpected rejection reason: {error}"
+                ),
+            }
         }
-        assert!(is_global_ip(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))));
+        assert!(resolve_and_validate("127.0.0.1", 80, true).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn tls_server_name_normalizes_bracketed_ipv6_literal() {
+        let host = "[2606:4700:4700::1111]";
+        assert!(ServerName::try_from(host.to_owned()).is_err());
+        assert!(tls_server_name(host).is_some());
     }
 
     #[test]
@@ -1696,7 +1742,7 @@ mod tests {
 
     #[test]
     fn ssrf_block_persists_failed_probe_without_opening_transport() -> Result<(), Box<dyn Error>> {
-        let store = seeded_store("http://127.0.0.1/health", "up")?;
+        let store = seeded_store("http://[::ffff:169.254.169.254]/health", "up")?;
         let transport = StaticTransport::ok(200, "ok");
         let sink = Arc::new(RecordingSink::default());
         let fanout = HealthEventFanout::new_without_failure_sink(sink);
@@ -1719,6 +1765,38 @@ mod tests {
             0,
             "no webhook subscriptions exist in this fixture"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn reqwest_transport_rejects_forged_non_global_destination_before_connecting()
+    -> Result<(), Box<dyn Error>> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        let request = ProbeRequest {
+            method: "GET".to_owned(),
+            url: format!("http://[::ffff:127.0.0.1]:{}/health", addr.port()),
+            headers: BTreeMap::new(),
+            timeout_ms: 50,
+            resolved_addrs: vec![addr],
+            allow_private_targets: false,
+        };
+
+        let error = match ReqwestProbeTransport.probe(request) {
+            Ok(_) => return Err("forged non-global destination was accepted".into()),
+            Err(error) => error,
+        };
+        let ProbeTransportError::Connection(detail) = error else {
+            return Err(format!("expected connection-policy error, got {error:?}").into());
+        };
+        assert!(detail.contains("non-global"));
+
+        listener.set_nonblocking(true)?;
+        match listener.accept() {
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Ok(_) => return Err("transport connected to forged non-global destination".into()),
+            Err(error) => return Err(error.into()),
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- replace the divergent probe and webhook public-destination filters with one shared egress oracle
- reject special-purpose, transition, translated, mapped, and currently unallocated IP space while preserving explicit internal-target bypasses
- pin approved probe destinations through the request capability and revalidate at the concrete transport boundary
- cover IPv4, IPv6, bracketed literals, DNS resolution, TLS SNI, and real request boundaries with table-driven and live tests
- document the unified-oracle footgun in the canonical harness contract

## Root cause

Target probes and webhook delivery had independently maintained address filters. Their policy drift let an IPv4-mapped metadata address pass the webhook path, and bracketed IPv6 literals were left to fail as misleading DNS errors rather than being evaluated by the security policy.

## Impact

All outbound target and webhook requests now pass through the same fail-closed decision layer. Approved destination addresses become an opaque request capability, so callers cannot bypass validation between resolution and transport setup.

## Validation

- `cargo test -p canary-server --locked` (272 library tests plus 2 binary tests)
- `cargo clippy -p canary-server --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `bin/canary-write-path-rehearsal --no-dr-status --json`
- `./bin/validate --strict` (full gate, production image and live smoke; 29m33s)
- fresh adversarial review: PASS (`20260714T232428.686Z-40458-cerberus.yaml`)

Powder: canary-937
