### PR TITLE
fix(store): harden SQLite maintenance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,8 +49,26 @@ All writes go through `canary_store::Store`. The production server shares one
 writable store behind a process-local lock so SQLite's single-writer constraint
 is explicit rather than hidden behind a pool.
 
+Read-model routes use a bounded pool of read-only WAL connections. The
+Prometheus `/metrics` snapshot runs on Tokio's blocking pool and is cancelled
+by a SQLite progress handler when its query budget expires; it does not hold
+the process-local writer lock while aggregating. Reads that intentionally
+expire claims remain on the writer because they mutate state.
+
+SQLite `BUSY` and `LOCKED` failures are a capacity signal, not an internal
+fault. Authenticated HTTP routes return RFC 9457 `503 unavailable` with
+`Retry-After: 5`; callers may retry after the current writer releases.
+
 Schema source lives in `crates/canary-store/src/schema.rs`. Custom string IDs
 use stable prefixes such as `ERR-`, `INC-`, `WHK-`, and `MON-`.
+
+The retention lifecycle deletes at most 1,000 rows per statement. It covers
+errors, service events, target checks, terminal webhook deliveries, monitor
+check-ins, annotations, resolved incident signals, terminal remediation
+claims, resolved incidents with no retained dependent history, and terminal
+Oban jobs. Active incidents, active claims, pending deliveries, and
+runnable jobs never match retention predicates. Each completed pass runs a
+bounded incremental vacuum that reclaims at most 1,000 free pages.
 
 ## Request Flow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "parking_lot",
  "rcgen",
  "reqwest",
+ "rusqlite",
  "rustls",
  "serde",
  "serde_json",

--- a/crates/canary-ingest/src/lib.rs
+++ b/crates/canary-ingest/src/lib.rs
@@ -498,7 +498,10 @@ mod tests {
             assert!(errors.contains_key("message"));
             assert!(!errors.contains_key("fingerprint"));
         }
-        assert_eq!(store.schema_version()?, canary_store_schema_version());
+        assert_eq!(
+            store.schema_version()?,
+            canary_store::CURRENT_SCHEMA_VERSION
+        );
 
         Ok(())
     }
@@ -711,9 +714,5 @@ mod tests {
             project_id: BOOTSTRAP_PROJECT_ID.to_owned(),
             now: now.to_owned(),
         }
-    }
-
-    const fn canary_store_schema_version() -> u32 {
-        2026071400
     }
 }

--- a/crates/canary-server/Cargo.toml
+++ b/crates/canary-server/Cargo.toml
@@ -31,6 +31,7 @@ x509-parser = "0.18"
 
 [dev-dependencies]
 rcgen = "0.14"
+rusqlite = { version = "0.37", features = ["bundled"] }
 tokio = { version = "1.48", features = ["macros", "net", "rt"] }
 tower = { version = "0.5", features = ["util"] }
 

--- a/crates/canary-server/src/annotations.rs
+++ b/crates/canary-server/src/annotations.rs
@@ -19,13 +19,17 @@ use canary_http::{
     request::{MAX_JSON_BODY_BYTES, decode_json_object},
 };
 use canary_ingest::{IngestEffect, ValidationErrors};
-use canary_store::{AnnotationError, AnnotationInsert, AnnotationPageOptions, VerifiedApiKey};
+use canary_store::{
+    AnnotationError, AnnotationInsert, AnnotationPageOptions, VerifiedApiKey, sqlite_error_is_busy,
+};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
 use crate::{
     IngestState, enforce_service_authority,
-    http_contract::{check_content_length, json_status_response, problem_response},
+    http_contract::{
+        check_content_length, json_status_response, problem_response, storage_busy_response,
+    },
     require_read_scope, require_responder_write_scope,
     server_time::current_rfc3339,
 };
@@ -272,6 +276,9 @@ fn create_annotation_request(
             Err(AnnotationError::InvalidLimit | AnnotationError::InvalidCursor) => {
                 return problem_response(internal_problem());
             }
+            Err(AnnotationError::Sqlite(error)) if sqlite_error_is_busy(&error) => {
+                return storage_busy_response();
+            }
             Err(AnnotationError::Sqlite(_)) => return problem_response(internal_problem()),
         };
         if let Some(service) = service.as_deref()
@@ -306,6 +313,9 @@ fn create_annotation_request(
             }
             Err(AnnotationError::InvalidLimit | AnnotationError::InvalidCursor) => {
                 return problem_response(internal_problem());
+            }
+            Err(AnnotationError::Sqlite(error)) if sqlite_error_is_busy(&error) => {
+                return storage_busy_response();
             }
             Err(AnnotationError::Sqlite(_)) => return problem_response(internal_problem()),
         };

--- a/crates/canary-server/src/http_contract.rs
+++ b/crates/canary-server/src/http_contract.rs
@@ -9,11 +9,11 @@ use axum::{
     body::Body,
     http::{
         HeaderMap, HeaderValue, Response, StatusCode,
-        header::{CONTENT_LENGTH, CONTENT_TYPE},
+        header::{CONTENT_LENGTH, CONTENT_TYPE, RETRY_AFTER},
     },
 };
 use canary_http::{
-    problem_details::{ProblemDetails, payload_too_large_problem},
+    problem_details::{ProblemCode, ProblemDetails, payload_too_large_problem},
     public::PublicResponse,
     request::MAX_JSON_BODY_BYTES,
 };
@@ -64,10 +64,34 @@ where
 
 pub(crate) fn problem_response(problem: ProblemDetails) -> Response<Body> {
     let status = problem.status;
+    let retryable = problem.code == ProblemCode::Unavailable.as_str();
     match serde_json::to_vec(&problem) {
-        Ok(body) => response(status, PROBLEM_CONTENT_TYPE, Body::from(body)),
+        Ok(body) => {
+            let mut response = response(status, PROBLEM_CONTENT_TYPE, Body::from(body));
+            if retryable {
+                response
+                    .headers_mut()
+                    .insert(RETRY_AFTER, HeaderValue::from_static("5"));
+            }
+            response
+        }
         Err(_) => internal_server_error(),
     }
+}
+
+/// Build the retryable problem used when SQLite's single writer is busy.
+pub(crate) fn storage_busy_problem() -> ProblemDetails {
+    ProblemDetails::new(
+        StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+        ProblemCode::Unavailable,
+        "Persistent storage is temporarily busy. Retry the request.",
+        None,
+    )
+}
+
+/// Build the retryable response used when SQLite's single writer is busy.
+pub(crate) fn storage_busy_response() -> Response<Body> {
+    problem_response(storage_busy_problem())
 }
 
 pub(crate) fn query_param_is_array(raw_query: Option<&str>, param: &str) -> bool {

--- a/crates/canary-server/src/ingest_routes.rs
+++ b/crates/canary-server/src/ingest_routes.rs
@@ -29,7 +29,9 @@ use crate::{
     HealthEventSource, IngestState,
     body_fields::{optional_string, required_string},
     enforce_service_authority,
-    http_contract::{check_content_length, json_status_response, problem_response},
+    http_contract::{
+        check_content_length, json_status_response, problem_response, storage_busy_response,
+    },
     require_ingest_scope,
     server_time::{current_rfc3339, current_unix_millis},
 };
@@ -101,6 +103,7 @@ pub(crate) async fn create_error(
         Err(IngestError::PayloadTooLarge(detail)) => {
             problem_response(payload_too_large_problem(detail))
         }
+        Err(IngestError::Store(error)) if error.is_busy() => storage_busy_response(),
         Err(IngestError::Store(_)) => problem_response(internal_problem()),
     }
 }
