### PR TITLE
feat(release): publish signed portable artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,22 @@ concurrency:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master')
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       contents: write
       issues: write
       pull-requests: write
+      packages: write
+      id-token: write
+    env:
+      OCI_REPOSITORY: ghcr.io/${{ github.repository_owner }}/canary
     steps:
       - name: Checkout release source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -35,10 +44,240 @@ jobs:
           app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
           private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
 
-      - name: Run Landmark
-        uses: misty-step/landmark@v0
+      - name: Set up Node for release planning
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+
+      - name: Prepare semantic-release publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP}/semantic-release"
+          landmark_ref=35d002b7a2bc80efc6d0f412b5adbc3f6a96eeab
+          mkdir -p "$install_dir"
+          curl --fail --silent --show-error --location \
+            "https://raw.githubusercontent.com/misty-step/landmark/${landmark_ref}/package.json" \
+            --output "${install_dir}/package.json"
+          curl --fail --silent --show-error --location \
+            "https://raw.githubusercontent.com/misty-step/landmark/${landmark_ref}/package-lock.json" \
+            --output "${install_dir}/package-lock.json"
+          (cd "$install_dir" && npm ci --no-fund --no-audit)
+
+          cat > .releaserc.json <<'JSON'
+          {
+            "branches": ["master"],
+            "tagFormat": "v${version}",
+            "plugins": [
+              [
+                "@semantic-release/commit-analyzer",
+                {
+                  "releaseRules": [
+                    { "breaking": true, "release": "minor" },
+                    { "type": "feat", "release": "patch" }
+                  ]
+                }
+              ],
+              "@semantic-release/release-notes-generator",
+              [
+                "@semantic-release/changelog",
+                { "changelogFile": "CHANGELOG.md" }
+              ],
+              [
+                "@semantic-release/git",
+                {
+                  "assets": ["CHANGELOG.md"],
+                  "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+                }
+              ],
+              [
+                "@semantic-release/github",
+                {
+                  "draftRelease": true,
+                  "assets": [
+                    {
+                      "path": "release-assets/canary-release-manifest.json",
+                      "name": "canary-release-manifest.json",
+                      "label": "Signed portable release manifest"
+                    },
+                    {
+                      "path": "release-assets/canary-release-manifest.bundle.json",
+                      "name": "canary-release-manifest.bundle.json",
+                      "label": "Signed portable release manifest bundle"
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+          JSON
+          remote_tags="$(git ls-remote --tags origin 'refs/tags/*')"
+          highest_version="$(
+            printf '%s\n' "$remote_tags" |
+              sed -nE 's#.*refs/tags/v?([0-9]+\.[0-9]+\.[0-9]+)(\^\{\})?$#\1#p' |
+              sort -V |
+              tail -n 1
+          )"
+          stability="stable"
+          if [[ -z "$highest_version" || "${highest_version%%.*}" == "0" ]]; then
+            stability="pre-stable"
+          fi
+          echo "::notice::semantic-release stability resolved to ${stability}"
+          if [[ "$stability" == "stable" ]]; then
+            stable_config="${RUNNER_TEMP}/releaserc-stable.json"
+            jq '(.plugins[0][1]) |= del(.releaseRules)' \
+              .releaserc.json >"$stable_config"
+            mv "$stable_config" .releaserc.json
+          fi
+
+      - name: Plan release with semantic-release
+        id: release-plan
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          SEMANTIC_RELEASE_BIN: ${{ runner.temp }}/semantic-release/node_modules/.bin/semantic-release
+        run: |
+          set -euo pipefail
+          log="${RUNNER_TEMP}/semantic-release-plan.log"
+          plan="${RUNNER_TEMP}/semantic-release-plan.json"
+          if ! NO_COLOR=1 "$SEMANTIC_RELEASE_BIN" --dry-run --no-ci >"$log" 2>&1; then
+            cat "$log"
+            exit 1
+          fi
+          cat "$log"
+          version="$(sed -nE 's/.*The next release version is ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' "$log" | tail -n 1)"
+          source_commit="$(git rev-parse HEAD)"
+          if [ -z "$version" ]; then
+            if ! grep -Fq "There are no relevant changes" "$log"; then
+              echo "::error::semantic-release dry-run did not produce a release version or a no-release result"
+              exit 1
+            fi
+            jq -n \
+              --arg source_commit "$source_commit" \
+              '{engine:"semantic-release", released:false, source_commit:$source_commit}' \
+              >"$plan"
+            echo "No release planned for ${source_commit}."
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          release_tag="v${version}"
+          [[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          jq -n \
+            --arg release_tag "$release_tag" \
+            --arg version "$version" \
+            --arg source_commit "$source_commit" \
+            '{engine:"semantic-release", released:true, release_tag:$release_tag, version:$version, source_commit:$source_commit}' \
+            >"$plan"
+          printf 'released=true\nrelease_tag=%s\nversion=%s\nsource_commit=%s\nplan=%s\n' \
+            "$release_tag" "$version" "$source_commit" "$plan" >> "$GITHUB_OUTPUT"
+
+
+      - name: Log in to GHCR
+        if: steps.release-plan.outputs.released == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up QEMU
+        if: steps.release-plan.outputs.released == 'true'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Docker Buildx
+        if: steps.release-plan.outputs.released == 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build and push release image
+        if: steps.release-plan.outputs.released == 'true'
+        id: image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.OCI_REPOSITORY }}:${{ steps.release-plan.outputs.release_tag }}
+            ${{ env.OCI_REPOSITORY }}:git-${{ steps.release-plan.outputs.source_commit }}
+          build-args: |
+            CANARY_VERSION=${{ steps.release-plan.outputs.release_tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.release-plan.outputs.source_commit }}
+            org.opencontainers.image.version=${{ steps.release-plan.outputs.release_tag }}
+
+      - name: Install Cosign
+        if: steps.release-plan.outputs.released == 'true'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Sign and verify release image
+        if: steps.release-plan.outputs.released == 'true'
+        shell: bash
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          SOURCE_COMMIT: ${{ steps.release-plan.outputs.source_commit }}
+          RELEASE_TAG: ${{ steps.release-plan.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image="${OCI_REPOSITORY}@${IMAGE_DIGEST}"
+          cosign sign --yes "$image"
+          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/heads/master"
+          cosign verify \
+            --certificate-identity "$identity" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "$image" >/dev/null
+
+          ./bin/release-manifest generate \
+            --version "$RELEASE_TAG" \
+            --commit "$SOURCE_COMMIT" \
+            --oci-repository "$OCI_REPOSITORY" \
+            --oci-digest "$IMAGE_DIGEST" \
+            --created-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --output "${RUNNER_TEMP}/canary-release-manifest.json"
+          ./bin/release-manifest verify \
+            --file "${RUNNER_TEMP}/canary-release-manifest.json"
+          cosign sign-blob \
+            --yes \
+            --bundle "${RUNNER_TEMP}/canary-release-manifest.bundle.json" \
+            "${RUNNER_TEMP}/canary-release-manifest.json"
+          cosign verify-blob \
+            --bundle "${RUNNER_TEMP}/canary-release-manifest.bundle.json" \
+            --certificate-identity "$identity" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${RUNNER_TEMP}/canary-release-manifest.json" >/dev/null
+
+      - name: Upload signed release evidence
+        if: steps.release-plan.outputs.released == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: canary-release-${{ steps.release-plan.outputs.release_tag }}
+          if-no-files-found: error
+          path: |
+            ${{ runner.temp }}/semantic-release-plan.json
+            ${{ runner.temp }}/canary-release-manifest.json
+            ${{ runner.temp }}/canary-release-manifest.bundle.json
+
+      - name: Stage signed release assets
+        if: steps.release-plan.outputs.released == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          cp "${RUNNER_TEMP}/canary-release-manifest.json" \
+            release-assets/canary-release-manifest.json
+          cp "${RUNNER_TEMP}/canary-release-manifest.bundle.json" \
+            release-assets/canary-release-manifest.bundle.json
+
+      - name: Publish GitHub release
+        if: steps.release-plan.outputs.released == 'true'
+        id: landmark
+        uses: misty-step/landmark@35d002b7a2bc80efc6d0f412b5adbc3f6a96eeab # v0
         with:
           mode: full
+          stability: "auto"
           # Short-lived installation token from the org's misty-step-releaser
           # GitHub App (misty-step-940), replacing the github.token stopgap
           # from #244: unlike GITHUB_TOKEN, App tokens still trigger
@@ -52,3 +291,40 @@ jobs:
           webhook-url: ${{ secrets.LANDMARK_WEBHOOK_URL }}
           webhook-secret: ${{ secrets.LANDMARK_WEBHOOK_SECRET }}
           product-description: "Canary is a self-hosted, agent-first production health ledger for errors, uptime, incidents, timelines, webhooks, and remediation claims."
+
+      - name: Verify Landmark release matches plan
+        if: steps.release-plan.outputs.released == 'true'
+        shell: bash
+        env:
+          EXPECTED_TAG: ${{ steps.release-plan.outputs.release_tag }}
+          ACTUAL_RELEASED: ${{ steps.landmark.outputs.released }}
+          ACTUAL_TAG: ${{ steps.landmark.outputs.release-tag }}
+        run: |
+          set -euo pipefail
+          test "$ACTUAL_RELEASED" = "true"
+          test "$ACTUAL_TAG" = "$EXPECTED_TAG"
+
+      - name: Verify release assets staged
+        if: steps.release-plan.outputs.released == 'true' && steps.landmark.outputs.released == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          RELEASE_TAG: ${{ steps.release-plan.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh release view "$RELEASE_TAG" --json isDraft,assets \
+            --jq '(.isDraft == true) and ([.assets[].name] | (index("canary-release-manifest.json") != null and index("canary-release-manifest.bundle.json") != null))' \
+            | grep -Fx true >/dev/null
+
+      - name: Publish verified GitHub release
+        if: steps.release-plan.outputs.released == 'true' && steps.landmark.outputs.released == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          RELEASE_TAG: ${{ steps.release-plan.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$RELEASE_TAG" --draft=false
+          gh release view "$RELEASE_TAG" --json isDraft,assets \
+            --jq '(.isDraft == false) and ([.assets[].name] | (index("canary-release-manifest.json") != null and index("canary-release-manifest.bundle.json") != null))' \
+            | grep -Fx true >/dev/null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,15 +79,15 @@ Prefer these over re-deriving from the code base.
 | **canary-010 Ramp pattern** (blocked, XL, north-star) | Powder | Blocked ~3.5 months on nonexistent bitterblossom artifacts; unblock-or-kill proposal via canary-932 child 5. |
 | **canary-020 Adminifi HTTP surface verification** (blocked, S) | Powder | Upstream Adminifi HTTP surface stability. |
 | **canary-063 Triage contract hardening** (backlog, XL, P1) | Powder | Durable webhook cooldown, dispatch budgets, claim-gated delivery. |
-| **canary-064 Trustworthy release/upgrade** (backlog, L, P1) | Powder | Rescoped 2026-07-09: release restore → canary-931, declarative image contract → canary-934; live artifact publication remains open. |
+| **canary-064 Trustworthy release/upgrade** (backlog, L, P1) | Powder | Rescoped 2026-07-09: release restore → canary-931, declarative image contract → canary-934; publisher wiring landed, while live release/readback evidence remains operator-gated. |
 | **canary-065 Runtime hardening** (backlog, L, P1) | Powder | bcrypt child superseded by canary-930; proxy-header trust invariant and witness cadence truth. |
 | **canary-066 Consolidation and archaeology deletion** (backlog, XL, P2) | Powder | Worker lifecycle QUINT unification (webhook_delivery is the divergent fifth), oban_jobs rename (gated on prod DB restamp), ValidationErrors relocation / canary-ingest fold, fixture WAL ignore. |
 | Recurring footgun surface | Footguns section below + Rust store/runtime/schema modules | Every remediation here must cite the footgun list and extend it when new failure modes appear. |
 | **canary-930 Request-path concurrency** (ready, P0) | Powder | bcrypt-under-store-lock root cause (live-reproduced), /readyz spiral, mutex poisoning, monitor_overdue scan, oban_jobs growth. Consolidates the slow-API/500 cards. |
-| **canary-931 Release pipeline restore** (ready, P0) | Powder | Releaser App secrets missing (releases hard-down), zero GitHub releases, version truth, and API/CLI/MCP integration contract. |
+| **canary-931 Release pipeline restore** (ready, P0) | Powder | Release App path and version truth are wired; NPM publication remains operator-gated, while signed OCI publication is owned by canary-934. |
 | **canary-932 Coordination loop in anger** (ready, P0) | Powder | CLI/MCP read-half parity (incident get, timeline cursor, drill-downs, parity guard) + dogfood claims on real incidents. |
 | **canary-933 Gate proves live behavior** (ready, P1) | Powder | Latency floor, seeded-volume + concurrency rehearsal, post-deploy gate, Rust coverage ratchet, diff-scoped strict. Absorbs 914/972. |
-| **canary-934 Portable release and recovery** (claimed, P1) | Powder | Declarative OCI release manifest, generic S3-compatible recovery, data verification, and product/deployment boundary cleanup; live publication/signing acceptance remains open. |
+| **canary-934 Portable release and recovery** (claimed, P1) | Powder | Declarative OCI release manifest, generic S3-compatible recovery, data verification, and pre-release image/manifest signing workflow are wired; live publication/signature/pull and restore acceptance remain operator-gated. |
 | **canary-935 /ui first-class** (ready, P1) | Powder | Vendored fonts, graceful degradation, read contract, UI smoke, mobile-first. Folds 067/068/915 intent. |
 | **canary-936 Service-bound reads + redaction corpus** (ready, P0) | Powder | Unbound read keys read cross-service rich context; four-regex redaction. 048 successor; ADR-gated scope model. |
 
@@ -107,9 +107,11 @@ Canary reports its own errors through the Rust runtime direct-ingest path, no HT
 
 ## Portable release acceptance crib
 
-The repository does not currently publish or sign the declared OCI release.
-When an atomic publisher exists, live acceptance must exercise this sequence;
-the commands are not evidence that a pullable artifact exists today.
+The Release workflow uses one semantic-release decision engine: a dry-run
+plans the tag, then the full run creates a draft GitHub release, uploads the
+signed image manifest and bundle, and publishes only after both uploads
+succeed. After a successful run, live acceptance must exercise this sequence;
+local commands alone are not evidence that a pullable artifact exists.
 
 ```bash
 bin/release-manifest verify --file canary-release-manifest.json

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ cargo run -p canary-server
 No Docker is required for local development outside the Dagger gate. The repo
 includes the Rust service workspace and a private TypeScript source reference;
 supported application integrations use the HTTP API, CLI, and MCP surfaces.
-The declarative contract for a future portable OCI release and its runtime is
-in
+The declarative contract for the portable OCI release and its runtime is in
 [`docs/portable-runtime-contract.md`](docs/portable-runtime-contract.md).
-Canary does not yet publish or sign that artifact; live pull and signature
-verification remain unproved acceptance work.
+The Release workflow builds and keylessly signs the multi-platform image and
+release manifest, stages both signed files in a draft GitHub release, and
+publishes only after the uploads succeed.
 
 ### First run: capturing the bootstrap API key
 
@@ -618,15 +618,16 @@ schema (`priv/openapi/openapi.json`) for the authoritative contract.
 
 ## Portable OCI release contract
 
-Canary now declares the provider-neutral shape of a future multi-platform OCI
-artifact and signed release manifest. No release workflow currently builds,
-publishes, or signs that artifact: live pull, signature verification, and
-atomic publication are still open acceptance criteria.
+Canary declares the provider-neutral shape of a multi-platform OCI artifact
+and signed release manifest. The Release workflow uses one semantic-release
+decision engine, builds and keylessly signs the artifact, then stages the
+digest-pinned manifest and signature bundle in a draft GitHub release before
+publishing it.
 
-Once a release publisher can satisfy the contract atomically, acceptance must
-prove the manifest, signature bundle, digest-pinned image, classified runtime
-inputs, health, readiness, version, migration, application readback, and the
-generic S3-compatible restore check.
+After a successful release run, acceptance must prove the manifest, signature
+bundle, digest-pinned image, classified runtime inputs, health, readiness,
+version, migration, application readback, and the generic S3-compatible restore
+check.
 
 The exact commands and evidence schemas are in
 [`docs/portable-runtime-contract.md`](docs/portable-runtime-contract.md).

--- a/docs/portable-runtime-contract.md
+++ b/docs/portable-runtime-contract.md
@@ -1,21 +1,33 @@
 # Portable Runtime Contract
 
-This is Canary's product-owned deployment boundary. It declares a future
-portable release as an immutable OCI image plus a signed
+This is Canary's product-owned deployment boundary. It declares a portable
+release as an immutable OCI image plus a signed
 `canary.release-manifest.v1` document. The product defines runtime behavior and
-verification commands. Each deployer
-chooses resource sizing, placement, networking, persistence, credentials,
-promotion, rollback, and recovery policy outside this repository.
+verification commands. Each deployer chooses resource sizing, placement,
+networking, persistence, credentials, promotion, rollback, and recovery policy
+outside this repository.
 
 ## Release artifact
 
-This section is a declarative acceptance contract. Canary's current release
-workflow does not build, publish, sign, or attach this artifact. A live pull and
-signature verification have not been proved. Publication must remain disabled
-until the artifact, manifest, and signatures can be produced before the stable
-GitHub release becomes visible.
+The Release workflow uses semantic-release's dry-run and full pass with one
+generated config so the build tag and published tag come from the same engine.
+It builds `linux/amd64` and `linux/arm64` images with the release version
+stamped into the image, pushes the digest to GHCR, and signs the image with
+keyless GitHub Actions OIDC. It verifies the image signature, generates and
+verifies the digest-pinned release manifest, and signs and verifies that bundle.
+The semantic-release GitHub plugin creates a draft release, uploads the
+manifest and bundle, and publishes the release only after both uploads succeed.
+The manifest's `source.commit` is the exact revision used to build the image.
+The release-only changelog commit, if created, is intentionally not the image
+source.
 
-Once an atomic publisher exists, acceptance uses the published tag to download
+The digest reference in the signed manifest is the release identity. Tags are
+discovery aliases only. `contracts/release-manifest.v1.schema.json` and
+`bin/release-manifest` are the machine-readable schema and fail-closed
+verifier. A successful release run is required before claiming a live artifact
+publication; the acceptance sequence below is the operator readback.
+
+After a successful release run, acceptance uses the published tag to download
 and verify its manifest before pulling the image:
 
 ```bash

--- a/docs/self-host-docker.md
+++ b/docs/self-host-docker.md
@@ -1,8 +1,10 @@
 # OCI Runtime Contract
 
-Canary is not yet distributed as a signed, pullable OCI release. This document
-defines how that image must behave once atomic publication and live signature
-verification are proved. The declarative artifact contract is in
+The Release workflow builds and keylessly signs the multi-platform image and
+portable release manifest, stages both signed files in a draft GitHub release,
+and publishes only after the uploads succeed. A successful release run is
+required before treating the artifact as pullable; this document defines how
+that published image must behave. The declarative artifact contract is in
 [`portable-runtime-contract.md`](portable-runtime-contract.md#release-artifact).
 
 After a conforming artifact exists, the deployer runs its digest with values satisfying

--- a/docs/upgrade-and-rollback.md
+++ b/docs/upgrade-and-rollback.md
@@ -1,9 +1,11 @@
 # Upgrade and Rollback Contract
 
-Canary declares the required shape of immutable, signed OCI releases but does
-not yet publish them. Live pull, signature verification, and atomic publication
-remain unproved. Once a conforming artifact exists, the deployer owns
-promotion, placement, cutover, rollback policy, and recovery evidence.
+Canary declares the required shape of immutable, signed OCI releases. The
+Release workflow builds and signs those artifacts, stages the manifest and
+bundle in a draft GitHub release, and publishes only after both assets upload
+successfully. Live pull and signature verification remain operator evidence
+from a successful release run. Once a conforming artifact exists, the deployer
+owns promotion, placement, cutover, rollback policy, and recovery evidence.
 
 Before any future promotion:
 


### PR DESCRIPTION
## Summary
- derive the release tag with one semantic-release dry-run and reuse the generated config for the full publish pass
- build and push linux/amd64 + linux/arm64 GHCR images with stamped version
- keylessly sign and verify the image and portable release manifest with GitHub OIDC
- create a draft GitHub Release, upload and verify both signed manifest assets, then publish the draft
- refresh the portable release contract and operator docs

## Verification
- `actionlint .github/workflows/release.yml`
- `bash test/bin/release_manifest_test.sh`
- local semantic-release 24.2.9 dry-run with the generated config resolves `v0.16.7` from the master release context
- hosted Dagger check passed: run `29543913069`, job `87771830894`
- CodeRabbit check passed
- local `./bin/validate --fast` and Docker image smoke remain environment-blocked by the locked macOS Docker credential keychain before code execution

## Residual acceptance
The first live release still needs operator readback: download the published manifest, verify both Cosign signatures, pull the digest-pinned image, and run the restore/data-verification check. The workflow now keeps the GitHub Release in draft until the signed manifest and bundle are present.