### PR TITLE
fix(runtime): retry a failed worker pass without waiting a full tick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,16 +210,18 @@ original cannot be re-shown.
   drops its only upstream while `/healthz` still answers 200, hiding a total
   outage. `health_status` reports no success since process start as `Stale`, or
   as `Failing` once three consecutive failures land, because the failure count is
-  checked first. Recovery needs a successful pass, not a restart: the worker
-  loops and retries after its interval, which for `retention_prune` and
-  `tls_scan` defaults to 24h, so readiness can stay down that long while an
-  operator restart is merely the fast path. On 2026-08-08 `retention_prune`
-  failed its boot pass with `/readyz` reporting only
-  `last_error_class=runtime_error`, because Litestream log volume evicts server
-  tracing; Litestream's own coincident 759 MB truncate checkpoint and
-  `SQLITE_BUSY` are a likely trigger, not a proven one, so do not scope the
-  repair to lock contention. Never repoint the ingress probe at `/healthz` to
-  mask this; repair the worker (canary-993).
+  checked first. Recovery needs a successful pass, not a restart. Keep
+  `worker_retry::retry_delay` shared: before canary-993 each loop waited its own
+  tick after a failed pass, so `retention_prune` and `tls_scan` deferred
+  recovery for 24h. On 2026-08-08 `retention_prune` failed its boot pass with
+  `/readyz` reporting only `last_error_class=runtime_error`, because Litestream
+  log volume evicts server tracing; Litestream's own coincident 759 MB truncate
+  checkpoint and `SQLITE_BUSY` are a likely trigger, not a proven one. Ingress
+  stayed down until an operator restarted the service. Never repoint the ingress
+  probe at `/healthz` to mask a stale worker. A maintenance failure still fails
+  readiness closed, which `docs/canary-witness.md` and
+  `docs/architecture/worker-lifecycle-readiness-2026-06-12.md` define as the
+  contract; changing it needs a superseding decision record.
 
 This list is load-bearing — every remediation in the Known-debt map above must cite it and extend it when new failure modes appear.
 </content>

--- a/crates/canary-server/src/lib.rs
+++ b/crates/canary-server/src/lib.rs
@@ -56,6 +56,7 @@ mod webhook_delivery;
 mod webhook_delivery_routes;
 mod webhooks;
 mod worker_health;
+mod worker_retry;
 
 use admin_keys::{create_api_key, list_api_keys, revoke_api_key};
 use admin_monitors::{create_monitor, delete_monitor, list_monitors};

--- a/crates/canary-server/src/monitor_overdue.rs
+++ b/crates/canary-server/src/monitor_overdue.rs
@@ -27,6 +27,7 @@ use crate::{
     WorkerPressureSnapshot,
     route_state::SharedStore,
     server_time::{current_rfc3339, current_unix_millis},
+    worker_retry::retry_delay,
 };
 
 /// Persisted result of one overdue monitor transition.
@@ -392,36 +393,42 @@ fn run_lifecycle_worker(
     control: Arc<LifecycleControl>,
     health: WorkerHealthHandle,
 ) {
+    let mut consecutive_failures: u32 = 0;
     while !control.is_stopping() {
         if !control.is_paused() {
             let now = current_rfc3339();
             match catch_unwind(AssertUnwindSafe(|| {
                 lifecycle.run_due(now.clone(), current_unix_millis())
             })) {
-                Ok(Ok(report)) => health.record_success_with_pressure(
-                    now,
-                    current_unix_millis(),
-                    WorkerPressureSnapshot {
-                        due_count: report.loaded as u64,
-                        in_flight_count: 0,
-                        oldest_due_age_ms: report.oldest_due_age_ms,
-                        oldest_due_item: report.oldest_due_item,
-                        backoff_or_circuit_open: report.failed > 0
-                            || report.event_fanout_failed > 0
-                            || report.interrupted,
-                    },
-                ),
+                Ok(Ok(report)) => {
+                    consecutive_failures = 0;
+                    health.record_success_with_pressure(
+                        now,
+                        current_unix_millis(),
+                        WorkerPressureSnapshot {
+                            due_count: report.loaded as u64,
+                            in_flight_count: 0,
+                            oldest_due_age_ms: report.oldest_due_age_ms,
+                            oldest_due_item: report.oldest_due_item,
+                            backoff_or_circuit_open: report.failed > 0
+                                || report.event_fanout_failed > 0
+                                || report.interrupted,
+                        },
+                    );
+                }
                 Ok(Err(_)) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
                     control.record_failure();
                     health.record_failure("runtime_error");
                 }
                 Err(_) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
                     control.record_failure();
                     health.record_failure("panic");
                 }
             }
         }