@@ -158,6 +161,7 @@ pub(crate) async fn create_check_in(
     ) {
         Ok(Some(snapshot)) => snapshot,
         Ok(None) => return problem_response(not_found_problem("Monitor not found.")),
+        Err(error) if error.is_busy() => return storage_busy_response(),
         Err(_) => return problem_response(internal_problem()),
     };
     if let Err(problem) = enforce_service_authority(&key, &snapshot.service) {
@@ -189,6 +193,7 @@ pub(crate) async fn create_check_in(
     let response_state = plan.commit.state.clone();
     let commit = match store.commit_monitor_check_in(plan.commit) {
         Ok(commit) => commit,
+        Err(error) if error.is_busy() => return storage_busy_response(),
         Err(_) => return problem_response(internal_problem()),
     };
     drop(store);

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -269,7 +269,7 @@ mod tests {
         body::{Body, to_bytes},
         http::{
             HeaderMap, HeaderValue, Method, Request, Response, StatusCode,
-            header::{CACHE_CONTROL, CONTENT_TYPE},
+            header::{CACHE_CONTROL, CONTENT_TYPE, RETRY_AFTER},
         },
     };
     use canary_core::{
@@ -295,6 +295,7 @@ mod tests {
         retention::RetentionPolicy,
         webhooks::{CircuitDecision, TransportResult, WebhookJob, WebhookRequest},
     };
+    use rusqlite::Connection;
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
@@ -907,6 +908,39 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn metrics_snapshot_completes_while_the_writer_lock_is_held() -> Result<(), Box<dyn Error>> {
+        let path = temp_db_path("metrics-read-pool");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        let read_pool = Arc::new(ReadPool::open(&path)?);
+        let state = IngestState::new(store, IngestConfig::default()).with_read_pool(read_pool);
+
+        let guard = state.lock_store().map_err(|_| "store lock poisoned")?;
+        let worker_state = state.clone();
+        let (sent, received) = std::sync::mpsc::channel();
+        let worker = thread::spawn(move || {
+            let snapshot = worker_state
+                .read_source()
+                .and_then(|reader| reader.metrics_snapshot().map_err(|error| error.to_string()));
+            sent.send(snapshot)
+        });
+
+        let snapshot = received.recv_timeout(StdDuration::from_millis(500));
+        drop(guard);
+        worker
+            .join()
+            .map_err(|_| "metrics worker panicked")?
+            .map_err(|_| "metrics receiver dropped")?;
+        snapshot??;
+
+        fs::remove_file(&path)?;
+        let _ = fs::remove_file(format!("{}-wal", path.display()));
+        let _ = fs::remove_file(format!("{}-shm", path.display()));
+
+        Ok(())
+    }
+
     /// `report_error_groups_scoped` and `active_incidents` deliberately stay
     /// off the read pool because they fuse a claim-expiry write into the
     /// read (see `read_pool.rs` and `read_source.rs`). This guards that the
@@ -1242,6 +1276,90 @@ mod tests {
             )
             .await?;
         assert_eq!(next.status(), StatusCode::OK);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sqlite_write_contention_returns_retryable_503_for_write_routes()
+    -> Result<(), Box<dyn Error>> {
+        let path = temp_db_path("write-contention");
+        let mut store = Store::open(&path)?;
+        store.migrate()?;
+        seed_api_key(&mut store, "KEY-admin", ADMIN_KEY, "admin", None)?;
+        seed_api_key(&mut store, "KEY-ingest", INGEST_KEY, "ingest-only", None)?;
+        seed_target(&mut store, "test-svc")?;
+        seed_monitor(&mut store, "desktop-active-timer")?;
+        let state = IngestState::new(store, IngestConfig::default());
+        let router = ingest_router(state.clone());
+
+        // Warm both auth-cache entries before taking the database write lock;
+        // the observed failures must come from the route writes themselves.
+        let warm_ingest = router
+            .clone()
+            .oneshot(error_request(INGEST_KEY, valid_error_body())?)
+            .await?;
+        assert_eq!(warm_ingest.status(), StatusCode::CREATED);
+        let warm_admin = router
+            .clone()
+            .oneshot(read_request(ADMIN_KEY, "/metrics")?)
+            .await?;
+        assert_eq!(warm_admin.status(), StatusCode::OK);
+
+        let blocker = Connection::open(&path)?;
+        blocker.execute_batch("BEGIN IMMEDIATE")?;
+
+        let busy_ingest = router
+            .clone()
+            .oneshot(error_request(INGEST_KEY, valid_error_body())?)
+            .await?;
+        assert_eq!(busy_ingest.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            busy_ingest.headers().get(RETRY_AFTER),
+            Some(&HeaderValue::from_static("5"))
+        );
+        assert_eq!(json_body(busy_ingest).await?["code"], "unavailable");
+
+        let busy_check_in = router
+            .clone()
+            .oneshot(check_in_request(INGEST_KEY, valid_check_in_body())?)
+            .await?;
+        assert_eq!(busy_check_in.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            busy_check_in.headers().get(RETRY_AFTER),
+            Some(&HeaderValue::from_static("5"))
+        );
+        assert_eq!(json_body(busy_check_in).await?["code"], "unavailable");
+
+        let busy_annotation = router
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/v1/annotations",
+                ADMIN_KEY,
+                r#"{"subject_type":"target","subject_id":"TGT-test-svc","agent":"test","action":"busy"}"#,
+            )?)
+            .await?;
+        assert_eq!(busy_annotation.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            busy_annotation.headers().get(RETRY_AFTER),
+            Some(&HeaderValue::from_static("5"))
+        );
+        assert_eq!(json_body(busy_annotation).await?["code"], "unavailable");
+
+        blocker.execute_batch("ROLLBACK")?;
+        drop(blocker);
+        let retried = router
+            .clone()
+            .oneshot(error_request(INGEST_KEY, valid_error_body())?)
+            .await?;
+        assert_eq!(retried.status(), StatusCode::CREATED);
+
+        drop(router);
+        drop(state);
+        fs::remove_file(&path)?;
+        let _ = fs::remove_file(format!("{}-wal", path.display()));
+        let _ = fs::remove_file(format!("{}-shm", path.display()));
 
         Ok(())
     }

--- a/crates/canary-server/src/main.rs
+++ b/crates/canary-server/src/main.rs
@@ -4,7 +4,7 @@ use std::{error::Error, path::PathBuf, process};
 
 use canary_http::public::CANARY_VERSION;
 use canary_server::{CanaryServer, ServerProcessConfig, keygen};
-use canary_store::{CURRENT_SCHEMA_VERSION, Store, verify_database};
+use canary_store::{CURRENT_SCHEMA_VERSION, Store, vacuum_database, verify_database};
 use serde_json::json;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -46,6 +46,7 @@ fn run_operator_command(args: &[String]) -> Option<Result<(), Box<dyn Error>>> {
         Some("version" | "--version" | "-V") => Some(run_version(&args[1..])),
         Some("verify-data") => Some(run_verify_data(&args[1..], false)),
         Some("migrate") => Some(run_verify_data(&args[1..], true)),
+        Some("vacuum-database") => Some(run_vacuum_database(&args[1..])),
         // Recovery path for issuing a scoped API key directly against the
         // SQLite store when the one-time bootstrap key has been lost.
         Some("mint-key") => Some(run_mint_key(&args[1..])),
@@ -79,6 +80,26 @@ fn run_verify_data(args: &[String], migrate: bool) -> Result<(), Box<dyn Error>>
     if !evidence.verified() {
         return Err("database verification failed".into());
     }
+    Ok(())
+}
+
+fn run_vacuum_database(args: &[String]) -> Result<(), Box<dyn Error>> {
+    let database_path = parse_database_path(args)?;
+    let report = vacuum_database(&database_path)?;
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "schema": "canary.vacuum_database.v1",
+            "database": database_path,
+            "page_size": report.page_size,
+            "page_count_before": report.page_count_before,
+            "page_count_after": report.page_count_after,
+            "freelist_pages_before": report.freelist_pages_before,
+            "freelist_pages_after": report.freelist_pages_after,
+            "bytes_before": report.page_count_before.saturating_mul(report.page_size),
+            "bytes_after": report.page_count_after.saturating_mul(report.page_size),
+        }))?
+    );
     Ok(())
 }
 

