### PR TITLE
fix(store): repair missing current-schema FTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,12 @@ original cannot be re-shown.
 - **Schema ownership.** `crates/canary-store/src/schema.rs` is the Rust schema
   source. `Store::migrate` must fail closed on partial existing schemas before
   stamping `user_version`.
+- **Derived FTS repair.** A current-version database can lose an FTS table or
+  trigger without changing `user_version`. `Store::migrate` must recreate the
+  missing derived objects and rebuild the whole external-content FTS index in
+  one transaction before strict validation, because a trigger gap may have
+  left searchable rows stale. Healthy schemas must not rebuild; altered FTS
+  definitions and non-derived drift still fail closed.
 - **Custom string IDs.** Stable prefixes (`ERR-`, `INC-`, `EVT-`, `WHK-`,
   `MON-`) are product contracts. Keep ID generation in `canary-core::ids`.
 - **State machines stay pure.** Health transitions live in

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -1629,22 +1629,81 @@ mod tests {
     }
 
     #[test]
-    fn migrate_rejects_current_version_missing_fts_objects() -> Result<()> {
+    fn migrate_repairs_current_version_missing_fts_objects() -> Result<()> {
         let mut store = migrated_store()?;
+        store.connection.execute(
+            "INSERT INTO errors (
+                id, service, error_class, message, stack_trace, group_hash, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                "ERR-fts-repair",
+                "sploot",
+                "RuntimeError",
+                "boom before repair",
+                "stack before repair",
+                "group-fts-repair",
+                "2026-05-28T20:00:00Z"
+            ],
+        )?;
         store.connection.execute_batch("DROP TABLE errors_fts;")?;
 
-        let result = store.migrate();
-        assert!(
-            result.is_err(),
-            "migrate should fail when current FTS objects are missing"
+        store.migrate()?;
+
+        let count = store.connection.query_row(
+            "SELECT count(*) FROM errors_fts WHERE errors_fts MATCH 'repair'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        assert_eq!(count, 1);
+
+        store.migrate()?;
+        let repeat_count = store.connection.query_row(
+            "SELECT count(*) FROM errors_fts WHERE errors_fts MATCH 'repair'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        assert_eq!(repeat_count, 1);
+        assert_eq!(
+            trigger_names(&store.connection, "errors")?,
+            BTreeSet::from([
+                "errors_fts_delete".to_owned(),
+                "errors_fts_insert".to_owned(),
+                "errors_fts_update".to_owned(),
+            ])
         );
-        let error = result
-            .err()
-            .ok_or(StoreError::Sqlite(rusqlite::Error::QueryReturnedNoRows))?;
-        assert!(
-            matches!(error, StoreError::Sqlite(_)),
-            "expected a SQLite error, got {error:?}"
-        );
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_repairs_current_version_missing_fts_trigger() -> Result<()> {
+        let mut store = migrated_store()?;
+        store
+            .connection
+            .execute_batch("DROP TRIGGER errors_fts_insert;")?;
+        store.connection.execute(
+            "INSERT INTO errors (
+                id, service, error_class, message, stack_trace, group_hash, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                "ERR-fts-trigger-repair",
+                "sploot",
+                "RuntimeError",
+                "boom during trigger gap",
+                "stack during trigger gap",
+                "group-fts-trigger-repair",
+                "2026-05-28T20:00:00Z"
+            ],
+        )?;
+
+        store.migrate()?;
+
+        let count = store.connection.query_row(
+            "SELECT count(*) FROM errors_fts WHERE errors_fts MATCH 'gap'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        assert_eq!(count, 1);
+        assert!(trigger_names(&store.connection, "errors")?.contains("errors_fts_insert"));
         Ok(())
     }
 

--- a/crates/canary-store/src/schema.rs
+++ b/crates/canary-store/src/schema.rs
@@ -11,14 +11,16 @@ pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
     let user_version =
         connection.query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))?;
     if user_version == SCHEMA_VERSION {
-        // Current databases must stay on the metadata-only path. In
-        // particular, do not replay data backfills on every boot.
-        validate_schema_columns(connection)?;
+        let transaction = connection.transaction()?;
+        ensure_current_fts_objects(&transaction)?;
+        validate_schema_columns(&transaction)?;
+        transaction.commit()?;
         return Ok(());
     }
 
     let transaction = connection.transaction()?;
     transaction.execute_batch(SCHEMA_SQL)?;
+    transaction.execute_batch(FTS_SCHEMA_SQL)?;
     add_bootstrap_ownership_columns(&transaction)?;
     add_api_key_unbound_grant_column(&transaction)?;
     scope_error_group_identity(&transaction)?;
@@ -56,9 +58,70 @@ const APP_TABLES: &[&str] = &[
     "rate_limit_buckets",
 ];
 
+const FTS_SCHEMA_SQL: &str = r#"
+CREATE VIRTUAL TABLE IF NOT EXISTS errors_fts USING fts5(
+  service,
+  error_class,
+  message,
+  stack_trace,
+  content='errors',
+  content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS errors_fts_insert
+AFTER INSERT ON errors
+BEGIN
+  INSERT INTO errors_fts(rowid, service, error_class, message, stack_trace)
+  VALUES (new.rowid, new.service, new.error_class, new.message, new.stack_trace);
+END;
+
+CREATE TRIGGER IF NOT EXISTS errors_fts_delete
+AFTER DELETE ON errors
+BEGIN
+  INSERT INTO errors_fts(errors_fts, rowid, service, error_class, message, stack_trace)
+  VALUES ('delete', old.rowid, old.service, old.error_class, old.message, old.stack_trace);
+END;
+
+CREATE TRIGGER IF NOT EXISTS errors_fts_update
+AFTER UPDATE ON errors
+BEGIN
+  INSERT INTO errors_fts(errors_fts, rowid, service, error_class, message, stack_trace)
+  VALUES ('delete', old.rowid, old.service, old.error_class, old.message, old.stack_trace);
+
+  INSERT INTO errors_fts(rowid, service, error_class, message, stack_trace)
+  VALUES (new.rowid, new.service, new.error_class, new.message, new.stack_trace);
+END;
+"#;
+
+fn ensure_current_fts_objects(transaction: &rusqlite::Transaction<'_>) -> rusqlite::Result<()> {
+    let mut repair_needed = false;
+    for (name, object_type) in [
+        ("errors_fts", "table"),
+        ("errors_fts_insert", "trigger"),
+        ("errors_fts_delete", "trigger"),
+        ("errors_fts_update", "trigger"),
+    ] {
+        let present = transaction.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_schema
+                 WHERE type = ?1 AND name = ?2
+             )",
+            [object_type, name],
+            |row| row.get::<_, bool>(0),
+        )?;
+        repair_needed |= !present;
+    }
+    if repair_needed {
+        transaction.execute_batch(FTS_SCHEMA_SQL)?;
+        transaction.execute("INSERT INTO errors_fts(errors_fts) VALUES ('rebuild')", [])?;
+    }
+    Ok(())
+}
+
 fn validate_schema_columns(connection: &Connection) -> rusqlite::Result<()> {
     let reference = Connection::open_in_memory()?;
     reference.execute_batch(SCHEMA_SQL)?;
+    reference.execute_batch(FTS_SCHEMA_SQL)?;
     scope_monitor_name_index(&reference)?;
     scope_incident_open_service_index(&reference)?;
     for table in APP_TABLES {
@@ -742,39 +805,6 @@ ON incident_signals(incident_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS incident_signals_incident_id_signal_type_signal_ref_index
 ON incident_signals(incident_id, signal_type, signal_ref);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS errors_fts USING fts5(
-  service,
-  error_class,
-  message,
-  stack_trace,
-  content='errors',
-  content_rowid='rowid'
-);
-
-CREATE TRIGGER IF NOT EXISTS errors_fts_insert
-AFTER INSERT ON errors
-BEGIN
-  INSERT INTO errors_fts(rowid, service, error_class, message, stack_trace)
-  VALUES (new.rowid, new.service, new.error_class, new.message, new.stack_trace);
-END;
-
-CREATE TRIGGER IF NOT EXISTS errors_fts_delete
-AFTER DELETE ON errors
-BEGIN
-  INSERT INTO errors_fts(errors_fts, rowid, service, error_class, message, stack_trace)
-  VALUES ('delete', old.rowid, old.service, old.error_class, old.message, old.stack_trace);
-END;
-
-CREATE TRIGGER IF NOT EXISTS errors_fts_update
-AFTER UPDATE ON errors
-BEGIN
-  INSERT INTO errors_fts(errors_fts, rowid, service, error_class, message, stack_trace)
-  VALUES ('delete', old.rowid, old.service, old.error_class, old.message, old.stack_trace);
-
-  INSERT INTO errors_fts(rowid, service, error_class, message, stack_trace)
-  VALUES (new.rowid, new.service, new.error_class, new.message, new.stack_trace);
-END;
 
 CREATE TABLE IF NOT EXISTS service_events (
   id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

- transactionally recreate missing `errors_fts` derived objects on current-schema boot
- rebuild the external-content index after any table or trigger repair so rows written during a trigger gap become searchable
- preserve the O(1) healthy-schema fast path and fail closed on altered FTS definitions or non-derived schema drift
- document the derived-FTS recovery footgun

## Incident

Closes Powder incident `canary-986`. Production carried `PRAGMA user_version = 2026071400` while a required FTS object was missing. Release `7f26eaf` correctly stopped replaying migration DDL for healthy current schemas, but its strict validation failed before router construction instead of repairing derived FTS state. Caddy therefore returned empty-body 503s for every route.

## Verification

- exact CLI repair and repeat-migration reproduction passed
- `cargo test -p canary-store --locked`: 153 passed
- `cargo clippy -p canary-store --all-targets --locked -- -D warnings`: passed
- fresh Cerberus review: PASS, no important findings
- local `./bin/validate --strict` reached the production-image lane but was environment-blocked by the locked macOS Docker credential keychain; hosted Dagger CI is the authoritative full gate

## Deployment safety

The production DB is 2.6 GiB. A repair-triggered FTS rebuild is a full transaction. Before promotion, exercise the exact artifact against a production DB copy on root-backed scratch storage and record duration plus peak disk usage; do not make the live volume the first large-data rehearsal. Estate authorization remains required for production deployment.