-        if control.wait(interval) {
+        if control.wait(retry_delay(interval, consecutive_failures)) {
             break;
         }
     }

--- a/crates/canary-server/src/retention_prune.rs
+++ b/crates/canary-server/src/retention_prune.rs
@@ -22,6 +22,7 @@ use crate::{
     WorkerHealthHandle, WorkerName, WorkerPressureSnapshot,
     route_state::SharedStore,
     server_time::{current_unix_millis, current_utc, format_rfc3339},
+    worker_retry::retry_delay,
 };
 
 /// Configuration for the retention prune lifecycle worker.
@@ -412,37 +413,43 @@ fn run_lifecycle_worker(
     control: Arc<LifecycleControl>,
     health: WorkerHealthHandle,
 ) {
+    let mut consecutive_failures: u32 = 0;
     while !control.is_stopping() {
         if !control.is_paused() {
             let now = current_utc();
             match catch_unwind(AssertUnwindSafe(|| {
                 lifecycle.run_due_until(now, || control.is_stopping())
             })) {
-                Ok(Ok(report)) => health.record_success_with_pressure(
-                    format_rfc3339(now),
-                    current_unix_millis(),
-                    WorkerPressureSnapshot {
-                        due_count: report.errors_deleted
-                            + report.service_events_deleted
-                            + report.target_checks_deleted
-                            + report.oban_jobs_deleted,
-                        in_flight_count: 0,
-                        oldest_due_age_ms: None,
-                        oldest_due_item: None,
-                        backoff_or_circuit_open: report.interrupted,
-                    },
-                ),
+                Ok(Ok(report)) => {
+                    consecutive_failures = 0;
+                    health.record_success_with_pressure(
+                        format_rfc3339(now),
+                        current_unix_millis(),
+                        WorkerPressureSnapshot {
+                            due_count: report.errors_deleted
+                                + report.service_events_deleted
+                                + report.target_checks_deleted
+                                + report.oban_jobs_deleted,
+                            in_flight_count: 0,
+                            oldest_due_age_ms: None,
+                            oldest_due_item: None,
+                            backoff_or_circuit_open: report.interrupted,
+                        },
+                    );
+                }
                 Ok(Err(_)) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
                     control.record_failure();
                     health.record_failure("runtime_error");
                 }
                 Err(_) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
                     control.record_failure();
                     health.record_failure("panic");
                 }
             }
         }
-        if control.wait(interval) {
+        if control.wait(retry_delay(interval, consecutive_failures)) {
             break;
         }
     }
@@ -616,6 +623,48 @@ mod tests {
         assert!(snapshot.failure_count >= 1);
         assert_eq!(snapshot.last_error_class.as_deref(), Some("runtime_error"));
 
+        worker.join()?;
+
+        Ok(())
+    }
+
+    /// Regression for canary-993: a worker whose steady-state tick is long must
+    /// not defer its next attempt by a full tick after a failed pass.
+    ///
+    /// The tick here is an hour, so reaching a second failure at all proves the
+    /// loop waited on the bounded retry path instead of the steady-state tick.
+    #[test]
+    fn worker_retries_a_failed_pass_without_waiting_a_full_tick() -> Result<(), Box<dyn Error>> {
+        let mut store = Store::open_in_memory()?;
+        store.migrate()?;
+        let tick = StdDuration::from_secs(60 * 60);
+        let worker = RetentionPruneLifecycleWorker::spawn(
+            RetentionPruneLifecycle::new(
+                Arc::new(parking_lot::Mutex::new(store)),
+                RetentionPolicy {
+                    error_retention_days: -1,
+                    check_retention_days: 7,
+                },
+            ),
+            RetentionPruneLifecycleConfig {
+                tick_interval: tick,
+            },
+        )?;
+
+        let started = Instant::now();
+        let deadline = started + StdDuration::from_secs(20);
+        while worker.failure_count() < 2 {
+            if Instant::now() >= deadline {
+                return Err("worker never retried the failed pass".into());
+            }
+            thread::sleep(StdDuration::from_millis(20));
+        }
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < tick,
+            "retry waited the full steady-state tick: {elapsed:?}"
+        );
         worker.join()?;
 
         Ok(())