--- a/crates/canary-server/src/metrics_routes.rs
+++ b/crates/canary-server/src/metrics_routes.rs
@@ -27,17 +27,19 @@ pub(crate) async fn metrics(
         return problem_response(*problem);
     }
 
-    let store = match state.lock_store() {
-        Ok(store) => store,
-        Err(_) => return problem_response(internal_problem()),
+    let snapshot = match tokio::task::spawn_blocking(move || {
+        let reader = state.read_source()?;
+        reader.metrics_snapshot().map_err(|error| error.to_string())
+    })
+    .await
+    {
+        Ok(Ok(snapshot)) => snapshot,
+        Ok(Err(_)) | Err(_) => return problem_response(internal_problem()),
     };
 
-    match store.metrics_snapshot() {
-        Ok(snapshot) => response(
-            StatusCode::OK.as_u16(),
-            PROMETHEUS_CONTENT_TYPE,
-            Body::from(canary_core::metrics::render_prometheus(&snapshot)),
-        ),
-        Err(_) => problem_response(internal_problem()),
-    }
+    response(
+        StatusCode::OK.as_u16(),
+        PROMETHEUS_CONTENT_TYPE,
+        Body::from(canary_core::metrics::render_prometheus(&snapshot)),
+    )
 }

--- a/crates/canary-server/src/read_source.rs
+++ b/crates/canary-server/src/read_source.rs
@@ -25,8 +25,8 @@ use parking_lot::MutexGuard;
 use canary_core::query::{ActiveClaimsResponse, ErrorDetail, ErrorsByClass, TimelineResponse};
 use canary_store::{
     ActiveClaimListOptions, ApiKeyRecord, ClaimResult, ErrorSummaryItem, HealthMonitorStatus,
-    HealthTargetStatus, QueryResult, Result, Store, TargetCheckRead, TimelineQueryOptions,
-    TimelineQueryResult,
+    HealthTargetStatus, MetricsSnapshot, QueryResult, Result, Store, TargetCheckRead,
+    TimelineQueryOptions, TimelineQueryResult,
 };
 use canary_store::{RecentTransition, SearchResult, ServiceSliSummary};
 
@@ -230,6 +230,13 @@ impl ReadSource<'_> {
         match self {
             Self::Pool(conn) => conn.active_claims(options),
             Self::Writer(store) => store.active_claims(options),
+        }
+    }
+
+    pub(crate) fn metrics_snapshot(&self) -> Result<MetricsSnapshot> {
+        match self {
+            Self::Pool(conn) => conn.metrics_snapshot(),
+            Self::Writer(store) => store.metrics_snapshot(),
         }
     }
 }

--- a/crates/canary-server/src/retention_prune.rs
+++ b/crates/canary-server/src/retention_prune.rs
@@ -48,8 +48,22 @@ pub struct RetentionPruneLifecycleReport {
     pub service_events_deleted: u64,
     /// Deleted target-check rows.
     pub target_checks_deleted: u64,
+    /// Deleted terminal webhook delivery ledger rows.
+    pub webhook_deliveries_deleted: u64,
+    /// Deleted monitor check-ins.
+    pub monitor_check_ins_deleted: u64,
+    /// Deleted annotations.
+    pub annotations_deleted: u64,
+    /// Deleted resolved incident signals.
+    pub incident_signals_deleted: u64,
+    /// Deleted terminal remediation claims.
+    pub remediation_claims_deleted: u64,
+    /// Deleted resolved incidents.
+    pub incidents_deleted: u64,
     /// Deleted terminal (`completed`/`discarded`) webhook-delivery job rows.
     pub oban_jobs_deleted: u64,
+    /// Free database pages returned by the bounded incremental vacuum.
+    pub pages_reclaimed: u64,
     /// Store delete statements executed.
     pub batches: u64,
     /// True when shutdown interrupted the pass after a completed batch.
@@ -108,7 +122,7 @@ impl RetentionPruneLifecycle {
         }
         report.interrupted = self.prune_table(
             RetentionPruneTable::TargetChecks,
-            plan.check_cutoff,
+            plan.check_cutoff.clone(),
             |deleted| report.target_checks_deleted += deleted,
             &mut report.batches,
             &should_stop,
@@ -116,11 +130,69 @@ impl RetentionPruneLifecycle {
         if report.interrupted {
             return Ok(report);
         }
-        // Terminal webhook-delivery job rows share the error/service-event
-        // cutoff; only `completed`/`discarded` states ever match (see
-        // canary-store::retention::RetentionPruneTable::ObanJobsTerminal), so
-        // claimed (`executing`) or pending (`available`/`scheduled`) work is
-        // never pruned. Footgun: "Webhook delivery jobs" in AGENTS.md.
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::WebhookDeliveriesTerminal,
+            plan.error_cutoff.clone(),
+            |deleted| report.webhook_deliveries_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::MonitorCheckIns,
+            plan.check_cutoff,
+            |deleted| report.monitor_check_ins_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::Annotations,
+            plan.error_cutoff.clone(),
+            |deleted| report.annotations_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::IncidentSignalsResolved,
+            plan.error_cutoff.clone(),
+            |deleted| report.incident_signals_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::RemediationClaimsTerminal,
+            plan.error_cutoff.clone(),
+            |deleted| report.remediation_claims_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        report.interrupted = self.prune_table(
+            RetentionPruneTable::IncidentsResolved,
+            plan.error_cutoff.clone(),
+            |deleted| report.incidents_deleted += deleted,
+            &mut report.batches,
+            &should_stop,
+        )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        // Terminal jobs share the error/service-event cutoff. Claimed
+        // (`executing`) or pending (`available`/`scheduled`) work never
+        // matches the store predicate.
         report.interrupted = self.prune_table(
             RetentionPruneTable::ObanJobsTerminal,
             plan.error_cutoff,
@@ -128,6 +200,16 @@ impl RetentionPruneLifecycle {
             &mut report.batches,
             &should_stop,
         )?;
+        if report.interrupted {
+            return Ok(report);
+        }
+        report.pages_reclaimed = {
+            let mut store = self.store.lock();
+            store
+                .reclaim_retention_storage()
+                .map_err(|error| error.to_string())?
+                .pages_reclaimed
+        };
 
         Ok(report)
     }
@@ -411,10 +493,13 @@ mod tests {
                 service_events_deleted: 1005,
                 target_checks_deleted: 0,
                 oban_jobs_deleted: 0,
-                batches: 6,
+                batches: 12,
+                pages_reclaimed: report.pages_reclaimed,
                 interrupted: false,
+                ..RetentionPruneLifecycleReport::default()
             }
         );
+        assert!(report.pages_reclaimed > 0);
 
         Ok(())
     }
@@ -495,6 +580,7 @@ mod tests {
                 oban_jobs_deleted: 0,
                 batches: 1,
                 interrupted: true,
+                ..RetentionPruneLifecycleReport::default()
             }
         );
 

