### PR TITLE
chore(ci): extend release job timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'master')
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

- Increase the release job timeout from 45 to 90 minutes.
- Keep the existing multi-platform release build unchanged.

The v0.16.7 release build spent 43m14s compiling the linux/arm64 server image under emulation, leaving no margin for signing, manifest generation, and GitHub release publication before the 45-minute job limit. This is a bounded timeout correction; the separate cross-compilation optimization remains out of scope.

## Verification

- `actionlint .github/workflows/release.yml`
- Local fast/strict hooks were attempted but could not access the macOS login keychain for Dagger image credentials; hosted CI remains the authoritative gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum release process runtime to 90 minutes, reducing the chance of longer releases being terminated prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->