--- a/crates/canary-server/src/target_probes.rs
+++ b/crates/canary-server/src/target_probes.rs
@@ -21,6 +21,7 @@ use std::{
 
 use crate::egress::{host_without_ipv6_brackets, is_global_ip, resolve_destination_addrs};
 use crate::route_state::SharedStore;
+use crate::worker_retry::retry_delay;
 use canary_core::health::state_machine::{Counters, HealthState, Thresholds};
 use canary_store::{ActiveTargetProbeSchedule, TargetProbeSnapshot};
 use canary_workers::health::{
@@ -887,29 +888,39 @@ fn run_lifecycle_worker(
     control: Arc<LifecycleControl>,
     health: WorkerHealthHandle,
 ) {
+    let mut consecutive_failures: u32 = 0;
     while !control.is_stopping() {
         if !control.is_paused() {
             let now = current_rfc3339();
             match catch_unwind(AssertUnwindSafe(|| {
                 lifecycle.run_due_until(current_unix_millis(), || control.is_stopping())
             })) {
-                Ok(Ok(report)) => health.record_success_with_pressure(
-                    now,
-                    current_unix_millis(),
-                    WorkerPressureSnapshot {
-                        due_count: report.due as u64,
-                        in_flight_count: report.in_flight as u64,
-                        oldest_due_age_ms: report.oldest_due_age_ms,
-                        oldest_due_item: None,
-                        backoff_or_circuit_open: report.failed > 0
-                            || report.event_fanout_failed > 0,
-                    },
-                ),
-                Ok(Err(_)) => health.record_failure("runtime_error"),
-                Err(_) => health.record_failure("panic"),
+                Ok(Ok(report)) => {
+                    consecutive_failures = 0;
+                    health.record_success_with_pressure(
+                        now,
+                        current_unix_millis(),
+                        WorkerPressureSnapshot {
+                            due_count: report.due as u64,
+                            in_flight_count: report.in_flight as u64,
+                            oldest_due_age_ms: report.oldest_due_age_ms,
+                            oldest_due_item: None,
+                            backoff_or_circuit_open: report.failed > 0
+                                || report.event_fanout_failed > 0,
+                        },
+                    );
+                }
+                Ok(Err(_)) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    health.record_failure("runtime_error");
+                }
+                Err(_) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    health.record_failure("panic");
+                }
             }
         }
-        if control.wait(interval) {
+        if control.wait(retry_delay(interval, consecutive_failures)) {
             break;
         }
     }

--- a/crates/canary-server/src/tls_scan.rs
+++ b/crates/canary-server/src/tls_scan.rs
@@ -23,6 +23,7 @@ use crate::{
     EventSink, WorkerHealthHandle, WorkerName, WorkerPressureSnapshot,
     route_state::SharedStore,
     server_time::{current_unix_millis, current_utc, format_rfc3339},
+    worker_retry::retry_delay,
 };
 
 /// Configuration for the TLS-expiry scan lifecycle worker.
@@ -347,6 +348,7 @@ fn run_lifecycle_worker(
     control: Arc<LifecycleControl>,
     health: WorkerHealthHandle,
 ) {
+    let mut consecutive_failures: u32 = 0;
     while !control.is_stopping() {
         if !control.is_paused() {
             let now = current_utc();
@@ -354,30 +356,35 @@ fn run_lifecycle_worker(
             match catch_unwind(AssertUnwindSafe(|| {
                 lifecycle.run_due_until(now, now_string.clone(), || control.is_stopping())
             })) {
-                Ok(Ok(report)) => health.record_success_with_pressure(
-                    now_string,
-                    current_unix_millis(),
-                    WorkerPressureSnapshot {
-                        due_count: report.loaded as u64,
-                        in_flight_count: 0,
-                        oldest_due_age_ms: None,
-                        oldest_due_item: None,
-                        backoff_or_circuit_open: report.failed > 0
-                            || report.event_fanout_failed > 0
-                            || report.interrupted,
-                    },
-                ),
+                Ok(Ok(report)) => {
+                    consecutive_failures = 0;
+                    health.record_success_with_pressure(
+                        now_string,
+                        current_unix_millis(),
+                        WorkerPressureSnapshot {
+                            due_count: report.loaded as u64,
+                            in_flight_count: 0,
+                            oldest_due_age_ms: None,
+                            oldest_due_item: None,
+                            backoff_or_circuit_open: report.failed > 0
+                                || report.event_fanout_failed > 0
+                                || report.interrupted,
+                        },
+                    );
+                }
                 Ok(Err(_)) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
                     control.record_failure();
                     health.record_failure("runtime_error");
                 }
                 Err(_) => {
+                    consecutive_failures = consecutive_failures.saturating_add(1);
                     control.record_failure();
                     health.record_failure("panic");
                 }
             }
         }
-        if control.wait(interval) {
+        if control.wait(retry_delay(interval, consecutive_failures)) {
             break;
         }
     }

--- a/crates/canary-server/src/webhook_delivery.rs
+++ b/crates/canary-server/src/webhook_delivery.rs
@@ -30,6 +30,7 @@ use crate::{
     webhooks::{
         WebhookEventAuthority, WebhookTransport, delivery_insert, endpoint_from_subscription,
     },
+    worker_retry::retry_delay,
 };
 
 const WEBHOOK_EXECUTION_LEASE_SECONDS: u64 = 60;
@@ -549,28 +550,38 @@ fn run_drain_worker(
     stop: Arc<DrainStop>,
     health: WorkerHealthHandle,
 ) {
+    let mut consecutive_failures: u32 = 0;
     while !stop.is_requested() {
         let now = current_rfc3339();
         match catch_unwind(AssertUnwindSafe(|| drain.drain_due(&now))) {
-            Ok(Ok(report)) => health.record_success_with_pressure(
-                now,
-                current_unix_millis(),
-                WorkerPressureSnapshot {
-                    due_count: u64::from(report.due_count),
-                    in_flight_count: u64::from(report.in_flight_count),
-                    oldest_due_age_ms: report.oldest_due_age_ms,
-                    oldest_due_item: None,
-                    backoff_or_circuit_open: report.retried > 0
-                        || report.discarded > 0
-                        || report.circuit_open_suppressed > 0
-                        || report.recovery_retried > 0
-                        || report.recovery_discarded > 0,
-                },
-            ),
-            Ok(Err(_)) => health.record_failure("runtime_error"),
-            Err(_) => health.record_failure("panic"),
+            Ok(Ok(report)) => {
+                consecutive_failures = 0;
+                health.record_success_with_pressure(
+                    now,
+                    current_unix_millis(),
+                    WorkerPressureSnapshot {
+                        due_count: u64::from(report.due_count),
+                        in_flight_count: u64::from(report.in_flight_count),
+                        oldest_due_age_ms: report.oldest_due_age_ms,
+                        oldest_due_item: None,
+                        backoff_or_circuit_open: report.retried > 0
+                            || report.discarded > 0
+                            || report.circuit_open_suppressed > 0
+                            || report.recovery_retried > 0
+                            || report.recovery_discarded > 0,
+                    },
+                );
+            }
+            Ok(Err(_)) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                health.record_failure("runtime_error");
+            }
+            Err(_) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                health.record_failure("panic");
+            }
         }
-        if stop.wait(interval) {
+        if stop.wait(retry_delay(interval, consecutive_failures)) {
             break;
         }
     }

--- a/crates/canary-server/src/worker_retry.rs
+++ b/crates/canary-server/src/worker_retry.rs
@@ -1,0 +1,104 @@
+//! One post-failure retry-delay oracle shared by every lifecycle worker.
+//!
+//! A worker's tick interval is its steady-state cadence, not its recovery
+//! cadence. Reusing the tick after a failed pass ties recovery latency to the
+//! slowest maintenance schedule in the process: that cost canary-993 the whole
+//! public surface for a day, because `retention_prune` ticks every 24h.
+//!
+//! Keep this the only retry policy. Five loops call it, and per-loop copies
+//! would drift.
+
+use std::time::Duration as StdDuration;
+
+/// Base delay after a failed lifecycle pass, before clamping to the tick.
+///
+/// Readiness stays impaired until a pass succeeds, so the first retry sets the
+/// floor on recovery time. Doubling backs a persistently failing worker off
+/// within seconds, so a short base costs a few extra attempts, not a tight
+/// loop.
+const RETRY_BASE: StdDuration = StdDuration::from_secs(1);
+
+/// Longest delay this oracle imposes between retries.
+const RETRY_CEILING: StdDuration = StdDuration::from_secs(15 * 60);
+
+/// Return the delay before the worker's next attempt.
+///
+/// `consecutive_failures` counts failed passes with no success after them, so
+/// zero means nothing is pending: either no pass has run yet, or the last pass
+/// succeeded. Zero returns the steady-state `tick_interval`.
+///
+/// Each failure doubles the delay from [`RETRY_BASE`], clamped to
+/// [`RETRY_CEILING`] and to `tick_interval`. A worker whose tick is shorter
+/// than [`RETRY_BASE`] therefore keeps its own cadence and retries sooner.
+///
+/// `tick_interval` must be non-zero, which every worker enforces before
+/// spawning. A zero tick spins the loop through the success path as well, so
+/// no retry policy can repair it here.
+pub(crate) fn retry_delay(tick_interval: StdDuration, consecutive_failures: u32) -> StdDuration {
+    if consecutive_failures == 0 {
+        return tick_interval;
+    }
+    let doublings = consecutive_failures.saturating_sub(1);
+    RETRY_BASE
+        .saturating_mul(2u32.saturating_pow(doublings))
+        .min(RETRY_CEILING)
+        .min(tick_interval)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DAY: StdDuration = StdDuration::from_secs(24 * 60 * 60);
+
+    #[test]
+    fn repeated_failures_double_the_delay_up_to_the_ceiling() {
+        assert_eq!(retry_delay(DAY, 1), StdDuration::from_secs(1));
+        assert_eq!(retry_delay(DAY, 2), StdDuration::from_secs(2));
+        assert_eq!(retry_delay(DAY, 3), StdDuration::from_secs(4));
+        assert_eq!(retry_delay(DAY, 4), StdDuration::from_secs(8));
+        assert_eq!(retry_delay(DAY, 10), StdDuration::from_secs(512));
+        assert_eq!(retry_delay(DAY, 11), RETRY_CEILING);
+        assert_eq!(retry_delay(DAY, 12), RETRY_CEILING);
+    }
+
+    /// The ceiling must hold for any failure count, including values whose
+    /// doubling would overflow.
+    #[test]
+    fn the_ceiling_holds_for_extreme_failure_counts() {
+        assert_eq!(retry_delay(DAY, 64), RETRY_CEILING);
+        assert_eq!(retry_delay(DAY, u32::MAX), RETRY_CEILING);
+    }
+
+    /// A tick between the base and the ceiling caps its own backoff. This is
+    /// the webhook drain in production at 5s: growth stops at its cadence, and
+    /// a saturated backoff still lands there rather than at the ceiling.
+    #[test]
+    fn an_intermediate_tick_caps_the_backoff_at_its_own_cadence() {
+        let tick = StdDuration::from_secs(5);
+
+        assert_eq!(retry_delay(tick, 4), tick);
+        assert_eq!(retry_delay(tick, 20), tick);
+    }
+
+    /// A worker that ticks at or below the retry base keeps its own cadence.
+    /// Backoff may only shorten a wait, never lengthen one. The 100ms tick is
+    /// the case that exercises the clamp; 1s sits exactly on [`RETRY_BASE`].
+    #[test]
+    fn a_fast_worker_never_slows_down_after_a_failure() {
+        for tick in [StdDuration::from_millis(100), RETRY_BASE] {
+            for failures in [1, 2, 3, 10, u32::MAX] {
+                assert_eq!(retry_delay(tick, failures), tick);
+            }
+        }
+    }
+
+    /// A successful pass restores the steady-state cadence at every interval
+    /// length, so recovery ends the backoff.
+    #[test]
+    fn success_restores_the_steady_state_interval() {
+        for interval in [StdDuration::from_millis(10), StdDuration::from_secs(5), DAY] {
+            assert_eq!(retry_delay(interval, 0), interval);
+        }
+    }
+}


### PR DESCRIPTION
Closes the 24h recovery cliff behind canary-993.

## The defect

A lifecycle worker treated its tick interval as its *recovery* cadence. After a failed pass it waited one full tick before trying again — 24h for `retention_prune` and `tls_scan`.

Observed live on 2026-08-08 during the v0.16.10 promote. `retention_prune` failed its boot pass, so health stayed `stale`, `/readyz` stayed `not_ready`, Caddy dropped its only upstream, and inbound check-ins from mint and sanctum were rejected with 503 and lost. `/healthz` kept answering 200, which hid a total outage. Only an operator restart cleared it.

## The fix

One shared oracle, `worker_retry::retry_delay(tick_interval, consecutive_failures)`, with all five worker loops routed through it. After a failed pass the wait starts at 1s and doubles, clamped to a 15-minute ceiling **and** to the worker's own tick. A successful pass resets the counter and restores the steady-state tick.

Effect per worker, using production defaults:

| Worker | Tick | Retry after 1 failure | Before |
|---|---|---|---|
| `retention_prune` | 24h | 1s | 24h |
| `tls_scan` | 24h | 1s | 24h |
| `webhook_delivery` | 5s | 1s, then 2s, 4s, capped at 5s | 5s |
| `target_probe` | 1s | 1s (unchanged) | 1s |
| `monitor_overdue` | 1s | 1s (unchanged) | 1s |

Deliberately one shared oracle, not five copies, per this repo's own "one egress oracle" footgun: the reason all five loops drifted into reusing their own tick is that each owned its own wait.

## Not in scope

**The readiness verdict is unchanged.** A `stale` or `failing` worker still fails `/readyz` closed. That is a real remaining defect — a maintenance failure still 503s the ingest path and drops inbound data — but it is a documented product contract: `docs/canary-witness.md:24` states readiness is "route readiness, not alert-plane health", and `docs/architecture/worker-lifecycle-readiness-2026-06-12.md:38-45` defines stale and failing as `not_ready`. Changing it needs a superseding decision record and an operator ruling, so canary-993 stays open for that half. This PR removes the 24h amplifier, which is what turned a transient failure into a day-long outage.

`pause`/`resume` on the worker structs remain dead API with no callers. Left alone to keep this narrow.

## Evidence

- **Mutation-checked regression test.** Reverting the one-line loop change makes `worker_retries_a_failed_pass_without_waiting_a_full_tick` fail with "worker never retried the failed pass" after timing out at 20.02s; with the fix it passes in 1.02s.
- **Live proof on the real binary.** Booted `canary-server` with `ERROR_RETENTION_DAYS=-1` to force the same planning failure. `/readyz` reported `retention_prune` `health=failing`, `last_error_class=runtime_error`, with the failure count advancing 4 → 5 → 6 across 25s, matching 1/2/4/8/16s backoff. Old code would show exactly one failure, then nothing for 24h.
- **Healthy control.** Same binary with a valid policy: HTTP 200, `status: ready`, all five workers `ok`.
- Full workspace suite 648 passed / 0 failed; clippy clean; `./bin/validate --strict` passed with `noCache: true`.

## Review

Four rounds, seven leaf runs. Findings accepted and applied: a zero-delay edge, four documentation inaccuracies, a duplicate test, duplicated prose, a redundant clamp, a "fast worker" test that used a tick equal to the base and so never exercised the clamp, and a missing intermediate-tick case covering `webhook_delivery`'s real 5s tick.

Two lanes conflicted on a `MIN_DELAY` floor — correctness required it, erasure wanted it cut. I removed it: the floor could not deliver its own guarantee, because with a zero tick the *success* path already spins via `wait(Duration::ZERO)`. The five spawn guards are the only real enforcement point, and the correctness lane independently confirmed that reasoning.

Receipt `bundle_digest sha256:b9e4be80dd6bc0b2b8809f30351fbb0565da5888691249675f9aec9b473d7894`, lanes autoreview + thermo-nuclear-review + ponytail + thermo-nuclear-code-quality-review, all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery for background monitoring, cleanup, scanning, probing, and webhook delivery tasks after temporary failures.
  - Failed tasks now retry sooner with progressive delays, while successful tasks return to their normal schedule.
  - Added safeguards to prevent prolonged delays after repeated failures.
  - Health status reporting now more accurately reflects worker failures, recovery, and backoff conditions.

- **Documentation**
  - Updated operational guidance for worker readiness and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->