--- a/crates/canary-server/src/server_auth.rs
+++ b/crates/canary-server/src/server_auth.rs
@@ -17,6 +17,7 @@ use canary_http::{
 use canary_store::{DurableRateLimitDecision, VerifiedApiKey};
 use serde_json::json;
 
+use crate::http_contract::storage_busy_problem;
 use crate::rate_limit::RateLimitDecision;
 use crate::server_time::current_unix_millis;
 use crate::{AuthFailIdentityConfig, IngestState};
@@ -326,20 +327,19 @@ fn enforce_rate_limit(
     let mut store = state
         .lock_store()
         .map_err(|_| Box::new(internal_problem()))?;
-    match store
-        .check_rate_limit(
-            rate_limit_kind_name(kind),
-            identity,
-            policy.limit,
-            policy.window_ms,
-            current_unix_millis(),
-        )
-        .map_err(|_| Box::new(internal_problem()))?
-    {
-        DurableRateLimitDecision::Allowed => Ok(()),
-        DurableRateLimitDecision::Limited {
+    match store.check_rate_limit(
+        rate_limit_kind_name(kind),
+        identity,
+        policy.limit,
+        policy.window_ms,
+        current_unix_millis(),
+    ) {
+        Ok(DurableRateLimitDecision::Allowed) => Ok(()),
+        Ok(DurableRateLimitDecision::Limited {
             retry_after_seconds,
-        } => Err(Box::new(rate_limited_problem(retry_after_seconds))),
+        }) => Err(Box::new(rate_limited_problem(retry_after_seconds))),
+        Err(error) if error.is_busy() => Err(Box::new(storage_busy_problem())),
+        Err(_) => Err(Box::new(internal_problem())),
     }
 }
 

--- a/crates/canary-store/Cargo.toml
+++ b/crates/canary-store/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 bcrypt = "0.17.1"
 canary-core = { path = "../canary-core" }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled", "hooks"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -74,7 +74,7 @@ pub use rate_limits::DurableRateLimitDecision;
 pub use read_pool::{ReadConnection, ReadPool};
 pub use retention::{
     RetentionPrune, RetentionPruneBatch, RetentionPruneBatchReport, RetentionPruneReport,
-    RetentionPruneTable,
+    RetentionPruneTable, StorageReclaimReport, VacuumDatabaseReport, vacuum_database,
 };
 pub use service_sli::{
     MIN_TRAJECTORY_SAMPLES, ServiceSliSummary, ServiceSliTrajectory, TrajectoryStatus,
@@ -113,6 +113,29 @@ pub enum StoreError {
     /// A service-onboarding target conflicts with an existing target row.
     #[error("target conflict")]
     TargetConflict(TargetConflict),
+}
+
+impl StoreError {
+    /// Whether SQLite rejected the operation because another connection holds
+    /// a conflicting lock. Callers may safely translate this transient class
+    /// to a retryable response instead of reporting an internal fault.
+    pub fn is_busy(&self) -> bool {
+        matches!(self, Self::Sqlite(error) if sqlite_error_is_busy(error))
+    }
+}
+
+/// Whether a SQLite error represents `SQLITE_BUSY` or `SQLITE_LOCKED`.
+pub fn sqlite_error_is_busy(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked,
+                ..
+            },
+            _
+        )
+    )
 }
 
 /// Canary's single writable SQLite connection.
@@ -1265,6 +1288,11 @@ impl Store {
         retention::prune_batch(&self.connection, batch)
     }
 
+    /// Reclaim a bounded number of free pages after a retention pass.
+    pub fn reclaim_retention_storage(&mut self) -> Result<StorageReclaimReport> {
+        retention::incremental_vacuum(&self.connection)
+    }
+
     /// Count persisted errors.
     pub fn error_count(&self) -> Result<u64> {
         let count = self
@@ -1300,6 +1328,17 @@ impl Store {
     }
 
     fn from_connection(connection: Connection) -> Result<Self> {
+        let has_application_tables = connection.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM sqlite_schema
+                WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+            )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )?;
+        if !has_application_tables {
+            connection.pragma_update(None, "auto_vacuum", "INCREMENTAL")?;
+        }
         connection.pragma_update(None, "foreign_keys", "ON")?;
         connection.pragma_update(None, "journal_mode", "WAL")?;
         connection.busy_timeout(std::time::Duration::from_secs(5))?;
@@ -5106,6 +5145,7 @@ mod tests {
                 errors_deleted: 1005,
                 service_events_deleted: 1,
                 target_checks_deleted: 1,
+                ..RetentionPruneReport::default()
             }
         );
         assert_eq!(row_count(&store.connection, "errors")?, 1);
