### PR TITLE
docs(governance): mark the retention_prune trigger as unproven

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,9 +213,13 @@ original cannot be re-shown.
   checked first. Recovery needs a successful pass, not a restart: the worker
   loops and retries after its interval, which for `retention_prune` and
   `tls_scan` defaults to 24h, so readiness can stay down that long while an
-  operator restart is merely the fast path (2026-08-08: `retention_prune` lost a
-  lock race against a post-migration 759 MB WAL checkpoint). Never repoint the
-  ingress probe at `/healthz` to mask this; repair the worker (canary-993).
+  operator restart is merely the fast path. On 2026-08-08 `retention_prune`
+  failed its boot pass with `/readyz` reporting only
+  `last_error_class=runtime_error`, because Litestream log volume evicts server
+  tracing; Litestream's own coincident 759 MB truncate checkpoint and
+  `SQLITE_BUSY` are a likely trigger, not a proven one, so do not scope the
+  repair to lock contention. Never repoint the ingress probe at `/healthz` to
+  mask this; repair the worker (canary-993).
 
 This list is load-bearing — every remediation in the Known-debt map above must cite it and extend it when new failure modes appear.
 </content>


### PR DESCRIPTION
Follow-up correction to #284.

That PR's readiness footgun asserted as fact that `retention_prune` "lost a lock race against a post-migration 759 MB WAL checkpoint". I could not prove that. The only recorded evidence was `last_error_class=runtime_error` in the `/readyz` worker snapshot, because docker json-file rotation — driven by Litestream writing roughly one line per second — evicted the canary-server tracing lines before the error text could be read.

What is actually established: Litestream logged forcing truncate checkpoints at 524 MB, 620 MB, then 759 MB plus one `checkpoint: database is locked (5) (SQLITE_BUSY)`, and a restart after the WAL drained to 543 KB made the same pass succeed in about 20 seconds. That is circumstantial, not causal.

Why it matters beyond wording: a future agent reading the old text would scope the canary-993 repair to lock contention. The defect is structural regardless of trigger, because any failed first pass leaves the worker with no success since start, which readiness treats as not-ready. The entry now says so explicitly.

Also records that Litestream log volume evicts server tracing from the container log, which is why this incident was not diagnosable after the fact.

## Review

Two rounds. Round 1 returned a P1 provenance ambiguity — "only `runtime_error` recorded" appeared to contradict the separately logged `SQLITE_BUSY` — plus a P2 on length. Both fixed: `runtime_error` is now attributed to the `/readyz` snapshot and the checkpoint evidence to Litestream, compressed in the same pass. Round 2 clean, and confirmed the retained bindings (`/healthz` prohibition, canary-993 pointer, no-lock-scoping warning, successful-pass recovery, 24h defaults).

Net +4 lines, +32 words. Receipt `bundle_digest sha256:a3ca39aaf16a4afba133d408d2e31fe4664bd0ab299c7a53ee394715a8a3a014`.