### PR TITLE
docs(governance): record cascade-orphan and readiness footguns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,30 @@ original cannot be re-shown.
   boundary/exception rows together. Validated probe plans remain opaque to
   callers, and the concrete transport rechecks public plans before connecting;
   otherwise a forged pinned address bypasses the shared resolver.
+- **Cascade only fires with `foreign_keys` on.** Every declared foreign key in
+  `crates/canary-store/src/schema.rs` uses `ON DELETE CASCADE`, but SQLite
+  cascades only when `PRAGMA foreign_keys` is on for the connection performing
+  the delete, so a parent deleted without enforcement leaves unreachable
+  children. `verification::verify_database` counts them through
+  `pragma_foreign_key_check`, and `canary-server migrate` exits non-zero on any
+  count, which fails the recovery evidence a deployer needs before promoting
+  (2026-08-08: 1 orphaned `monitor_state` and 4 orphaned `monitor_check_ins`
+  rows). `schema::delete_orphaned_cascade_rows` clears the residue before the
+  version stamp; use `NOT EXISTS`, never `NOT IN`, so a NULL parent id cannot
+  suppress the predicate, and guard nullable `annotations.incident_id` so
+  deliberately unlinked rows survive.
+- **A worker with no successful pass fails readiness.** `readyz_response`
+  accepts worker health `Ok` or `Pressured`, so `Pressured` keeps serving, but
+  `Stopped`, `Failing`, or `Stale` returns 503 — and production ingress then
+  drops its only upstream while `/healthz` still answers 200, hiding a total
+  outage. `health_status` reports no success since process start as `Stale`, or
+  as `Failing` once three consecutive failures land, because the failure count is
+  checked first. Recovery needs a successful pass, not a restart: the worker
+  loops and retries after its interval, which for `retention_prune` and
+  `tls_scan` defaults to 24h, so readiness can stay down that long while an
+  operator restart is merely the fast path (2026-08-08: `retention_prune` lost a
+  lock race against a post-migration 759 MB WAL checkpoint). Never repoint the
+  ingress probe at `/healthz` to mask this; repair the worker (canary-993).
 
 This list is load-bearing — every remediation in the Known-debt map above must cite it and extend it when new failure modes appear.
 </content>


### PR DESCRIPTION
The footgun list is load-bearing and its closing line requires extension when new failure modes appear. The 2026-08-08 v0.16.10 promote surfaced two it did not carry.

## 1. Cascade only fires with `foreign_keys` on

Every declared foreign key in `schema.rs` uses `ON DELETE CASCADE`, but SQLite cascades only for a connection with `PRAGMA foreign_keys` on. Production carried 1 orphaned `monitor_state` row and 4 orphaned `monitor_check_ins` rows, so `verify_database` counted 5 violations and `canary-server migrate` exited non-zero, failing the recovery evidence needed before promotion. Fixed in v0.16.10 by `schema::delete_orphaned_cascade_rows` (#283); the footgun records the `NOT EXISTS` requirement and the nullable-`annotations` guard.

## 2. A worker with no successful pass fails readiness

`readyz_response` accepts `Ok` or `Pressured` but returns 503 for `Stopped`, `Failing`, or `Stale`. Production ingress then drops its only upstream while `/healthz` still answers 200, hiding a total outage. During the promote, `retention_prune` lost a lock race against a post-migration 759 MB WAL checkpoint, so it had no successful pass and reported `Stale`; every public request 503'd until a restart. Tracked as canary-993.

## Review

Three rounds. Rounds 1 and 2 returned 6 accuracy findings against my own text, all fixed:

- readiness accepts `Pressured`, so "any non-ok worker" was wrong
- `consecutive_failures >= 3` is checked first, so no-success can be `Failing`, not always `Stale`
- the workers loop and retry, so recovery needs a successful pass, not a restart
- 24h is a configurable default, not a fixed tick
- promotion policy belongs to the deployer, not to `canary-server migrate`

Round 3 clean. Receipt `bundle_digest sha256:66c163530b61ae9c20ef26bfa8dbbf24dc06d59aa47a3418fde981c48584358b`, lanes autoreview + thermo-nuclear-code-quality-review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enforcing SQLite foreign-key constraints during cascading deletes.
  * Documented orphan cleanup and verification requirements.
  * Clarified worker readiness requirements, including failure thresholds and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->