@@ -5298,6 +5338,212 @@ mod tests {
             }
         );
         assert_eq!(row_count(&store.connection, "oban_jobs")?, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn retention_prune_covers_unbounded_tables_without_deleting_live_state()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut store = migrated_store()?;
+        store.connection.execute_batch(
+            r#"
+            INSERT INTO webhook_deliveries (
+              delivery_id, webhook_id, event, status, delivered_at, created_at, updated_at
+            ) VALUES
+              ('DLV-old', 'WH-test', 'incident.updated', 'delivered',
+               '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('DLV-recent', 'WH-test', 'incident.updated', 'delivered',
+               '2026-05-28T00:00:00Z', '2026-05-28T00:00:00Z', '2026-05-28T00:00:00Z'),
+              ('DLV-pending', 'WH-test', 'incident.updated', 'pending',
+               NULL, '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z');
+
+            INSERT INTO monitors (
+              id, name, service, mode, expected_every_ms, created_at
+            ) VALUES (
+              'MON-retention', 'retention', 'retention', 'check_in', 60000,
+              '2026-04-01T00:00:00Z'
+            );
+            INSERT INTO monitor_check_ins (
+              id, monitor_id, status, observed_at
+            ) VALUES
+              ('CHK-old', 'MON-retention', 'success', '2026-04-01T00:00:00Z'),
+              ('CHK-recent', 'MON-retention', 'success', '2026-05-28T00:00:00Z');
+
+            INSERT INTO incidents (
+              id, service, state, severity, opened_at, resolved_at
+            ) VALUES
+              ('INC-delete', 'retention', 'resolved', 'medium',
+               '2026-03-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('INC-protected', 'retention', 'resolved', 'medium',
+               '2026-03-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('INC-annotated', 'retention', 'resolved', 'medium',
+               '2026-03-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('INC-signaled', 'retention', 'resolved', 'medium',
+               '2026-03-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('INC-claimed', 'retention', 'resolved', 'medium',
+               '2026-03-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('INC-live', 'retention', 'investigating', 'medium',
+               '2026-03-01T00:00:00Z', NULL);
+            INSERT INTO incident_signals (
+              incident_id, signal_type, signal_ref, attached_at, resolved_at
+            ) VALUES
+              ('INC-protected', 'error_group', 'old-resolved',
+               '2026-03-01T00:00:00Z', '2026-04-01T00:00:00Z'),
+              ('INC-signaled', 'error_group', 'recent-resolved',
+               '2026-03-01T00:00:00Z', '2026-05-28T00:00:00Z'),
+              ('INC-live', 'error_group', 'live-unresolved',
+               '2026-03-01T00:00:00Z', NULL);
+
+            INSERT INTO annotations (
+              id, incident_id, agent, action, metadata, created_at, subject_type, subject_id
+            ) VALUES
+              ('ANN-old', 'INC-protected', 'retention', 'verified', '{}',
+               '2026-04-01T00:00:00Z', 'incident', 'INC-protected'),
+              ('ANN-recent', 'INC-protected', 'retention', 'verified', '{}',
+               '2026-05-28T00:00:00Z', 'incident', 'INC-protected'),
+              ('ANN-protect', 'INC-annotated', 'retention', 'verified', '{}',
+               '2026-05-28T00:00:00Z', 'incident', 'INC-annotated');
+
+            INSERT INTO remediation_claims (
+              id, subject_type, subject_id, owner, purpose, state,
+              idempotency_key, evidence_links, created_at, updated_at,
+              expires_at, completed_at
+            ) VALUES
+              ('CLM-terminal', 'incident', 'INC-delete', 'retention', 'done',
+               'verified', 'terminal', '[]', '2026-03-01T00:00:00Z',
+               '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z',
+               '2026-04-01T00:00:00Z'),
+              ('CLM-active', 'incident', 'INC-protected', 'retention', 'working',
+               'claimed', 'active', '[]', '2026-03-01T00:00:00Z',
+               '2026-04-01T00:00:00Z', '2027-04-01T00:00:00Z', NULL),
+              ('CLM-recent', 'incident', 'INC-claimed', 'retention', 'recent',
+               'verified', 'recent', '[]', '2026-03-01T00:00:00Z',
+               '2026-05-28T00:00:00Z', '2026-05-28T00:00:00Z',
+               '2026-05-28T00:00:00Z');
+            "#,
+        )?;
+
+        for (table, cutoff, expected_deleted) in [
+            (
+                RetentionPruneTable::WebhookDeliveriesTerminal,
+                "2026-05-01T00:00:00Z",
+                1,
+            ),
+            (
+                RetentionPruneTable::MonitorCheckIns,
+                "2026-05-22T00:00:00Z",
+                1,
+            ),
+            (RetentionPruneTable::Annotations, "2026-05-01T00:00:00Z", 1),
+            (
+                RetentionPruneTable::IncidentSignalsResolved,
+                "2026-05-01T00:00:00Z",
+                1,
+            ),
+            (
+                RetentionPruneTable::RemediationClaimsTerminal,
+                "2026-05-01T00:00:00Z",
+                1,
+            ),
+            (
+                RetentionPruneTable::IncidentsResolved,
+                "2026-05-01T00:00:00Z",
+                1,
+            ),
+        ] {
+            let report = store.prune_retention_batch(RetentionPruneBatch {
+                table,
+                cutoff: cutoff.to_owned(),
+            })?;
+            assert_eq!(report.deleted, expected_deleted, "{table:?}");
+            assert!(report.complete);
+        }
+
+        let exists = |table: &str, column: &str, id: &str| -> rusqlite::Result<bool> {
+            store.connection.query_row(
+                &format!("SELECT EXISTS(SELECT 1 FROM {table} WHERE {column} = ?1)"),
+                [id],
+                |row| row.get(0),
+            )
+        };
+        assert!(!exists("webhook_deliveries", "delivery_id", "DLV-old")?);
+        assert!(exists("webhook_deliveries", "delivery_id", "DLV-recent")?);
+        assert!(exists("webhook_deliveries", "delivery_id", "DLV-pending")?);
+        assert!(!exists("monitor_check_ins", "id", "CHK-old")?);
+        assert!(exists("monitor_check_ins", "id", "CHK-recent")?);
+        assert!(!exists("annotations", "id", "ANN-old")?);
+        assert!(exists("annotations", "id", "ANN-recent")?);
+        assert!(!exists("remediation_claims", "id", "CLM-terminal")?);
+        assert!(exists("remediation_claims", "id", "CLM-active")?);
+        assert!(!exists("incidents", "id", "INC-delete")?);
+        assert!(exists("incidents", "id", "INC-protected")?);
+        assert!(exists("incidents", "id", "INC-live")?);
+        assert!(exists("incidents", "id", "INC-annotated")?);
+        assert!(exists("incidents", "id", "INC-signaled")?);
+        assert!(exists("incidents", "id", "INC-claimed")?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn vacuum_database_reclaims_free_pages_and_keeps_incremental_mode()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "canary-store-vacuum-{}-{unique}.db",
+            std::process::id()
+        ));
+
+        {
+            let mut store = Store::open(&path)?;
+            store.migrate()?;
+            let auto_vacuum: u32 =
+                store
+                    .connection
+                    .pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
+            assert_eq!(auto_vacuum, 2, "new databases must use incremental vacuum");
+            store.connection.execute_batch(
+                r#"
+                WITH RECURSIVE sequence(value) AS (
+                  VALUES(1)
+                  UNION ALL
+                  SELECT value + 1 FROM sequence WHERE value < 4000
+                )
+                INSERT INTO service_events (
+                  id, service, event, entity_type, summary, payload, created_at
+                )
+                SELECT
+                  printf('EVT-vacuum-%d', value),
+                  'vacuum',
+                  'test.padding',
+                  'test',
+                  'vacuum test',
+                  json_object('padding', hex(zeroblob(1024))),
+                  '2026-04-01T00:00:00Z'
+                FROM sequence;
+                DELETE FROM service_events;
+                PRAGMA wal_checkpoint(TRUNCATE);
+                "#,
+            )?;
+        }
+
+        let report = vacuum_database(&path)?;
+        assert!(report.page_count_before > report.page_count_after);
+        assert!(report.freelist_pages_before > 0);
+        assert_eq!(report.freelist_pages_after, 0);
+
+        let connection = Connection::open(&path)?;
+        let auto_vacuum: u32 =
+            connection.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
+        assert_eq!(auto_vacuum, 2);
+        drop(connection);
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
 
         Ok(())
     }

--- a/crates/canary-store/src/metrics.rs
+++ b/crates/canary-store/src/metrics.rs
@@ -1,13 +1,28 @@
 //! Store-backed metrics snapshot queries.
 
+use std::time::{Duration, Instant};
+
 use canary_core::metrics::{HealthStateMetric, LabeledCount, MetricsSnapshot};
 use rusqlite::Connection;
 
 use crate::{Result, health};
 
 const HEALTH_STATES: [&str; 6] = ["unknown", "up", "degraded", "down", "paused", "flapping"];
