### PR TITLE
fix(health): resolve incidents on surface deletion

### DIFF
--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -2128,9 +2128,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2217,9 +2217,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2237,7 +2237,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/crates/canary-store/src/health.rs
+++ b/crates/canary-store/src/health.rs
@@ -1015,9 +1015,25 @@ fn resolve_deleted_health_signal(
     Ok(())
 }
 
-fn delete_monitor_with_scope(
+#[derive(Clone, Copy)]
+enum HealthSurfaceKind {
+    Monitor,
+    Target,
+}
+
+impl HealthSurfaceKind {
+    const fn table(self) -> &'static str {
+        match self {
+            Self::Monitor => "monitors",
+            Self::Target => "targets",
+        }
+    }
+}
+
+fn delete_health_surface(
     connection: &mut rusqlite::Connection,
-    monitor_id: &str,
+    kind: HealthSurfaceKind,
+    surface_id: &str,
     owner_filter: Option<(&str, &str)>,
 ) -> Result<bool> {
     let transaction = connection.transaction()?;
@@ -1026,11 +1042,14 @@ fn delete_monitor_with_scope(
         .unwrap_or((None, None));
     let owner = transaction
         .query_row(
-            "DELETE FROM monitors
-             WHERE id = ?1
-               AND (?2 IS NULL OR (tenant_id = ?2 AND project_id = ?3))
-             RETURNING tenant_id, project_id, COALESCE(NULLIF(service, ''), name)",
-            params![monitor_id, tenant_id, project_id],
+            &format!(
+                "DELETE FROM {table}
+                 WHERE id = ?1
+                   AND (?2 IS NULL OR (tenant_id = ?2 AND project_id = ?3))
+                 RETURNING tenant_id, project_id, COALESCE(NULLIF(service, ''), name)",
+                table = kind.table(),
+            ),
+            params![surface_id, tenant_id, project_id],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -1044,7 +1063,17 @@ fn delete_monitor_with_scope(
         transaction.commit()?;
         return Ok(false);
     };
-    resolve_deleted_health_signal(&transaction, monitor_id, owner)?;
+    if matches!(kind, HealthSurfaceKind::Target) {
+        transaction.execute(
+            "DELETE FROM target_state WHERE target_id = ?1",
+            [surface_id],
+        )?;
+        transaction.execute(
+            "DELETE FROM target_checks WHERE target_id = ?1",
+            [surface_id],
+        )?;
+    }
+    resolve_deleted_health_signal(&transaction, surface_id, owner)?;
     transaction.commit()?;
     Ok(true)
 }
@@ -1053,7 +1082,7 @@ pub(crate) fn delete_monitor(
     connection: &mut rusqlite::Connection,
     monitor_id: &str,
 ) -> Result<bool> {
-    delete_monitor_with_scope(connection, monitor_id, None)
+    delete_health_surface(connection, HealthSurfaceKind::Monitor, monitor_id, None)
 }
 
 pub(crate) fn delete_monitor_scoped(
@@ -1062,7 +1091,12 @@ pub(crate) fn delete_monitor_scoped(
     tenant_id: &str,
     project_id: &str,
 ) -> Result<bool> {
-    delete_monitor_with_scope(connection, monitor_id, Some((tenant_id, project_id)))
+    delete_health_surface(
+        connection,
+        HealthSurfaceKind::Monitor,
+        monitor_id,
+        Some((tenant_id, project_id)),
+    )
 }
 
 pub(crate) fn insert_target(connection: &rusqlite::Connection, target: TargetInsert) -> Result<()> {
@@ -1379,50 +1413,11 @@ fn target_check_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TargetCheckRead
     })
 }
 
-fn delete_target_with_scope(
-    connection: &mut rusqlite::Connection,
-    target_id: &str,
-    owner_filter: Option<(&str, &str)>,
-) -> Result<bool> {
-    let transaction = connection.transaction()?;
-    let (tenant_id, project_id) = owner_filter
-        .map(|(tenant_id, project_id)| (Some(tenant_id), Some(project_id)))
-        .unwrap_or((None, None));
-    let owner = transaction
-        .query_row(
-            "DELETE FROM targets
-             WHERE id = ?1
-               AND (?2 IS NULL OR (tenant_id = ?2 AND project_id = ?3))
-             RETURNING tenant_id, project_id, COALESCE(NULLIF(service, ''), name)",
-            params![target_id, tenant_id, project_id],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                ))
-            },
-        )
-        .optional()?;
-    let Some(owner) = owner else {
-        transaction.commit()?;
-        return Ok(false);
-    };
-    transaction.execute("DELETE FROM target_state WHERE target_id = ?1", [target_id])?;
-    transaction.execute(
-        "DELETE FROM target_checks WHERE target_id = ?1",
-        [target_id],
-    )?;
-    resolve_deleted_health_signal(&transaction, target_id, owner)?;
-    transaction.commit()?;
-    Ok(true)
-}
-
 pub(crate) fn delete_target(
     connection: &mut rusqlite::Connection,
     target_id: &str,
 ) -> Result<bool> {
-    delete_target_with_scope(connection, target_id, None)
+    delete_health_surface(connection, HealthSurfaceKind::Target, target_id, None)
 }
 
 pub(crate) fn delete_target_scoped(
@@ -1431,7 +1426,12 @@ pub(crate) fn delete_target_scoped(
     tenant_id: &str,
     project_id: &str,
 ) -> Result<bool> {
-    delete_target_with_scope(connection, target_id, Some((tenant_id, project_id)))
+    delete_health_surface(
+        connection,
+        HealthSurfaceKind::Target,
+        target_id,
+        Some((tenant_id, project_id)),
+    )
 }
 
 pub(crate) fn update_target_active(

--- a/crates/canary-store/src/health.rs
+++ b/crates/canary-store/src/health.rs
@@ -990,14 +990,70 @@ fn health_monitors_where(
     Ok(rows)
 }
 
+fn resolve_deleted_health_signal(
+    transaction: &rusqlite::Transaction<'_>,
+    signal_ref: &str,
+    owner: (String, String, String),
+) -> Result<()> {
+    let (tenant_id, project_id, service) = owner;
+    let now = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let _ = correlate_in_transaction(
+        transaction,
+        IncidentCorrelation {
+            tenant_id,
+            project_id,
+            signal_type: "health_transition".to_owned(),
+            signal_ref: signal_ref.to_owned(),
+            service,
+            incident_id: IncidentId::generate(),
+            event_id: EventId::generate(),
+            now,
+        },
+    )?;
+    Ok(())
+}
+
+fn delete_monitor_with_scope(
+    connection: &mut rusqlite::Connection,
+    monitor_id: &str,
+    owner_filter: Option<(&str, &str)>,
+) -> Result<bool> {
+    let transaction = connection.transaction()?;
+    let (tenant_id, project_id) = owner_filter
+        .map(|(tenant_id, project_id)| (Some(tenant_id), Some(project_id)))
+        .unwrap_or((None, None));
+    let owner = transaction
+        .query_row(
+            "DELETE FROM monitors
+             WHERE id = ?1
+               AND (?2 IS NULL OR (tenant_id = ?2 AND project_id = ?3))
+             RETURNING tenant_id, project_id, COALESCE(NULLIF(service, ''), name)",
+            params![monitor_id, tenant_id, project_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some(owner) = owner else {
+        transaction.commit()?;
+        return Ok(false);
+    };
+    resolve_deleted_health_signal(&transaction, monitor_id, owner)?;
+    transaction.commit()?;
+    Ok(true)
+}
+
 pub(crate) fn delete_monitor(
     connection: &mut rusqlite::Connection,
     monitor_id: &str,
 ) -> Result<bool> {
-    let transaction = connection.transaction()?;
-    let changed = transaction.execute("DELETE FROM monitors WHERE id = ?1", [monitor_id])?;
-    transaction.commit()?;
-    Ok(changed > 0)
+    delete_monitor_with_scope(connection, monitor_id, None)
 }
 
 pub(crate) fn delete_monitor_scoped(
@@ -1006,13 +1062,7 @@ pub(crate) fn delete_monitor_scoped(
     tenant_id: &str,
     project_id: &str,
 ) -> Result<bool> {
-    let transaction = connection.transaction()?;
-    let changed = transaction.execute(
-        "DELETE FROM monitors WHERE id = ?1 AND tenant_id = ?2 AND project_id = ?3",
-        params![monitor_id, tenant_id, project_id],
-    )?;
-    transaction.commit()?;
-    Ok(changed > 0)
+    delete_monitor_with_scope(connection, monitor_id, Some((tenant_id, project_id)))
 }
 
 pub(crate) fn insert_target(connection: &rusqlite::Connection, target: TargetInsert) -> Result<()> {
@@ -1329,21 +1379,50 @@ fn target_check_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TargetCheckRead
     })
 }
 
+fn delete_target_with_scope(
+    connection: &mut rusqlite::Connection,
+    target_id: &str,
+    owner_filter: Option<(&str, &str)>,
+) -> Result<bool> {
+    let transaction = connection.transaction()?;
+    let (tenant_id, project_id) = owner_filter
+        .map(|(tenant_id, project_id)| (Some(tenant_id), Some(project_id)))
+        .unwrap_or((None, None));
+    let owner = transaction
+        .query_row(
+            "DELETE FROM targets
+             WHERE id = ?1
+               AND (?2 IS NULL OR (tenant_id = ?2 AND project_id = ?3))
+             RETURNING tenant_id, project_id, COALESCE(NULLIF(service, ''), name)",
+            params![target_id, tenant_id, project_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some(owner) = owner else {
+        transaction.commit()?;
+        return Ok(false);
+    };
+    transaction.execute("DELETE FROM target_state WHERE target_id = ?1", [target_id])?;
+    transaction.execute(
+        "DELETE FROM target_checks WHERE target_id = ?1",
+        [target_id],
+    )?;
+    resolve_deleted_health_signal(&transaction, target_id, owner)?;
+    transaction.commit()?;
+    Ok(true)
+}
+
 pub(crate) fn delete_target(
     connection: &mut rusqlite::Connection,
     target_id: &str,
 ) -> Result<bool> {
-    let transaction = connection.transaction()?;
-    let changed = transaction.execute("DELETE FROM targets WHERE id = ?1", [target_id])?;
-    if changed > 0 {
-        transaction.execute("DELETE FROM target_state WHERE target_id = ?1", [target_id])?;
-        transaction.execute(
-            "DELETE FROM target_checks WHERE target_id = ?1",
-            [target_id],
-        )?;
-    }
-    transaction.commit()?;
-    Ok(changed > 0)
+    delete_target_with_scope(connection, target_id, None)
 }
 
 pub(crate) fn delete_target_scoped(
@@ -1352,20 +1431,7 @@ pub(crate) fn delete_target_scoped(
     tenant_id: &str,
     project_id: &str,
 ) -> Result<bool> {
-    let transaction = connection.transaction()?;
-    let changed = transaction.execute(
-        "DELETE FROM targets WHERE id = ?1 AND tenant_id = ?2 AND project_id = ?3",
-        params![target_id, tenant_id, project_id],
-    )?;
-    if changed > 0 {
-        transaction.execute("DELETE FROM target_state WHERE target_id = ?1", [target_id])?;
-        transaction.execute(
-            "DELETE FROM target_checks WHERE target_id = ?1",
-            [target_id],
-        )?;
-    }
-    transaction.commit()?;
-    Ok(changed > 0)
+    delete_target_with_scope(connection, target_id, Some((tenant_id, project_id)))
 }
 
 pub(crate) fn update_target_active(

--- a/crates/canary-store/src/lib.rs
+++ b/crates/canary-store/src/lib.rs
@@ -7076,6 +7076,175 @@ mod tests {
     }
 
     #[test]
+    fn deleting_down_targets_resolves_all_delete_paths() -> Result<()> {
+        let mut store = migrated_store()?;
+        for (id, incident, service, extra, scoped, expected_state, expected_event) in [
+            (
+                "TGT-delete-target-unscoped",
+                "INC-delete-target-unscoped",
+                "delete-target-unscoped",
+                None,
+                false,
+                "resolved",
+                "incident.resolved",
+            ),
+            (
+                "TGT-delete-target-scoped",
+                "INC-delete-target-scoped",
+                "delete-target-scoped",
+                Some("TGT-delete-target-other"),
+                true,
+                "investigating",
+                "incident.updated",
+            ),
+        ] {
+            seed_target_delete_fixture(&mut store, id, incident, service, extra)?;
+            let before = incident_events(&store, incident)?;
+            if scoped {
+                assert!(!store.delete_target_scoped(id, BOOTSTRAP_TENANT_ID, "PROJECT-wrong")?);
+                assert_eq!(incident_events(&store, incident)?, before);
+                assert!(!store.delete_target_scoped(id, "TENANT-wrong", BOOTSTRAP_PROJECT_ID)?);
+                assert_eq!(incident_events(&store, incident)?, before);
+                assert!(store.delete_target_scoped(
+                    id,
+                    BOOTSTRAP_TENANT_ID,
+                    BOOTSTRAP_PROJECT_ID
+                )?);
+            } else {
+                assert!(store.delete_target(id)?);
+            }
+            for (table, column) in [
+                ("targets", "id"),
+                ("target_state", "target_id"),
+                ("target_checks", "target_id"),
+            ] {
+                assert_eq!(count_for(&store, table, column, id)?, 0);
+            }
+            let row = incident_row(&store, incident)?;
+            assert_eq!(row.1, expected_state);
+            assert_eq!(row.3.is_some(), expected_state == "resolved");
+            assert_eq!(signal_count(&store, incident, "health_transition", id)?, 1);
+            assert_eq!(
+                active_signal_count(&store, incident)?,
+                if extra.is_some() { 1 } else { 0 }
+            );
+            let events = incident_events(&store, incident)?;
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].1, expected_event);
+            assert_eq!(events[0].2, service);
+            assert!(events[0].3.contains(incident));
+            let repeat = if scoped {
+                store.delete_target_scoped(id, BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)?
+            } else {
+                store.delete_target(id)?
+            };
+            assert!(!repeat);
+            assert_eq!(incident_events(&store, incident)?, events);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn deleting_down_monitors_resolves_all_delete_paths_with_name_fallback() -> Result<()> {
+        let mut store = migrated_store()?;
+        for (id, name, incident, scoped) in [
+            (
+                "MON-delete-monitor-unscoped",
+                "delete-monitor-unscoped",
+                "INC-delete-monitor-unscoped",
+                false,
+            ),
+            (
+                "MON-delete-monitor-scoped",
+                "delete-monitor-scoped",
+                "INC-delete-monitor-scoped",
+                true,
+            ),
+        ] {
+            seed_monitor_delete_fixture(&mut store, id, name, incident)?;
+            let before = incident_events(&store, incident)?;
+            if scoped {
+                assert!(!store.delete_monitor_scoped(id, BOOTSTRAP_TENANT_ID, "PROJECT-wrong")?);
+                assert_eq!(incident_events(&store, incident)?, before);
+                assert!(!store.delete_monitor_scoped(id, "TENANT-wrong", BOOTSTRAP_PROJECT_ID)?);
+                assert_eq!(incident_events(&store, incident)?, before);
+                assert!(store.delete_monitor_scoped(
+                    id,
+                    BOOTSTRAP_TENANT_ID,
+                    BOOTSTRAP_PROJECT_ID
+                )?);
+            } else {
+                assert!(store.delete_monitor(id)?);
+            }
+            for (table, column) in [("monitors", "id"), ("monitor_state", "monitor_id")] {
+                assert_eq!(count_for(&store, table, column, id)?, 0);
+            }
+            let row = incident_row(&store, incident)?;
+            assert_eq!(row.0, name);
+            assert_eq!(row.1, "resolved");
+            assert!(row.3.is_some());
+            assert_eq!(active_signal_count(&store, incident)?, 0);
+            let events = incident_events(&store, incident)?;
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].1, "incident.resolved");
+            assert_eq!(events[0].2, name);
+            assert!(events[0].3.contains(incident));
+            let repeat = if scoped {
+                store.delete_monitor_scoped(id, BOOTSTRAP_TENANT_ID, BOOTSTRAP_PROJECT_ID)?
+            } else {
+                store.delete_monitor(id)?
+            };
+            assert!(!repeat);
+            assert_eq!(incident_events(&store, incident)?, events);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn deleting_down_target_rolls_back_when_incident_event_insert_fails() -> Result<()> {
+        let mut store = migrated_store()?;
+        seed_target_delete_fixture(
+            &mut store,
+            "TGT-delete-target-rollback",
+            "INC-delete-target-rollback",
+            "delete-target-rollback",
+            None,
+        )?;
+        let before = incident_events(&store, "INC-delete-target-rollback")?;
+        store.connection.execute_batch(
+            "CREATE TRIGGER reject_incident_resolution
+             BEFORE INSERT ON service_events
+             WHEN NEW.event = 'incident.resolved'
+             BEGIN
+               SELECT RAISE(ABORT, 'incident resolution blocked');
+             END;",
+        )?;
+        assert!(store.delete_target("TGT-delete-target-rollback").is_err());
+        for (table, column) in [
+            ("targets", "id"),
+            ("target_state", "target_id"),
+            ("target_checks", "target_id"),
+        ] {
+            assert_eq!(
+                count_for(&store, table, column, "TGT-delete-target-rollback")?,
+                1
+            );
+        }
+        let row = incident_row(&store, "INC-delete-target-rollback")?;
+        assert_eq!(row.1, "investigating");
+        assert!(row.3.is_none());
+        assert_eq!(
+            active_signal_count(&store, "INC-delete-target-rollback")?,
+            1
+        );
+        assert_eq!(
+            incident_events(&store, "INC-delete-target-rollback")?,
+            before
+        );
+        Ok(())
+    }
+
+    #[test]
     fn target_health_transition_updates_state_timeline_and_incident_in_one_commit()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut store = migrated_store()?;
@@ -8226,6 +8395,124 @@ mod tests {
             active: true,
             created_at: "2026-05-28T19:00:00Z".to_owned(),
         })
+    }
+
+    const DELETE_AT: &str = "2026-05-28T20:00:00Z";
+
+    fn seed_target_delete_fixture(
+        store: &mut Store,
+        target_id: &str,
+        incident_id: &str,
+        service: &str,
+        extra_signal_ref: Option<&str>,
+    ) -> Result<()> {
+        store.insert_target(TargetInsert {
+            id: target_id.to_owned(),
+            url: format!("https://{target_id}.example.test/health"),
+            name: target_id.to_owned(),
+            service: service.to_owned(),
+            method: "GET".to_owned(),
+            headers: None,
+            interval_ms: 60_000,
+            timeout_ms: 10_000,
+            expected_status: "200".to_owned(),
+            body_contains: None,
+            degraded_after: 1,
+            down_after: 1,
+            up_after: 1,
+            active: true,
+            created_at: "2026-05-28T19:00:00Z".to_owned(),
+        })?;
+        store.connection.execute(
+            "INSERT INTO target_state (target_id, state, consecutive_failures)
+             VALUES (?1, 'down', 3)",
+            [target_id],
+        )?;
+        store.connection.execute(
+            "INSERT INTO target_checks (target_id, checked_at, result)
+             VALUES (?1, ?2, 'error')",
+            params![target_id, DELETE_AT],
+        )?;
+        insert_incident(store, incident_id, service, DELETE_AT)?;
+        insert_incident_signal(
+            store,
+            incident_id,
+            "health_transition",
+            target_id,
+            DELETE_AT,
+            None,
+        )?;
+        if let Some(extra) = extra_signal_ref {
+            store.connection.execute(
+                "INSERT INTO target_state (target_id, state) VALUES (?1, 'down')",
+                [extra],
+            )?;
+            insert_incident_signal(
+                store,
+                incident_id,
+                "health_transition",
+                extra,
+                DELETE_AT,
+                None,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn seed_monitor_delete_fixture(
+        store: &mut Store,
+        monitor_id: &str,
+        name: &str,
+        incident_id: &str,
+    ) -> Result<()> {
+        store.insert_monitor(MonitorInsert {
+            id: monitor_id.to_owned(),
+            name: name.to_owned(),
+            service: String::new(),
+            mode: "ttl".to_owned(),
+            expected_every_ms: 60_000,
+            grace_ms: 5_000,
+            created_at: "2026-05-28T19:00:00Z".to_owned(),
+        })?;
+        store.connection.execute(
+            "INSERT INTO monitor_state (monitor_id, state) VALUES (?1, 'down')",
+            [monitor_id],
+        )?;
+        insert_incident(store, incident_id, name, DELETE_AT)?;
+        insert_incident_signal(
+            store,
+            incident_id,
+            "health_transition",
+            monitor_id,
+            DELETE_AT,
+            None,
+        )?;
+        Ok(())
+    }
+
+    fn incident_events(
+        store: &Store,
+        incident_id: &str,
+    ) -> Result<Vec<(String, String, String, String)>> {
+        let mut statement = store.connection.prepare(
+            "SELECT id, event, service, payload
+             FROM service_events
+             WHERE entity_type = 'incident' AND entity_ref = ?1
+             ORDER BY rowid",
+        )?;
+        Ok(statement
+            .query_map([incident_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    fn count_for(store: &Store, table: &str, column: &str, id: &str) -> Result<i64> {
+        Ok(store.connection.query_row(
+            &format!("SELECT COUNT(*) FROM {table} WHERE {column} = ?1"),
+            [id],
+            |row| row.get(0),
+        )?)
     }
 
     fn claim_insert(


### PR DESCRIPTION
## Summary
- Deleting a down target or monitor now resolves its attached `health_transition` signal in the same store transaction.
- Empty incidents resolve; multi-signal incidents stay open when other signals remain active.
- Scoped wrong-tenant deletes stay no-ops. Failures roll back the delete.
- Bumps `postcss`/`nanoid` in the TypeScript client lockfile past high npm advisories so `validate --strict` can pass.

Powder: **canary-990**.

## Proof
- `cargo test -p canary-store deleting_down --locked` → 3 passed
- `./bin/validate --fast` → pass
- `./bin/validate --strict` → pass
- Review gate clean: `bundle_digest=sha256:c0f6d87db988a1935dbc68a1bfa9f16c03189b3265e61e019262c6435309f97f` (autoreview, thermo-nuclear-review, ponytail)

## Test plan
- [x] Focused store tests for unscoped/scoped target and monitor deletes
- [x] Multi-signal incident remains open when one surface is deleted
- [x] Rollback when incident event insert fails
- [x] Full strict gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitor and target deletion to consistently remove related health-check state.
  * Deletions now correctly resolve associated incident signals and record incident events.
  * Added safer handling for scoped, unscoped, repeated, and unsuccessful deletion attempts.
  * Ensured failed deletion transactions leave existing monitoring and incident data unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->