+const METRICS_QUERY_BUDGET: Duration = Duration::from_millis(250);
+const PROGRESS_CALLBACK_OPS: i32 = 1_000;
 
 pub(crate) fn snapshot(connection: &Connection) -> Result<MetricsSnapshot> {
+    let deadline = Instant::now() + METRICS_QUERY_BUDGET;
+    connection.progress_handler(
+        PROGRESS_CALLBACK_OPS,
+        Some(move || Instant::now() >= deadline),
+    );
+    let result = snapshot_with_budget(connection);
+    connection.progress_handler(0, None::<fn() -> bool>);
+    result
+}
+
+fn snapshot_with_budget(connection: &Connection) -> Result<MetricsSnapshot> {
     Ok(MetricsSnapshot {
         errors_total: count_errors(connection)?,
         webhook_queue_depth: webhook_queue_depth(connection)?,

--- a/crates/canary-store/src/read_pool.rs
+++ b/crates/canary-store/src/read_pool.rs
@@ -53,8 +53,9 @@ use canary_core::query::{ErrorDetail, ErrorsByClass};
 use rusqlite::{Connection, OpenFlags};
 
 use crate::{
-    ApiKeyRecord, ErrorSummaryItem, HealthMonitorStatus, HealthTargetStatus, QueryResult, Result,
-    ServiceSliSummary, StoreError, TargetCheckRead, TimelineQueryOptions, TimelineQueryResult,
+    ApiKeyRecord, ErrorSummaryItem, HealthMonitorStatus, HealthTargetStatus, MetricsSnapshot,
+    QueryResult, Result, ServiceSliSummary, StoreError, TargetCheckRead, TimelineQueryOptions,
+    TimelineQueryResult,
 };
 use crate::{RecentTransition, SearchResult};
 use crate::{api_keys, health, query, service_sli};
@@ -332,6 +333,11 @@ impl ReadConnection {
         options: &crate::ActiveClaimListOptions,
     ) -> crate::ClaimResult<canary_core::query::ActiveClaimsResponse> {
         crate::claims::list_active(&self.connection, options)
+    }
+
+    /// Gather a point-in-time Prometheus metrics snapshot.
+    pub fn metrics_snapshot(&self) -> Result<MetricsSnapshot> {
+        crate::metrics::snapshot(&self.connection)
     }
 }
 

--- a/crates/canary-store/src/retention.rs
+++ b/crates/canary-store/src/retention.rs
@@ -1,6 +1,8 @@
 //! Retention prune persistence.
 
-use rusqlite::{Connection, params};
+use std::{path::Path, time::Duration};
+
+use rusqlite::{Connection, OpenFlags, params};
 
 use crate::Result;
 
@@ -15,6 +17,18 @@ pub enum RetentionPruneTable {
     ServiceEvents,
     /// Target check rows, keyed by `checked_at`.
     TargetChecks,
+    /// Terminal webhook delivery ledger rows.
+    WebhookDeliveriesTerminal,
+    /// Monitor check-ins, keyed by `observed_at`.
+    MonitorCheckIns,
+    /// Annotation audit rows, keyed by `created_at`.
+    Annotations,
+    /// Resolved incident signals, keyed by `resolved_at`.
+    IncidentSignalsResolved,
+    /// Terminal remediation claims.
+    RemediationClaimsTerminal,
+    /// Resolved incidents without an active remediation claim.
+    IncidentsResolved,
     /// Terminal (`completed`/`discarded`) webhook-delivery job rows, keyed by
     /// their terminal timestamp. Non-terminal rows (`available`, `scheduled`,
     /// `executing`) are never matched, so claimed work is never pruned.
@@ -39,6 +53,20 @@ pub struct RetentionPruneReport {
     pub service_events_deleted: u64,
     /// Deleted target-check rows.
     pub target_checks_deleted: u64,
+    /// Deleted terminal webhook delivery ledger rows.
+    pub webhook_deliveries_deleted: u64,
+    /// Deleted monitor check-ins.
+    pub monitor_check_ins_deleted: u64,
+    /// Deleted annotations.
+    pub annotations_deleted: u64,
+    /// Deleted resolved incident signals.
+    pub incident_signals_deleted: u64,
+    /// Deleted terminal remediation claims.
+    pub remediation_claims_deleted: u64,
+    /// Deleted resolved incidents.
+    pub incidents_deleted: u64,
+    /// Deleted terminal webhook delivery jobs.
+    pub oban_jobs_deleted: u64,
 }
 
 /// One bounded retention delete statement.
@@ -59,6 +87,32 @@ pub struct RetentionPruneBatchReport {
     pub complete: bool,
 }
 
+/// Page-level storage reclaimed by one bounded incremental vacuum.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StorageReclaimReport {
+    /// Pages on SQLite's freelist before the operation.
+    pub freelist_pages_before: u64,
+    /// Pages on SQLite's freelist after the operation.
+    pub freelist_pages_after: u64,
+    /// Pages returned to the filesystem.
+    pub pages_reclaimed: u64,
+}
+
+/// Evidence emitted by the offline full-vacuum operator command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VacuumDatabaseReport {
+    /// Database pages before compaction.
+    pub page_count_before: u64,
+    /// Database pages after compaction.
+    pub page_count_after: u64,
+    /// Free pages before compaction.
+    pub freelist_pages_before: u64,
+    /// Free pages after compaction.
+    pub freelist_pages_after: u64,
+    /// SQLite page size in bytes.
+    pub page_size: u64,
+}
+
 pub(crate) fn prune(
     connection: &mut Connection,
     prune: RetentionPrune,
@@ -74,6 +128,41 @@ pub(crate) fn prune(
             connection,
             RetentionPruneTable::TargetChecks,
             &prune.check_cutoff,
+        )?,
+        webhook_deliveries_deleted: prune_table(
+            connection,
+            RetentionPruneTable::WebhookDeliveriesTerminal,
+            &prune.error_cutoff,
+        )?,
+        monitor_check_ins_deleted: prune_table(
+            connection,
+            RetentionPruneTable::MonitorCheckIns,
+            &prune.check_cutoff,
+        )?,
+        annotations_deleted: prune_table(
+            connection,
+            RetentionPruneTable::Annotations,
+            &prune.error_cutoff,
+        )?,
+        incident_signals_deleted: prune_table(
+            connection,
+            RetentionPruneTable::IncidentSignalsResolved,
+            &prune.error_cutoff,
+        )?,
+        remediation_claims_deleted: prune_table(
+            connection,
+            RetentionPruneTable::RemediationClaimsTerminal,
+            &prune.error_cutoff,
+        )?,
+        incidents_deleted: prune_table(
+            connection,
+            RetentionPruneTable::IncidentsResolved,
+            &prune.error_cutoff,
+        )?,
+        oban_jobs_deleted: prune_table(
+            connection,
+            RetentionPruneTable::ObanJobsTerminal,
+            &prune.error_cutoff,
         )?,
     })
 }
@@ -97,6 +186,51 @@ pub(crate) fn prune_batch(
         deleted,
         complete: deleted < u64::from(BATCH_SIZE),
     })
+}
+
+/// Reclaim at most 1,000 free pages after a retention pass.
+pub(crate) fn incremental_vacuum(connection: &Connection) -> Result<StorageReclaimReport> {
+    let freelist_pages_before = pragma_u64(connection, "freelist_count")?;
+    connection.execute_batch("PRAGMA incremental_vacuum(1000)")?;
+    let freelist_pages_after = pragma_u64(connection, "freelist_count")?;
+    Ok(StorageReclaimReport {
+        freelist_pages_before,
+        freelist_pages_after,
+        pages_reclaimed: freelist_pages_before.saturating_sub(freelist_pages_after),
+    })
+}
+
+/// Compact one offline database and enable bounded incremental vacuuming for
+/// subsequent retention passes. The open flags refuse to create a database
+/// when the operator supplied the wrong path.
+pub fn vacuum_database(path: impl AsRef<Path>) -> Result<VacuumDatabaseReport> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    connection.pragma_update(None, "foreign_keys", "ON")?;
+    connection.pragma_update(None, "locking_mode", "EXCLUSIVE")?;
+    connection.execute_batch("BEGIN EXCLUSIVE; COMMIT")?;
+
+    let page_count_before = pragma_u64(&connection, "page_count")?;
+    let freelist_pages_before = pragma_u64(&connection, "freelist_count")?;
+    let page_size = pragma_u64(&connection, "page_size")?;
+
+    connection.pragma_update(None, "auto_vacuum", "INCREMENTAL")?;
+    connection.execute_batch("VACUUM; PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    Ok(VacuumDatabaseReport {
+        page_count_before,
+        page_count_after: pragma_u64(&connection, "page_count")?,
+        freelist_pages_before,
+        freelist_pages_after: pragma_u64(&connection, "freelist_count")?,
+        page_size,
+    })
+}
+
+fn pragma_u64(connection: &Connection, pragma: &str) -> Result<u64> {
+    Ok(connection.pragma_query_value(None, pragma, |row| row.get(0))?)
 }
 
 fn prune_table(connection: &Connection, table: RetentionPruneTable, cutoff: &str) -> Result<u64> {
@@ -125,6 +259,49 @@ fn table_predicate(table: RetentionPruneTable) -> (&'static str, &'static str) {
         RetentionPruneTable::Errors => ("errors", "created_at < ?1"),
         RetentionPruneTable::ServiceEvents => ("service_events", "created_at < ?1"),
         RetentionPruneTable::TargetChecks => ("target_checks", "checked_at < ?1"),
+        RetentionPruneTable::WebhookDeliveriesTerminal => (
+            "webhook_deliveries",
+            "((status = 'delivered' AND delivered_at < ?1)
+              OR (status = 'discarded' AND discarded_at < ?1)
+              OR (status = 'suppressed' AND updated_at < ?1))",
+        ),
+        RetentionPruneTable::MonitorCheckIns => ("monitor_check_ins", "observed_at < ?1"),
+        RetentionPruneTable::Annotations => ("annotations", "created_at < ?1"),
+        RetentionPruneTable::IncidentSignalsResolved => (
+            "incident_signals",
+            "resolved_at IS NOT NULL AND resolved_at < ?1",
+        ),
+        RetentionPruneTable::RemediationClaimsTerminal => (
+            "remediation_claims",
+            "state IN ('verified', 'dismissed', 'expired', 'released')
+              AND COALESCE(completed_at, released_at, updated_at) < ?1",
+        ),
+        RetentionPruneTable::IncidentsResolved => (
+            "incidents",
+            "state = 'resolved'
+              AND resolved_at IS NOT NULL
+              AND resolved_at < ?1
+              AND NOT EXISTS (
+                  SELECT 1 FROM remediation_claims
+                  WHERE tenant_id = incidents.tenant_id
+                    AND project_id = incidents.project_id
+                    AND subject_type = 'incident'
+                    AND subject_id = incidents.id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM annotations
+                  WHERE (
+                      incident_id = incidents.id
+                      OR (subject_type = 'incident' AND subject_id = incidents.id)
+                    )
+                    AND created_at >= ?1
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM incident_signals
+                  WHERE incident_id = incidents.id
+                    AND (resolved_at IS NULL OR resolved_at >= ?1)
+              )",
+        ),
         // Only terminal states are eligible. `available`/`scheduled`/`executing`
         // rows never match this predicate regardless of cutoff. `cancelled` is
         // a legacy Elixir-era state the Rust write path never produces, but

--- a/crates/canary-store/src/schema.rs
+++ b/crates/canary-store/src/schema.rs
@@ -5,7 +5,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use rusqlite::Connection;
 
 /// Current Rust schema version.
-pub const SCHEMA_VERSION: u32 = 2026071400;
+pub const SCHEMA_VERSION: u32 = 2026071700;
+const PREVIOUS_SCHEMA_VERSION: u32 = 2026071400;
 
 pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
     let user_version =
@@ -14,6 +15,16 @@ pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
         let transaction = connection.transaction()?;
         ensure_current_fts_objects(&transaction)?;
         validate_schema_columns(&transaction)?;
+        transaction.commit()?;
+        return Ok(());
+    }
+
+    if user_version == PREVIOUS_SCHEMA_VERSION {
+        let transaction = connection.transaction()?;
+        ensure_current_fts_objects(&transaction)?;
+        create_retention_cutoff_indexes(&transaction)?;
+        validate_schema_columns(&transaction)?;
+        transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
         transaction.commit()?;
         return Ok(());
     }
@@ -30,6 +41,7 @@ pub(crate) fn migrate(connection: &mut Connection) -> rusqlite::Result<()> {
     scope_monitor_name_index(&transaction)?;
     scope_incident_open_service_index(&transaction)?;
     scope_oban_jobs_claim_index(&transaction)?;
+    create_retention_cutoff_indexes(&transaction)?;
     validate_schema_columns(&transaction)?;
     transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
     transaction.commit()?;
@@ -288,7 +300,11 @@ fn index_columns(connection: &Connection, index_name: &str) -> rusqlite::Result<
     let escaped_index = index_name.replace('"', "\"\"");
     let mut statement = connection.prepare(&format!("PRAGMA index_info(\"{escaped_index}\")"))?;
     statement
-        .query_map([], |row| row.get::<_, String>(2))?
+        .query_map([], |row| {
+            Ok(row
+                .get::<_, Option<String>>(2)?
+                .unwrap_or_else(|| "<expression>".to_owned()))
+        })?
         .collect()
 }
 
@@ -363,6 +379,72 @@ fn scope_oban_jobs_claim_index(connection: &Connection) -> rusqlite::Result<()> 
         [],
     )?;
     Ok(())
+}
+
+/// Cutoff-leading and terminal-state indexes used by bounded retention batches.
+///
+/// These are isolated from historical column backfills so an install already
+/// at the immediately previous schema version can add only the new indexes
+/// instead of replaying every legacy migration.
+fn create_retention_cutoff_indexes(connection: &Connection) -> rusqlite::Result<()> {
+    connection.execute_batch(
+        r#"
+        CREATE INDEX IF NOT EXISTS errors_created_at_index
+        ON errors(created_at);
+
+        CREATE INDEX IF NOT EXISTS target_checks_checked_at_index
+        ON target_checks(checked_at);
+
+        CREATE INDEX IF NOT EXISTS webhook_deliveries_delivered_at_index
+        ON webhook_deliveries(delivered_at)
+        WHERE status = 'delivered';
+
+        CREATE INDEX IF NOT EXISTS webhook_deliveries_discarded_at_index
+        ON webhook_deliveries(discarded_at)
+        WHERE status = 'discarded';
+
+        CREATE INDEX IF NOT EXISTS webhook_deliveries_suppressed_updated_at_index
+        ON webhook_deliveries(updated_at)
+        WHERE status = 'suppressed';
+
+        CREATE INDEX IF NOT EXISTS monitor_check_ins_observed_at_index
+        ON monitor_check_ins(observed_at);
+
+        CREATE INDEX IF NOT EXISTS annotations_created_at_index
+        ON annotations(created_at);
+
+        CREATE INDEX IF NOT EXISTS annotations_incident_id_created_at_index
+        ON annotations(incident_id, created_at);
+
+        CREATE INDEX IF NOT EXISTS incident_signals_resolved_at_index
+        ON incident_signals(resolved_at)
+        WHERE resolved_at IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS incidents_resolved_at_index
+        ON incidents(resolved_at)
+        WHERE state = 'resolved' AND resolved_at IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS remediation_claims_terminal_timestamp_index
+        ON remediation_claims(COALESCE(completed_at, released_at, updated_at))
+        WHERE state IN ('verified', 'dismissed', 'expired', 'released');
+
+        CREATE INDEX IF NOT EXISTS oban_jobs_completed_at_index
+        ON oban_jobs(completed_at)
+        WHERE state = 'completed';
+
+        CREATE INDEX IF NOT EXISTS oban_jobs_discarded_at_index
+        ON oban_jobs(discarded_at)
+        WHERE state = 'discarded';
+
+        CREATE INDEX IF NOT EXISTS oban_jobs_cancelled_at_index
+        ON oban_jobs(cancelled_at)
+        WHERE state = 'cancelled';
+
+        CREATE INDEX IF NOT EXISTS oban_jobs_active_queue_metrics_index
+        ON oban_jobs(queue, state)
+        WHERE state IN ('available', 'scheduled', 'executing');
+        "#,
+    )
 }
 
 fn backfill_service_scope_columns(connection: &Connection) -> rusqlite::Result<()> {
@@ -995,3 +1077,52 @@ CREATE TABLE IF NOT EXISTS monitor_check_ins (
 CREATE INDEX IF NOT EXISTS monitor_check_ins_monitor_id_observed_at_index
 ON monitor_check_ins(monitor_id, observed_at);
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_from_previous_schema_adds_retention_indexes() -> rusqlite::Result<()> {
+        let retention_indexes = [
+            "errors_created_at_index",
+            "target_checks_checked_at_index",
+            "webhook_deliveries_delivered_at_index",
+            "webhook_deliveries_discarded_at_index",
+            "webhook_deliveries_suppressed_updated_at_index",
+            "monitor_check_ins_observed_at_index",
+            "annotations_created_at_index",
+            "annotations_incident_id_created_at_index",
+            "incident_signals_resolved_at_index",
+            "incidents_resolved_at_index",
+            "remediation_claims_terminal_timestamp_index",
+            "oban_jobs_completed_at_index",
+            "oban_jobs_discarded_at_index",
+            "oban_jobs_cancelled_at_index",
+            "oban_jobs_active_queue_metrics_index",
+        ];
+        let mut connection = Connection::open_in_memory()?;
+        migrate(&mut connection)?;
+        for index in retention_indexes {
+            connection.execute(&format!("DROP INDEX {index}"), [])?;
+        }
+        connection.pragma_update(None, "user_version", PREVIOUS_SCHEMA_VERSION)?;
+
+        migrate(&mut connection)?;
+
+        let user_version: u32 =
+            connection.pragma_query_value(None, "user_version", |row| row.get(0))?;
+        assert_eq!(user_version, SCHEMA_VERSION);
+        for index in retention_indexes {
+            let exists: bool = connection.query_row(
+                "SELECT EXISTS (
+                   SELECT 1 FROM sqlite_schema WHERE type = 'index' AND name = ?1
+                 )",
+                [index],
+                |row| row.get(0),
+            )?;
+            assert!(exists, "missing retention index {index}");
+        }
+        Ok(())
+    }
+}

--- a/crates/canary-store/tests/legacy_fixture_compat.rs
+++ b/crates/canary-store/tests/legacy_fixture_compat.rs
@@ -24,7 +24,7 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 const LEGACY_FIXTURE: &str = "tests/fixtures/legacy_schema.db";
 const POPULATED_LEGACY_FIXTURE: &str = "tests/fixtures/legacy_read_models.db";
-const RUST_SCHEMA_VERSION: u32 = 2026071400;
+const RUST_SCHEMA_VERSION: u32 = canary_store::CURRENT_SCHEMA_VERSION;
 
 const LEGACY_MIGRATIONS: &[&str] = &[
     "20260314000001",

--- a/docs/portable-runtime-contract.md
+++ b/docs/portable-runtime-contract.md
@@ -103,6 +103,33 @@ evidence used by the recovery drill. A manifest sets
 explicit previous-image compatibility proof. Otherwise recovery requires a
 verified database restore; the deployer owns the decision and policy.
 
+## Storage maintenance
+
+The runtime retention worker prunes old rows in 1,000-row transactions and
+performs a bounded incremental vacuum after each pass. The default policy keeps
+errors, events, annotations, resolved incident history, terminal claims,
+terminal delivery history, and terminal jobs for 30 days; target checks and
+monitor check-ins use a 7-day window. Active incidents, active claims, pending
+deliveries, and runnable jobs are never eligible.
+
+Incremental vacuum prevents new free-page growth from remaining unbounded. It
+does not compact free pages left by deployments created before incremental
+vacuum was enabled. Reclaim that historical space with the image-owned offline
+command:
+
+```bash
+canary-server vacuum-database --database "$CANARY_DB_PATH"
+```
+
+Stop the Canary server and Litestream replication process before running the
+command against the mounted database. The command refuses a missing path,
+acquires an exclusive SQLite lock, enables incremental auto-vacuum, runs one
+full `VACUUM`, checkpoints the WAL, and emits a
+`canary.vacuum_database.v1` JSON receipt with before/after page and byte
+counts. Keep a verified backup and free disk capacity comparable to the
+database size, then restart the normal runtime and prove `/healthz`, `/readyz`,
+and replication status.
+
 ## Backup and restore
 
 Canary supports Litestream replication to generic S3-compatible object


### PR DESCRIPTION
## Summary
- extend bounded retention to terminal deliveries, monitor check-ins, annotations, resolved incident history, terminal claims, and terminal Oban jobs, with safe dependency guards and cutoff indexes
- enable incremental auto-vacuum for new databases, reclaim a bounded page budget after retention, and add an explicit offline `vacuum-database` command with a JSON receipt
- map SQLite BUSY/LOCKED writes to RFC 9457 `503 unavailable` plus `Retry-After: 5`
- move Prometheus aggregation to the read pool on `spawn_blocking`, with a 250ms SQLite progress budget

## Evidence
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- focused retention, migration, vacuum, contention/recovery, metrics-isolation, and lifecycle tests
- real CLI migrate + vacuum smoke; post-vacuum `PRAGMA integrity_check` = `ok`
- independent Scully verification: PASS on all four contracted surfaces
- independent adversarial review: correct, confidence 0.92, no material findings
- `bin/validate --fast`
- repo pre-push/full Dagger gate via `git push`

Powder: `canary-955`